### PR TITLE
chore: add issue templates and issue-writing conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/change.md
+++ b/.github/ISSUE_TEMPLATE/change.md
@@ -1,0 +1,22 @@
+---
+name: Change (fix / feat)
+about: Behavior, spec, or implementation change. Only the opening paragraphs are mandatory.
+---
+
+<!--
+Opening paragraphs (mandatory, 1-2):
+  1. Current state (point to the relevant docs/ section if any)
+  2. What changes
+  3. Why
+A reader who was not part of the conversation that spawned this issue must get
+the picture from the opening alone.
+No vocabulary or references that only made sense in that conversation;
+reference other issues as "#N (short description)".
+Numbers used as evidence come with the measurement environment and
+reproduction steps.
+
+Sections below are guidance (move out of this comment only what you need):
+## Details      — what exactly changes
+## Spec updates — which docs/ sections change (behavior changes ship with doc updates; AGENTS.md)
+## Tests        — how it is verified
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/decision.md
+++ b/.github/ISSUE_TEMPLATE/decision.md
@@ -1,0 +1,17 @@
+---
+name: Design decision
+about: Architecture / policy decision record. Only the opening paragraphs are mandatory.
+---
+
+<!--
+Opening paragraphs (mandatory, 1-2):
+  1. Current state
+  2. The decision itself (write it here; do not assume it was made elsewhere)
+  3. Role of this issue (decision record, split into implementation issues, ...)
+
+Sections below are guidance (move out of this comment only what you need):
+## Context  — what led to the decision
+## Evidence — measurements, comparisons, prior art; numbers with environment and reproduction steps
+## Decision — chosen design and accompanying choices; rejected alternatives with reasons
+## Plan     — split into implementation issues and their dependencies
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ Commit messages additionally follow [Conventional Commits](https://www.conventio
 (e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`, `fix(zle): clear listing on accept-line`).
 Bodies may be English or Japanese.
 
+Issue bodies must be self-contained for a reader who was not part of the conversation that spawned them:
+open with one or two paragraphs stating the current state, the change or decision being made, and the reason, before any detail.
+Do not use vocabulary or references that only made sense in that conversation; reference other issues as `#N` plus a short description.
+Numbers used as evidence come with the measurement environment and reproduction steps.
+Templates under `.github/ISSUE_TEMPLATE/` mirror these rules; only the opening paragraphs are mandatory — the other sections are guidance to keep or drop.
+
 ## Core principles
 
 Details live in `docs/internal/specs/`; these are the invariants:


### PR DESCRIPTION
Closes #27.

## 変更内容

- `.github/ISSUE_TEMPLATE/change.md` — 変更用(fix / feat)テンプレート
- `.github/ISSUE_TEMPLATE/decision.md` — 設計決定用テンプレート
- `.github/ISSUE_TEMPLATE/config.yml` — blank issue を許可
- `AGENTS.md` — 「Commits, issues, and pull requests」節に issue の自己完結規範を追記

## なぜ

常駐ワーカー化の issue 群(#22〜#26)の初版が起票時の会話の文脈を前提に書かれてしまい、
後から全面的な書き直しが必要になった(#27 の背景)。
書く瞬間に構造を強制する仕組みとして、テンプレート(web UI 経路 + 構造の正典)と
AGENTS.md 規範(`gh issue create --body` 経路への実効的な強制点)の 2 本立てを導入する。

## レビュー時の観点

- 必須は冒頭段落(現状 → 変更/決定 → 理由)のみで、目安セクションは
  **HTML コメント内**に置いてある(強制は逆ピラミッドだけ、の方針。
  テンプレートを無編集で提出すると issue が見た目空になり、骨組みだけの空洞 issue が生まれない)。
- テンプレートの案内文は英語(新規の恒久成果物は英語に寄せる方針)。
  `Bodies may be English or Japanese.` は現状維持(本文言語の方針変更はスコープ外)。
- 各検討項目の結論と不採用案の理由は #27 のコメントに記録済み。
- コードには触れていない。cargo fmt / clippy / build / test は全 green(192 テスト)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)