### PR TITLE
fix(zle): preserve shell standard file descriptors

### DIFF
--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -68,6 +68,9 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   即座に zrush を無効化する。source 時の `zrush config` 版照合も同じく不一致なら無効化する。
 - worker 障害のユーザー向け警告は、種類や再発回数によらず同じシェルセッションで高々 1 回表示する。
   `ZRUSH_LOG` が設定されている場合、ユーザー向け警告を抑止した後も各障害の診断を追記する。
+- worker の起動・通常終了・異常終了・再起動・re-source・無効化を含む全 lifecycle で、zsh が所有する
+  内部 fd の操作は対話シェル自身の fd 0 / 1 / 2 の open / closed 状態と接続先を変更しない。
+  内部 fd の close error を抑止するときも、その抑止を対話シェルの標準エラーへ恒久適用しない。
 - 同じシェルで zrush.zsh を re-source するときは、既存 worker プロセスを終了して回収し、`zle -F` watcher を解除して
   stdin/stdout pipe fd を閉じてからフックとキーバインドを再構築する。cleanup 中に新旧 worker を重複させない。
   re-source は同じシェルセッションの request_id 単調性・警告済み状態・連続失敗回数・無効化状態を巻き戻さない。

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -98,7 +98,7 @@ mkdir -p $PLAYGROUND/fx/longcol
 : >| $PLAYGROUND/fx/longcol/"item-${(l:90::x:)}-3.txt"
 
 typeset -gi HOSTFD=-1
-typeset -g TRANSCRIPT= EXPECT_BUF=
+typeset -g TRANSCRIPT= EXPECT_BUF= STDIO_BASELINE=
 
 send_line() { zpty -w  host $1 }
 send_keys() { zpty -wn host $1 }
@@ -202,6 +202,31 @@ dump_get() {
   return 1
 }
 
+assert_host_stdio() {  # $1=label; compare fd targets and stdout/stderr delivery
+  local label=$1
+  log_count 'TESTSTDIO='; local -i baseline=$REPLY
+  EXPECT_BUF=
+  send_keys $'\C-xf'
+  if ! wait_log 'TESTSTDIO=' $baseline 5; then
+    ng "$label: stdio probe did not run"
+    return 1
+  fi
+  drain 0.2
+  local -a lines=( "${(@f)"$(grep -F 'TESTSTDIO=' $ZRUSH_LOG 2>/dev/null)"}" )
+  local latest=${lines[-1]#*TESTSTDIO=}
+  local signature=${latest#*fds=}
+  local visible=${EXPECT_BUF//$'\e['[0-9;]#m/}
+  [[ -n $STDIO_BASELINE ]] || STDIO_BASELINE=$signature
+  if [[ $signature == "$STDIO_BASELINE" \
+        && $visible == *ZRUSH-STDOUT-SENTINEL* \
+        && $visible == *ZRUSH-STDERR-SENTINEL* ]]; then
+    ok "$label"
+    return 0
+  fi
+  ng "$label: fds=${signature:-<none>} baseline=${STDIO_BASELINE:-<none>} output=${(qqqq)visible}"
+  return 1
+}
+
 # A send-break reset for scenarios that can leave a multiline BUFFER: ^U
 # (backward-kill-line) only clears the current physical line of a multiline
 # buffer, so those scenarios need a real line abandon + resync instead.
@@ -244,6 +269,15 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   else
     ng "(worker-1a) worker was not lazy: ${REPLY:-<none>}"
   fi
+  assert_host_stdio "(fd-1a) source leaves host fd 0/1/2 attached and writable"
+
+  if dump_get $'\C-xj' TESTAUX \
+     && [[ $REPLY == 'closed=1 retry=-1 drain=-1 timer=-1' ]]; then
+    ok "(fd-1b) timer/retry/drain descriptors close through shared teardown"
+  else
+    ng "(fd-1b) auxiliary fd teardown mismatch: ${REPLY:-<none>}"
+  fi
+  assert_host_stdio "(fd-1c) timer/retry/drain teardown preserves host fd 0/1/2"
 
   # ================================================================ (1) Capture fork -> candidate records
   # (cap-1a) A real compsys fork collects candidates, ships candidate records
@@ -264,6 +298,21 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   fi
   clear_line
   drain 0.3
+  assert_host_stdio "(fd-2a) lazy worker start preserves host fd 0/1/2"
+
+  # A config reload after the worker is live must still deliver its warning to
+  # the host pty. The fixture is removed immediately so later cases use defaults.
+  print -r -- $'[unknown]\nvalue = true' >| $XDG_CONFIG_HOME/zrush/config.toml
+  send_line ':'
+  if expect '*zrush: config:*unknown table*ignoring*HP>*' 5; then
+    ok "(fd-2b) config warning reaches stderr after worker startup"
+  else
+    ng "(fd-2b) config warning missing after worker startup"
+  fi
+  rm -f $XDG_CONFIG_HOME/zrush/config.toml
+  send_line ':'
+  sync_prompt
+  assert_host_stdio "(fd-2c) config reload preserves host fd 0/1/2"
 
   # (cap-1b) The batch header's shared X/J tags reach the worker and come back
   # as a heading line (_files' 'file' tag with group-name '').
@@ -300,6 +349,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   else
     ng "(worker-1e) old worker was not wait-reaped: line=${reaped_resource:-<none>}"
   fi
+  assert_host_stdio "(fd-3) re-source teardown preserves host fd 0/1/2"
 
   # (cap-1c) w vs m: a candidate whose quoted form differs from its raw text.
   # The listing must show the raw text (m, cli-protocol.md "候補レコード"), and
@@ -617,15 +667,23 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   else
     ng "(err-setup) explicit teardown did not reap old worker: ${explicit_reap:-<none>}"
   fi
+  assert_host_stdio "(fd-4) explicit worker teardown preserves host fd 0/1/2"
   print -r -- die > $ZRUSH_FAKE_CONTROL
   log_count 'worker: session failure:'; local -i err_fail0=$REPLY
   fake_count 'die 1 '; local -i fake_die0=$REPLY
   local -i err_log_line0=0
   [[ -r $ZRUSH_LOG ]] && err_log_line0=$(wc -l < $ZRUSH_LOG)
+  EXPECT_BUF=
   send_keys 'ls fx/basic/al'
   local -i active_death_ok=1
   wait_fake 'die 1 ' $fake_die0 10 || active_death_ok=0
   wait_log 'worker: session failure:' $err_fail0 10 || active_death_ok=0
+  local worker_warning_output=${EXPECT_BUF//$'\e['[0-9;]#m/}
+  if [[ $worker_warning_output == *'zrush: worker transport failed; suppressing further warnings this session'* ]]; then
+    ok "(fd-5a) worker warning reaches stderr after worker startup"
+  else
+    ng "(fd-5a) worker warning missing from pty output: ${(qqqq)worker_warning_output}"
+  fi
   local err_log_delta=$(sed -n "$(( err_log_line0 + 1 )),\$p" $ZRUSH_LOG 2>/dev/null)
   local fake_started=$(print -r -- "$err_log_delta" | grep -F 'worker: started pid=' 2>/dev/null)
   local -i fake_started_count=$(print -r -- "$fake_started" | grep -cF 'worker: started pid=' 2>/dev/null)
@@ -663,6 +721,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   # The next real request lazily starts one replacement. Hold it after ready
   # and assignment so state can be inspected before its terminal response.
   clear_line; drain 0.3
+  assert_host_stdio "(fd-5b) session failure teardown preserves host fd 0/1/2"
   print -r -- hold > $ZRUSH_FAKE_CONTROL
   fake_count 'hold 2 '; local -i fake_hold0=$REPLY
   send_keys 'ls fx/basic/'
@@ -718,6 +777,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
 
   clear_line
   drain 0.3
+  assert_host_stdio "(fd-6) explicit disable preserves host fd 0/1/2"
   send_keys 'print HISTMARK-AFTER-ERROR'
   send_keys $'\r'
   if expect '*HISTMARK-AFTER-ERROR*HP>*' 5; then

--- a/tests/zsh/rc/minimal.zshrc
+++ b/tests/zsh/rc/minimal.zshrc
@@ -34,6 +34,54 @@ _zrt_teardown_worker() { _zrush_worker_transport_teardown test }
 zle -N _zrt-teardown-worker _zrt_teardown_worker
 bindkey '^Xq' _zrt-teardown-worker
 
+# ^Xf: record the exact stdio targets and emit one marker through stdout and
+# stderr. The driver compares the signature across lifecycle transitions; the
+# markers prove that both output streams still reach the host pty.
+typeset -gi _zrt_stdio_seq=0
+_zrt_probe_stdio() {
+  emulate -L zsh
+  local signature= dev= ino=
+  local -a stat
+  local -i fd
+  for fd in 0 1 2; do
+    stat=()
+    if zstat -A stat +device /dev/fd/$fd 2>/dev/null; then
+      dev=$stat[1]
+      stat=()
+      zstat -A stat +inode /dev/fd/$fd 2>/dev/null || stat=( unknown )
+      ino=$stat[1]
+      signature+="$fd:$dev:$ino;"
+    else
+      signature+="$fd:closed;"
+    fi
+  done
+  _zlog "TESTSTDIO=seq=$(( ++_zrt_stdio_seq )) fds=$signature"
+  print -r -- ZRUSH-STDOUT-SENTINEL
+  print -ru2 -- ZRUSH-STDERR-SENTINEL
+  zle -R
+}
+zle -N _zrt-probe-stdio _zrt_probe_stdio
+bindkey '^Xf' _zrt-probe-stdio
+
+# ^Xj: synthesize the timer/retry/drain descriptors and exercise their shared
+# teardown paths without depending on timing or kernel backpressure.
+_zrt_close_aux_fds() {
+  emulate -L zsh
+  local -i retry_fd drain_fd timer_fd closed=1
+  exec {retry_fd}< <( print )
+  exec {drain_fd}< <( print )
+  exec {timer_fd}< <( print )
+  _zrush_worker_retry_fd=$retry_fd
+  _zrush_worker_drain_fd=$drain_fd
+  _zrush_timer_fd=$timer_fd
+  _zrush_worker_disarm_retry
+  _zrush_disarm_timer
+  [[ -e /dev/fd/$retry_fd || -e /dev/fd/$drain_fd || -e /dev/fd/$timer_fd ]] && closed=0
+  _zlog "TESTAUX=closed=$closed retry=$_zrush_worker_retry_fd drain=$_zrush_worker_drain_fd timer=$_zrush_timer_fd"
+}
+zle -N _zrt-close-aux-fds _zrt_close_aux_fds
+bindkey '^Xj' _zrt-close-aux-fds
+
 _zrt_cursor_left_three() { (( CURSOR >= 3 )) && (( CURSOR -= 3 )) }
 zle -N _zrt-cursor-left-three _zrt_cursor_left_three
 bindkey '^Xv' _zrt-cursor-left-three

--- a/tests/zsh/vectors.zsh
+++ b/tests/zsh/vectors.zsh
@@ -165,6 +165,64 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   (( $+functions[_zrush_history_payload] )) || { out "FATAL: _zrush_history_payload undefined after source"; exit 1 }
   (( _zrush_enabled )) && { out "FATAL: ZRUSH_NO_INIT did not suppress initialization"; exit 1 }
 
+  # ---------------- Internal fd close ----------------
+  # Preserve duplicates of the runner's stdio so the helper contract can be
+  # checked without assuming those descriptors point at a terminal.
+  local saved_fd_log=${ZRUSH_LOG:-}
+  ZRUSH_LOG=$WORK/fd-close.log
+  local -i saved_stdin saved_stdout saved_stderr read_fd write_fd
+  exec {saved_stdin}<&0
+  exec {saved_stdout}>&1
+  exec {saved_stderr}>&2
+  exec {read_fd}< /dev/null
+  exec {write_fd}> /dev/null
+
+  _zrush_close_internal_fd $read_fd
+  _zrush_close_internal_fd $read_fd
+  _zrush_close_internal_fd $write_fd
+  _zrush_close_internal_fd -1
+  _zrush_close_internal_fd 0
+  _zrush_close_internal_fd 1
+  _zrush_close_internal_fd 2
+
+  local fd_close_log=$(<$ZRUSH_LOG)
+  if [[ ! -e /dev/fd/$read_fd && ! -e /dev/fd/$write_fd \
+        && /dev/fd/0 -ef /dev/fd/$saved_stdin \
+        && /dev/fd/1 -ef /dev/fd/$saved_stdout \
+        && /dev/fd/2 -ef /dev/fd/$saved_stderr \
+        && $fd_close_log == *"fd: close failed fd=$read_fd status="* \
+        && $fd_close_log == *'fd: refusing to close reserved fd=0'* \
+        && $fd_close_log == *'fd: refusing to close reserved fd=1'* \
+        && $fd_close_log == *'fd: refusing to close reserved fd=2'* ]]; then
+    ok "fd lifecycle: internal close is idempotent and preserves fd 0/1/2"
+  else
+    ng "fd lifecycle: close/open state, stdio target, or diagnostic mismatch"
+  fi
+
+  local -i exit_timer_fd exit_rfd exit_wfd
+  exec {exit_timer_fd}< /dev/null
+  exec {exit_rfd}< /dev/null
+  exec {exit_wfd}> /dev/null
+  _zrush_timer_fd=$exit_timer_fd _zrush_rfd=$exit_rfd _zrush_wfd=$exit_wfd
+  _zrush_pty= _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1
+  _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_setup_fd=-1
+  _zrush_worker_retry_fd=-1 _zrush_worker_drain_fd=-1
+  _zrush_zshexit
+  if (( _zrush_timer_fd == -1 && _zrush_rfd == -1 && _zrush_wfd == -1 )) \
+     && [[ ! -e /dev/fd/$exit_timer_fd && ! -e /dev/fd/$exit_rfd \
+           && ! -e /dev/fd/$exit_wfd \
+           && /dev/fd/0 -ef /dev/fd/$saved_stdin \
+           && /dev/fd/1 -ef /dev/fd/$saved_stdout \
+           && /dev/fd/2 -ef /dev/fd/$saved_stderr ]]; then
+    ok "fd lifecycle: zshexit closes owned descriptors and preserves fd 0/1/2"
+  else
+    ng "fd lifecycle: zshexit close/open state or stdio target mismatch"
+  fi
+  _zrush_close_internal_fd $saved_stdin
+  _zrush_close_internal_fd $saved_stdout
+  _zrush_close_internal_fd $saved_stderr
+  ZRUSH_LOG=$saved_fd_log
+
   # ---------------- Persistent-session framing ----------------
   # Exercise the same incremental loop as _zrush_worker_read without a process
   # or zle. Every byte boundary is tried, and two responses deliberately share
@@ -332,14 +390,28 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   # An explicit incompatible handshake opens the permanent shell-session
   # disable immediately; it is not counted as the first retryable failure.
   _zrush_worker_ready=0 _zrush_worker_failures=0 _zrush_disabled=0 _zrush_enabled=1
-  _zrush_worker_warned=0 _zrush_worker_pid=-1 _zrush_worker_rfd=-1 _zrush_worker_wfd=-1
+  _zrush_worker_warned=0 _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1
+  local -i mismatch_rfd mismatch_wfd mismatch_setup_fd mismatch_retry_fd mismatch_drain_fd
+  exec {mismatch_rfd}< /dev/null
+  exec {mismatch_wfd}> /dev/null
+  exec {mismatch_setup_fd}< /dev/null
+  exec {mismatch_retry_fd}< /dev/null
+  exec {mismatch_drain_fd}< /dev/null
+  _zrush_worker_rfd=$mismatch_rfd _zrush_worker_wfd=$mismatch_wfd
+  _zrush_worker_setup_fd=$mismatch_setup_fd
+  _zrush_worker_retry_fd=$mismatch_retry_fd _zrush_worker_drain_fd=$mismatch_drain_fd
   _zrush_encode_message incompatible 7
   local mismatch_frame=$REPLY
   _zrush_netstring_take "$mismatch_frame"
   _zrush_worker_handle_message "$REPLY" 2>/dev/null
   if (( _zrush_disabled && !_zrush_enabled && _zrush_worker_failures == 0 \
-        && _zrush_worker_warned )); then
-    ok "worker lifecycle: protocol mismatch disables immediately"
+        && _zrush_worker_warned && _zrush_worker_rfd == -1 && _zrush_worker_wfd == -1 \
+        && _zrush_worker_setup_fd == -1 && _zrush_worker_retry_fd == -1 \
+        && _zrush_worker_drain_fd == -1 )) \
+     && [[ ! -e /dev/fd/$mismatch_rfd && ! -e /dev/fd/$mismatch_wfd \
+           && ! -e /dev/fd/$mismatch_setup_fd && ! -e /dev/fd/$mismatch_retry_fd \
+           && ! -e /dev/fd/$mismatch_drain_fd ]]; then
+    ok "worker lifecycle: protocol mismatch disables immediately and closes every transport fd"
   else
     ng "worker lifecycle: mismatch state enabled=$_zrush_enabled disabled=$_zrush_disabled failures=$_zrush_worker_failures warned=$_zrush_worker_warned"
   fi

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -134,6 +134,20 @@ _zlog() { [[ -n $ZRUSH_LOG ]] && print -r -- "[$$ ${EPOCHREALTIME:-0}] $1" >>| $
 
 _zrush_warn() { print -ru2 -- "zrush: $1" }
 
+_zrush_close_internal_fd() {  # $1=owned fd; idempotent best-effort close
+  emulate -L zsh
+  local -i fd=${1:--1}
+  (( fd < 0 )) && return 0
+  if (( fd <= 2 )); then
+    _zlog "fd: refusing to close reserved fd=$fd"
+    return 0
+  fi
+  { exec {fd}>&- } 2>/dev/null
+  local -i st=$?
+  (( st == 0 )) || _zlog "fd: close failed fd=$fd status=$st"
+  return 0
+}
+
 # ---------------------------------------------------------------- Widening
 # See docs/internal/specs/behavior.md "候補収集" and cli-protocol.md "起動".
 _zrush_widen() {  # $1=buffer through the cursor
@@ -404,7 +418,7 @@ _zrush_capture_entry() {
     RBUFFER=
     builtin zle _zrush-capture-comp -w 2>>| ${ZRUSH_LOG:-/dev/null}
   } always {
-    exec {_zrush_wfd}>&-
+    _zrush_close_internal_fd $_zrush_wfd
     builtin exit 0
   }
 }
@@ -427,7 +441,7 @@ _zrush_capture_worker() {
   SAVEHIST=0
   _zlog "fork: start wfd=$_zrush_wfd"
   # The inherited read-side copy is not needed.
-  (( _zrush_rfd >= 0 )) && exec {_zrush_rfd}<&-
+  _zrush_close_internal_fd $_zrush_rfd
   # Report the real pid first so the parent can SIGINT its process group on cancellation.
   print -rn -u $_zrush_wfd -- "pid"$'\1'"$sysparams[pid]"$'\0' 2>/dev/null
   # The fork inherits active ZLE state, so it can invoke the widget directly.
@@ -440,11 +454,11 @@ _zrush_cancel_collection() {
   emulate -L zsh
   if (( _zrush_rfd >= 0 )); then
     zle -F $_zrush_rfd 2>/dev/null
-    exec {_zrush_rfd}<&-
+    _zrush_close_internal_fd $_zrush_rfd
     _zrush_rfd=-1
   fi
   if (( _zrush_wfd >= 0 )); then
-    exec {_zrush_wfd}>&-
+    _zrush_close_internal_fd $_zrush_wfd
     _zrush_wfd=-1
   fi
   if [[ -n $_zrush_pty ]]; then
@@ -465,7 +479,7 @@ _zrush_disarm_timer() {
   emulate -L zsh
   if (( _zrush_timer_fd >= 0 )); then
     zle -F $_zrush_timer_fd 2>/dev/null
-    exec {_zrush_timer_fd}<&-
+    _zrush_close_internal_fd $_zrush_timer_fd
     _zrush_timer_fd=-1
   fi
 }
@@ -636,7 +650,7 @@ _zrush_start_request() {
   exec {rw}<>$fifo
   exec {_zrush_rfd}<$fifo
   exec {_zrush_wfd}>$fifo
-  exec {rw}>&-
+  _zrush_close_internal_fd $rw
   rm -f $fifo
 
   _zrush_pty=zrush-w$(( ++_zrush_gen ))
@@ -646,7 +660,7 @@ _zrush_start_request() {
     return 1
   fi
   # Close the parent's write-side copy immediately after the fork so EOF remains detectable.
-  exec {_zrush_wfd}>&-
+  _zrush_close_internal_fd $_zrush_wfd
   _zrush_wfd=-1
 
   zle -F -w $_zrush_rfd _zrush-on-data
@@ -674,7 +688,7 @@ _zrush_on_data() {  # zle -F -w handler ($1=fd)
   fi
   # EOF (5) or a read error ends reception for this request.
   zle -F $fd 2>/dev/null
-  exec {fd}<&-
+  _zrush_close_internal_fd $fd
   _zrush_rfd=-1
   zpty -d $_zrush_pty 2>/dev/null
   _zrush_pty=
@@ -802,12 +816,12 @@ _zrush_worker_warn_once() {
 _zrush_worker_disarm_retry() {
   if (( _zrush_worker_retry_fd >= 0 )); then
     zle -F $_zrush_worker_retry_fd 2>/dev/null
-    exec {_zrush_worker_retry_fd}<&- 2>/dev/null
+    _zrush_close_internal_fd $_zrush_worker_retry_fd
     _zrush_worker_retry_fd=-1
   fi
   if (( _zrush_worker_drain_fd >= 0 )); then
     zle -F $_zrush_worker_drain_fd 2>/dev/null
-    exec {_zrush_worker_drain_fd}<&- 2>/dev/null
+    _zrush_close_internal_fd $_zrush_worker_drain_fd
     _zrush_worker_drain_fd=-1
   fi
 }
@@ -833,7 +847,7 @@ _zrush_worker_transport_teardown() {
   _zrush_worker_disarm_retry
   if (( _zrush_worker_setup_fd >= 0 )); then
     zle -F $_zrush_worker_setup_fd 2>/dev/null
-    exec {_zrush_worker_setup_fd}<&- 2>/dev/null
+    _zrush_close_internal_fd $_zrush_worker_setup_fd
     _zrush_worker_setup_fd=-1
   fi
   _zrush_worker_terminate_and_reap $_zrush_worker_setup_pid
@@ -844,11 +858,11 @@ _zrush_worker_transport_teardown() {
   _zrush_worker_setup_req= _zrush_worker_setup_resp=
   if (( _zrush_worker_rfd >= 0 )); then
     zle -F $_zrush_worker_rfd 2>/dev/null
-    exec {_zrush_worker_rfd}<&- 2>/dev/null
+    _zrush_close_internal_fd $_zrush_worker_rfd
     _zrush_worker_rfd=-1
   fi
   if (( _zrush_worker_wfd >= 0 )); then
-    exec {_zrush_worker_wfd}>&- 2>/dev/null
+    _zrush_close_internal_fd $_zrush_worker_wfd
     _zrush_worker_wfd=-1
   fi
   if (( _zrush_worker_pid > 1 )); then
@@ -934,24 +948,31 @@ _zrush_worker_finish_start() {
      ! sysopen -rw -o cloexec -u resp_anchor "$resp" ||
      ! sysopen -r -o nonblock,cloexec -u _zrush_worker_rfd "$resp" ||
      ! sysopen -w -o cloexec -u child_out "$resp"; then
-    (( ${req_anchor:--1} >= 0 )) && exec {req_anchor}>&- 2>/dev/null
-    (( ${resp_anchor:--1} >= 0 )) && exec {resp_anchor}>&- 2>/dev/null
-    (( ${child_in:--1} >= 0 )) && exec {child_in}<&- 2>/dev/null
-    (( ${child_out:--1} >= 0 )) && exec {child_out}>&- 2>/dev/null
-    (( _zrush_worker_wfd >= 0 )) && exec {_zrush_worker_wfd}>&- 2>/dev/null
-    (( _zrush_worker_rfd >= 0 )) && exec {_zrush_worker_rfd}<&- 2>/dev/null
+    _zrush_close_internal_fd ${req_anchor:--1}
+    _zrush_close_internal_fd ${resp_anchor:--1}
+    _zrush_close_internal_fd ${child_in:--1}
+    _zrush_close_internal_fd ${child_out:--1}
+    _zrush_close_internal_fd $_zrush_worker_wfd
+    _zrush_close_internal_fd $_zrush_worker_rfd
     _zrush_worker_wfd=-1 _zrush_worker_rfd=-1
     return 1
   fi
 
   (
     exec 0<&$child_in 1>&$child_out
-    exec {req_anchor}>&- {resp_anchor}>&- {child_in}<&- {child_out}>&-
-    exec {_zrush_worker_rfd}<&- {_zrush_worker_wfd}>&-
+    _zrush_close_internal_fd $req_anchor
+    _zrush_close_internal_fd $resp_anchor
+    _zrush_close_internal_fd $child_in
+    _zrush_close_internal_fd $child_out
+    _zrush_close_internal_fd $_zrush_worker_rfd
+    _zrush_close_internal_fd $_zrush_worker_wfd
     exec "$ZRUSH_BIN" worker 2>>| "${ZRUSH_LOG:-/dev/null}"
   ) &
   _zrush_worker_pid=$!
-  exec {req_anchor}>&- {resp_anchor}>&- {child_in}<&- {child_out}>&-
+  _zrush_close_internal_fd $req_anchor
+  _zrush_close_internal_fd $resp_anchor
+  _zrush_close_internal_fd $child_in
+  _zrush_close_internal_fd $child_out
   command rm -f "$req" "$resp" >/dev/null 2>&1 &!
   _zrush_worker_setup_req= _zrush_worker_setup_resp=
   if ! zle -F -w $_zrush_worker_rfd _zrush-worker-on-data 2>/dev/null; then
@@ -969,7 +990,7 @@ _zrush_worker_consume_setup() {
   sysread -t 0 -i $_zrush_worker_setup_fd signal; st=$?
   (( st == 0 )) || return 1
   zle -F $_zrush_worker_setup_fd 2>/dev/null
-  exec {_zrush_worker_setup_fd}<&- 2>/dev/null
+  _zrush_close_internal_fd $_zrush_worker_setup_fd
   _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
   _zrush_worker_terminate_and_reap $setup_pid
   [[ $signal == 1 ]] || return 1
@@ -997,7 +1018,7 @@ _zrush_worker_arm_retry() {
   exec {fd}< <( zselect -t 1; print )
   _zrush_worker_retry_fd=$fd
   zle -F -w $fd _zrush-worker-on-write 2>/dev/null || {
-    exec {fd}<&-
+    _zrush_close_internal_fd $fd
     _zrush_worker_retry_fd=-1
     _zrush_worker_session_fail "write retry fd registration failed"
     return 1
@@ -1055,7 +1076,7 @@ _zrush_worker_on_write() {
   emulate -L zsh
   local -i fd=$1
   zle -F $fd 2>/dev/null
-  exec {fd}<&- 2>/dev/null
+  _zrush_close_internal_fd $fd
   (( fd == _zrush_worker_retry_fd )) && _zrush_worker_retry_fd=-1
   _zrush_worker_flush
   return 0
@@ -1158,7 +1179,7 @@ _zrush_worker_arm_drain() {
   exec {fd}< <( zselect -t 1; print )
   _zrush_worker_drain_fd=$fd
   zle -F -w $fd _zrush-worker-on-drain 2>/dev/null || {
-    exec {fd}<&-
+    _zrush_close_internal_fd $fd
     _zrush_worker_drain_fd=-1
     _zrush_worker_session_fail "read continuation fd registration failed"
     return 1
@@ -1222,7 +1243,7 @@ _zrush_worker_on_drain() {
   emulate -L zsh
   local -i fd=$1
   zle -F $fd 2>/dev/null
-  exec {fd}<&- 2>/dev/null
+  _zrush_close_internal_fd $fd
   (( fd == _zrush_worker_drain_fd )) && _zrush_worker_drain_fd=-1
   _zrush_worker_read async
   return 0
@@ -1561,7 +1582,7 @@ _zrush_timer_fire() {  # zle -F -w handler ($1=fd)
   emulate -L zsh
   local -i fd=$1
   zle -F $fd 2>/dev/null
-  exec {fd}<&-
+  _zrush_close_internal_fd $fd
   (( fd == _zrush_timer_fd )) && _zrush_timer_fd=-1
   # Discard if the buffer changed; pre-redraw has armed a newer timer.
   [[ $BUFFER == "$_zrush_pending_buffer" ]] || return 0
@@ -2015,9 +2036,9 @@ _zrush_zshexit() {
   emulate -L zsh
   # ZLE is inactive here; leave it untouched and reliably close only fds and zpty.
   _zrush_worker_transport_teardown exit
-  (( _zrush_timer_fd >= 0 )) && { exec {_zrush_timer_fd}<&- 2>/dev/null; _zrush_timer_fd=-1 }
-  if (( _zrush_rfd >= 0 )); then exec {_zrush_rfd}<&-; _zrush_rfd=-1; fi
-  if (( _zrush_wfd >= 0 )); then exec {_zrush_wfd}>&-; _zrush_wfd=-1; fi
+  (( _zrush_timer_fd >= 0 )) && { _zrush_close_internal_fd $_zrush_timer_fd; _zrush_timer_fd=-1 }
+  if (( _zrush_rfd >= 0 )); then _zrush_close_internal_fd $_zrush_rfd; _zrush_rfd=-1; fi
+  if (( _zrush_wfd >= 0 )); then _zrush_close_internal_fd $_zrush_wfd; _zrush_wfd=-1; fi
   if [[ -n $_zrush_pty ]]; then
     if [[ $_zrush_capture_pid == <-> ]] && (( _zrush_capture_pid > 1 )); then
       kill -INT -$_zrush_capture_pid 2>/dev/null || kill -INT $_zrush_capture_pid 2>/dev/null


### PR DESCRIPTION
## Summary

zrush worker lifecycle paths could close or redirect the interactive shell's standard file descriptors while cleaning up dynamically allocated descriptors. This change centralizes internal descriptor closure so fd 0, 1, and 2 remain intact, while keeping cleanup best-effort and diagnostics scoped.

- add a guarded helper for closing zrush-owned file descriptors
- route worker startup, teardown, failure, timer, retry, drain, reload, re-source, disable, and exit paths through the helper
- document the standard-descriptor preservation invariant
- add focused and PTY lifecycle regression coverage, including zsh 5.8/5.9 behavior

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`
- `zsh -f tests/zsh/vectors.zsh` — 73 passed
- `zsh -f tests/zsh/driver.zsh <sandbox>` — 139 passed
- `zsh -f tests/zsh/driver-coexist.zsh <sandbox>` — 37 passed

Closes #31