### PR TITLE
Tighten AGENTS.md rules and run the zle driver in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,8 @@ jobs:
         run: cargo build --release
       - name: cargo test
         run: cargo test
+      - name: Install zsh (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y zsh
+      - name: zle driver
+        run: zsh -f tests/zsh/driver.zsh "$(mktemp -d)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,12 @@ cargo test
 
 zle-integration regression tests live in `tests/zsh/driver*.zsh`, and `zsh/verify.zsh` launches an isolated shell for manual verification; each file's header documents prerequisites and usage.
 
-## Commits
+## Commits, issues, and pull requests
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/), concise and in English
+One-line titles — commit messages, issue titles, PR titles — are concise English, because they flow through tooling.
+Commit messages additionally follow [Conventional Commits](https://www.conventionalcommits.org/)
 (e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`, `fix(zle): clear listing on accept-line`).
+Bodies may be English or Japanese.
 
 ## Core principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ cargo build --release
 cargo test
 ```
 
-zle-integration regression tests live in `tests/zsh/driver*.zsh`, and `zsh/verify.zsh` launches an isolated shell for manual verification; each file's header documents prerequisites and usage.
+For changes touching `zsh/`, the zle-integration drivers `tests/zsh/driver.zsh` and `tests/zsh/driver-coexist.zsh` must also pass — run them locally; CI runs only the headless `driver.zsh`.
+`zsh/verify.zsh` launches an isolated shell for manual verification, and `tests/zsh/driver-latency.zsh` measures first-paint latency; each file's header documents prerequisites and usage.
 
 ## Commits, issues, and pull requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Docs describe only the current state — no history or review notes (git keeps t
 
 ## Build and test
 
-Run all four before considering a change done (CI enforces the same):
+Run all of the following before considering a change done (CI enforces the same):
 
 ```sh
 cargo fmt --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,15 @@ Development is dogfooding-driven: the author's daily use comes first.
 
 ## Docs are the single source of truth
 
-The `docs/` directory is authoritative for design and behavior:
+The `docs/` directory records intended behavior — a commitment, not a description of the code:
 
 - Resolve design/spec questions by reading `docs/` first.
 - When changing design or behavior, update the relevant doc before (or together with) the code.
-- If code and docs disagree, treat the docs as correct; verify which side is wrong and fix it.
+- Code that disagrees with docs is a bug in the code.
+  If the intent itself has changed, that is a spec change: update the doc deliberately, never merely to match what the code happens to do.
+  When unsure which case it is, ask instead of picking a side.
+- Behavior the docs don't cover is not guaranteed and may change freely; to rely on it, spec it first.
+- Code comments never restate the docs; at most they point to the relevant doc.
 
 Layout: `docs/user/` (install, configuration, usage), `docs/internal/specs/` (settled behavior specs), `docs/internal/contracts/` (component boundaries such as the zsh ↔ Rust CLI protocol and config schema).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ Details live in `docs/internal/specs/`; these are the invariants:
 - Responsibilities: Rust = matching, ranking, history search, layout/render-plan computation, insertion-text construction, config interpretation; zsh = zle integration, compsys capture, applying the plan (rendering).
 - Keep pure Rust logic (matching, ranking, config parsing) separate from the UI and unit-testable.
 
+## Design discipline
+
+zrush is alpha software developed by dogfooding; simplicity outranks continuity.
+
+- No backward compatibility.
+  When behavior, config, protocol, or data formats change, replace the old form and delete the old code path in the same change — no deprecation shims, migration code, legacy aliases, or versioned fallbacks.
+  (The protocol version check stays: it detects a stale build, it is not a compat layer.)
+- Prefer a few principled rules over many ad-hoc ones.
+  Growing special cases, conditionals, or implementation size relative to the goal is a sign of a wrong approach: step back and restructure so a general rule covers the cases, instead of patching case by case.
+  If a requested change would require such growth, propose the simpler restructuring first.
+
 ## Guardrails
 
 - Never run tests or verification against the real `~/.zshrc` or shell history; use the isolated sandbox (`zsh/verify.zsh`).


### PR DESCRIPTION
## Summary

AGENTS.md のレビューで見つかった穴と曖昧さを解消する。

- **English titles rule / design discipline** (`0ae2355`, `0a8fd9c`): コミット・issue・PR タイトルの英語統一と、後方互換なし・原理的ルール優先の設計規律を明文化。
- **zle driver as a done-condition** (`0f75f61`): `zsh/` に触れる変更は `driver.zsh` / `driver-coexist.zsh` のローカルパスを完了条件とし、ヘッドレスな `driver.zsh` を CI (ubuntu / macos) でも実行する。従来は cargo の4コマンドだけで zsh 側の回帰を検出できなかった。
- **Docs as normative intent** (`0afc898`): 自己矛盾していた食い違い解消ルール(「docs を正とみなせ、どちらが間違いか検証せよ」)を規範フレームに置き換え。docs はコミットメントであり、食い違うコードはバグ。意図が変わったなら doc の意図的改訂(仕様変更)で、コードに合わせるためだけの doc 書き換えは禁止。系として「未記載挙動は無保証」「コメントは docs を再述しない」を追加。
- **No hardcoded command count** (`7d62c1f`): 「Run all four」の数え上げを除去。

## Test plan

- [x] `zsh -f tests/zsh/driver.zsh <playground>` をローカル実行し 38/38 PASS を確認
- [ ] CI で新設の zle driver ステップが両 OS で緑になることを確認(初回実行。zpty のタイミング起因で flaky なら対処)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB4fsgwfSAMpcN2W8gLFej