### PR TITLE
docs: unify title conventions across issues, PRs, and commits

### DIFF
--- a/.github/ISSUE_TEMPLATE/change.md
+++ b/.github/ISSUE_TEMPLATE/change.md
@@ -1,9 +1,15 @@
 ---
 name: Change (fix / feat)
-about: Behavior, spec, or implementation change. Only the opening paragraphs are mandatory.
+about: Behavior, spec, or implementation change. Only the title and the opening paragraphs are mandatory.
 ---
 
 <!--
+Title (mandatory): Conventional Commits, naming the change itself
+(e.g. "fix(zle): clear listing on accept-line"). It is reused as the PR title
+and can land on main unedited as the commit subject, so write it as that
+commit message.
+Omit the scope when the affected component is not yet known.
+
 Opening paragraphs (mandatory, 1-2):
   1. Current state (point to the relevant docs/ section if any)
   2. What changes

--- a/.github/ISSUE_TEMPLATE/decision.md
+++ b/.github/ISSUE_TEMPLATE/decision.md
@@ -1,9 +1,13 @@
 ---
 name: Design decision
-about: Architecture / policy decision record. Only the opening paragraphs are mandatory.
+about: Architecture / policy decision record. Only the title and the opening paragraphs are mandatory.
 ---
 
 <!--
+Title (mandatory): Conventional Commits, naming the change the decision
+commits to (e.g. "feat: adopt a persistent per-shell worker process"),
+not the act of deciding.
+
 Opening paragraphs (mandatory, 1-2):
   1. Current state
   2. The decision itself (write it here; do not assume it was made elsewhere)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,16 +37,19 @@ For changes touching `zsh/`, the zle-integration drivers `tests/zsh/driver.zsh` 
 
 ## Commits, issues, and pull requests
 
-One-line titles — commit messages, issue titles, PR titles — are concise English, because they flow through tooling.
-Commit messages additionally follow [Conventional Commits](https://www.conventionalcommits.org/)
-(e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`, `fix(zle): clear listing on accept-line`).
+One-line titles — issue titles, PR titles, commit messages — are concise English following [Conventional Commits](https://www.conventionalcommits.org/)
+(e.g. `docs: update config schema`, `feat(match): add typo-tolerant matching`, `fix(zle): clear listing on accept-line`), because they flow through tooling.
+A change is titled once: the issue names it, and the PR reuses that title — written as the commit message for the whole change, so that it can land on `main` unedited.
+Never write the ` (#N)` suffix by hand; GitHub appends it on squash merge.
+Omit the scope when the affected component is not yet known.
+Mark the type with `!` only for breakage the user sees — configuration, keybindings, observable behavior; a zsh ↔ Rust protocol version bump is internal and does not qualify.
 Bodies may be English or Japanese.
 
 Issue bodies must be self-contained for a reader who was not part of the conversation that spawned them:
 open with one or two paragraphs stating the current state, the change or decision being made, and the reason, before any detail.
 Do not use vocabulary or references that only made sense in that conversation; reference other issues as `#N` plus a short description.
 Numbers used as evidence come with the measurement environment and reproduction steps.
-Templates under `.github/ISSUE_TEMPLATE/` mirror these rules; only the opening paragraphs are mandatory — the other sections are guidance to keep or drop.
+Templates under `.github/ISSUE_TEMPLATE/` mirror these rules; only the title and the opening paragraphs are mandatory — the other sections are guidance to keep or drop.
 
 ## Core principles
 


### PR DESCRIPTION
Conventional Commits applied only to commit messages, so a PR title could be plain English and still become the subject of the squash commit on `main`.
`History menu on Up key filtered by current input (#13)` landed that way; #30 and #8 avoided it only because the title was rewritten by hand in the merge dialog.

A change is now titled once: the issue names it in Conventional Commits form, the PR reuses that title, and it lands on `main` unedited.
Issue titles are no longer a special case, which removes a rule instead of adding one.

The wording deliberately states how the title must be written rather than what the merge does with it, so it holds under squash and merge commits alike.
`!` is defined as user-visible breakage only — configuration, keybindings, observable behavior — because the repository had been split on whether a protocol version bump qualifies (#12 and #4 marked it, #30 did not).

The issue templates carry the same title rule, and the eight open issues have been retitled to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ85uWoAwfy3sZiSwaKa4X