### PR TITLE
fix(worker): keep the worker out of the shell job table

### DIFF
--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -39,6 +39,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 - worker の stdin/stdout は pty ではなく専用 pipe へ接続する。zsh は stdout の read fd を `zle -F` で監視し、
   通常の補完 plan 応答を非同期に読む。セッションの nested-netstring 形式と `hello` / `ready` 握手は
   `../contracts/cli-protocol.md` が定める。
+- worker は対話シェルの job table に登録せず、動作中でもシェルの `exit` を妨げない。
 - 通常の補完経路では、worker の cold start と握手を待たない。起動処理は ZLE へ直ちに制御を返し、
   `hello` も outbound queue から nonblocking に送り、残りの送信と `ready` の受信を fd callback / 非同期 retry で進める。
   握手中に生じた plan 要求は `hello` より後ろの outbound queue に置く。
@@ -58,7 +59,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   要求と対応しない応答、仕様を満たさない `ok` の描画プラン、履歴交換の deadline 超過は
   **worker セッション失敗**である。その session に割り当て済みで終端応答のない要求を、partial write 中・
   outbound queue 内・送信済みの区別なくすべて破棄し、既存一覧も消す。いずれも自動 replay しない。
-  worker プロセスが残っていれば終了して回収し、`zle -F` watcher を解除して stdin/stdout pipe fd を閉じ、
+  worker プロセスが残っていれば終了させて消滅を確認し、`zle -F` watcher を解除して stdin/stdout pipe fd を閉じ、
   head-of-line blocking を残さない。この cleanup が完了するまで代替 worker を起動せず、worker を重複させない。
 - 連続 worker セッション失敗回数は、正常に形成された終端 `ok` / `error` を受けたときだけ 0 に戻す。
   握手成功だけでは戻さない。1 回目の失敗後は worker 不在のままにし、**次の実要求**で 1 個だけ代替 worker を
@@ -71,11 +72,11 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 - worker の起動・通常終了・異常終了・再起動・re-source・無効化を含む全 lifecycle で、zsh が所有する
   内部 fd の操作は対話シェル自身の fd 0 / 1 / 2 の open / closed 状態と接続先を変更しない。
   内部 fd の close error を抑止するときも、その抑止を対話シェルの標準エラーへ恒久適用しない。
-- 同じシェルで zrush.zsh を re-source するときは、既存 worker プロセスを終了して回収し、`zle -F` watcher を解除して
+- 同じシェルで zrush.zsh を re-source するときは、既存 worker プロセスを終了させて消滅を確認し、`zle -F` watcher を解除して
   stdin/stdout pipe fd を閉じてからフックとキーバインドを再構築する。cleanup 中に新旧 worker を重複させない。
   re-source は同じシェルセッションの request_id 単調性・警告済み状態・連続失敗回数・無効化状態を巻き戻さない。
-  `zshexit` でも worker プロセスを終了して回収し、watcher を解除して pipe fd を閉じる。
-  worker が既に終了・回収済みであることはエラーにしない。
+  `zshexit` でも worker プロセスを終了させて消滅を確認し、watcher を解除して pipe fd を閉じる。
+  worker が既に終了していることはエラーにしない。
 
 ## 候補収集
 
@@ -234,7 +235,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   payload 合成に費やす時間はこの deadline に含めない。
 - 同期待ちの間に先行する非同期要求の応答を受けた場合も通常どおり終端まで読み、stale なら破棄して
   対象 request_id を待ち続ける。先行要求の outbound queue 送信と直列処理に費やす時間も同じ deadline を消費する。
-  deadline を要求ごと・write/read ごとに延長しない。超過時は worker プロセスを終了して回収し、
+  deadline を要求ごと・write/read ごとに延長しない。超過時は worker プロセスを終了させて消滅を確認し、
   watcher を解除して pipe fd を閉じてから、その session の未完了要求をすべて破棄する。自動 replay しない
   (連続失敗の扱いは「worker ライフサイクル」)。
 - クエリは `BUFFER` 全体。`min-input` と空バッファ抑止規則は適用しないため、

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -341,13 +341,12 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   else
     ng "(worker-1d) bad post-resource state: ${REPLY:-<none>}"
   fi
-  local reaped_resource=$(grep -F "worker: reaped pid=$first_worker_pid status=" $ZRUSH_LOG 2>/dev/null | tail -1)
-  local reaped_resource_status=${reaped_resource##*status=}
-  if [[ -n $reaped_resource && $reaped_resource_status != 127 ]] \
+  local terminated_resource=$(grep -F "worker: terminated pid=$first_worker_pid gone=1" $ZRUSH_LOG 2>/dev/null | tail -1)
+  if [[ -n $terminated_resource ]] \
      && ! kill -0 $first_worker_pid 2>/dev/null; then
-    ok "(worker-1e) re-source terminates and wait-reaps old worker pid=$first_worker_pid (status=$reaped_resource_status)"
+    ok "(worker-1e) re-source terminates old worker pid=$first_worker_pid and confirms it is gone"
   else
-    ng "(worker-1e) old worker was not wait-reaped: line=${reaped_resource:-<none>}"
+    ng "(worker-1e) old worker did not disappear: line=${terminated_resource:-<none>}"
   fi
   assert_host_stdio "(fd-3) re-source teardown preserves host fd 0/1/2"
 
@@ -660,12 +659,12 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   drain 0.3
   dump_get $'\C-xw' TESTWORKER
   [[ $REPLY == 'pid=-1 ready=0 '* ]] || ng "(err-setup) worker teardown failed: $REPLY"
-  local explicit_reap=$(grep -F "worker: reaped pid=$explicit_teardown_pid status=" $ZRUSH_LOG 2>/dev/null | tail -1)
-  if (( explicit_teardown_pid > 1 )) && [[ -n $explicit_reap && $explicit_reap != *'status=127' ]] \
+  local explicit_termination=$(grep -F "worker: terminated pid=$explicit_teardown_pid gone=1" $ZRUSH_LOG 2>/dev/null | tail -1)
+  if (( explicit_teardown_pid > 1 )) && [[ -n $explicit_termination ]] \
      && ! kill -0 $explicit_teardown_pid 2>/dev/null; then
-    ok "(err-setup) explicit teardown terminates and wait-reaps pid=$explicit_teardown_pid"
+    ok "(err-setup) explicit teardown terminates pid=$explicit_teardown_pid and confirms it is gone"
   else
-    ng "(err-setup) explicit teardown did not reap old worker: ${explicit_reap:-<none>}"
+    ng "(err-setup) explicit teardown did not confirm old worker disappeared: ${explicit_termination:-<none>}"
   fi
   assert_host_stdio "(fd-4) explicit worker teardown preserves host fd 0/1/2"
   print -r -- die > $ZRUSH_FAKE_CONTROL
@@ -692,18 +691,18 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
     local fake_worker_tail=${fake_started#*'worker: started pid='}
     fake_worker_pid=${fake_worker_tail%% *}
   fi
-  local exact_fake_reap=
+  local exact_fake_termination=
   if (( fake_worker_pid > 1 )); then
-    exact_fake_reap=$(print -r -- "$err_log_delta" \
-      | grep -E "\\] worker: reaped pid=$fake_worker_pid status=19\$" 2>/dev/null)
+    exact_fake_termination=$(print -r -- "$err_log_delta" \
+      | grep -E "\\] worker: terminated pid=$fake_worker_pid gone=1\$" 2>/dev/null)
   fi
   if (( active_death_ok && fake_started_count == 1 && fake_worker_pid > 1 )) \
-     && [[ -n $exact_fake_reap ]] \
+     && [[ -n $exact_fake_termination ]] \
      && dump_get $'\C-xw' TESTWORKER \
      && [[ $REPLY == *'failures=1 disabled=0'*'warned=1'*'pending=0' ]]; then
     ok "(err-1a) ready worker dies with an assigned request; pending is discarded and failure is retryable"
   else
-    ng "(err-1a) active-death state missing: state=${REPLY:-<none>} pid=$fake_worker_pid reap=${exact_fake_reap:-<none>}"
+    ng "(err-1a) active-death state missing: state=${REPLY:-<none>} pid=$fake_worker_pid termination=${exact_fake_termination:-<none>}"
   fi
   local first_die=$(grep -F 'die 1 ' $ZRUSH_FAKE_STATE 2>/dev/null | tail -1)
   local first_dead_id=${first_die##* }
@@ -1491,6 +1490,50 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
       || ng "(h20a') ctrl-p did not change the buffer; it may have been silently swallowed instead of delegated"
   else
     ng "(h20-0) select-prev=[\"up\"] host failed to start"
+  fi
+
+  # ================================================================ Worker job-table isolation
+  # This host must exit during the assertion, so give it dedicated rc/config/log
+  # state rather than reusing any host needed by the preceding cases.
+  mkdir -p $WORK/zdot-exit $WORK/xdg-exit/zrush
+  print "source $REPO/tests/zsh/rc/minimal.zshrc" > $WORK/zdot-exit/.zshrc
+  if start_hist_host $WORK/zdot-exit $WORK/xdg-exit $WORK/host-exit.log; then
+    send_line '[[ -o checkjobs && -o checkrunningjobs ]] && print CHECK-JOBS-ENABLED'
+    if expect '*CHECK-JOBS-ENABLED*HP>*' 5; then
+      send_keys 'ls fx/basic/al'
+      expect '*alpha.txt*' 10 >/dev/null
+      if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == 'pid='<->' ready=1 '* ]]; then
+        clear_line
+        drain 0.3
+        local -F exit_deadline=$(( SECONDS + 5 ))
+        local -i exit_eof=0 exit_read_status=0
+        local exit_output= exit_chunk=
+        send_line exit
+        while (( SECONDS < exit_deadline )); do
+          if zselect -t 20 -r $HOSTFD 2>/dev/null; then
+            exit_chunk=
+            zpty -r host exit_chunk 2>/dev/null; exit_read_status=$?
+            (( exit_read_status == 0 )) && exit_output+=$exit_chunk
+            if (( exit_read_status == 2 )); then
+              exit_eof=1
+              break
+            fi
+          fi
+        done
+        local visible_exit_output=${exit_output//$'\e['[0-9;]#m/}
+        if (( exit_eof )) && [[ $visible_exit_output != *'zsh: you have running jobs.'* ]]; then
+          ok "(worker-job-table) one exit terminates a worker-owning shell without a running-jobs refusal"
+        else
+          ng "(worker-job-table) exit did not terminate cleanly: eof=$exit_eof output=${(qqqq)visible_exit_output}"
+        fi
+      else
+        ng "(worker-job-table) dedicated host did not start its worker: ${REPLY:-<none>}"
+      fi
+    else
+      ng "(worker-job-table) dedicated host did not enable CHECK_JOBS and CHECK_RUNNING_JOBS"
+    fi
+  else
+    ng "(worker-job-table) dedicated exit host failed to start"
   fi
 
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -85,7 +85,7 @@ typeset -gi _zrush_worker_drain_fd=-1
 typeset -gi _zrush_worker_pid=-1 _zrush_worker_ready=0
 typeset -g  _zrush_worker_rx= _zrush_worker_tx=
 typeset -gi _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
-typeset -g  _zrush_worker_setup_req= _zrush_worker_setup_resp=
+typeset -g  _zrush_worker_setup_req=
 typeset -gA _zrush_worker_pending=()
 typeset -gi _zrush_current_request=0
 typeset -gi _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
@@ -826,7 +826,7 @@ _zrush_worker_disarm_retry() {
   fi
 }
 
-_zrush_worker_terminate_and_reap() {
+_zrush_worker_terminate() {
   emulate -L zsh
   local -i pid=$1
   (( pid > 1 )) || return 0
@@ -835,9 +835,10 @@ _zrush_worker_terminate_and_reap() {
     zselect -t 1 2>/dev/null
     kill -0 $pid 2>/dev/null && kill -KILL $pid 2>/dev/null
   fi
-  local -i st=0
-  wait $pid 2>/dev/null; st=$?
-  _zlog "worker: reaped pid=$pid status=$st"
+  kill -0 $pid 2>/dev/null && zselect -t 1 2>/dev/null
+  local -i gone=0
+  kill -0 $pid 2>/dev/null || gone=1
+  _zlog "worker: terminated pid=$pid gone=$gone"
   return 0
 }
 
@@ -850,12 +851,12 @@ _zrush_worker_transport_teardown() {
     _zrush_close_internal_fd $_zrush_worker_setup_fd
     _zrush_worker_setup_fd=-1
   fi
-  _zrush_worker_terminate_and_reap $_zrush_worker_setup_pid
+  _zrush_worker_terminate $_zrush_worker_setup_pid
   _zrush_worker_setup_pid=-1
-  if [[ -n $_zrush_worker_setup_req || -n $_zrush_worker_setup_resp ]]; then
-    command rm -f "$_zrush_worker_setup_req" "$_zrush_worker_setup_resp" >/dev/null 2>&1 &!
+  if [[ -n $_zrush_worker_setup_req ]]; then
+    command rm -f "$_zrush_worker_setup_req" >/dev/null 2>&1 &!
   fi
-  _zrush_worker_setup_req= _zrush_worker_setup_resp=
+  _zrush_worker_setup_req=
   if (( _zrush_worker_rfd >= 0 )); then
     zle -F $_zrush_worker_rfd 2>/dev/null
     _zrush_close_internal_fd $_zrush_worker_rfd
@@ -866,7 +867,7 @@ _zrush_worker_transport_teardown() {
     _zrush_worker_wfd=-1
   fi
   if (( _zrush_worker_pid > 1 )); then
-    _zrush_worker_terminate_and_reap $_zrush_worker_pid
+    _zrush_worker_terminate $_zrush_worker_pid
   fi
   _zrush_worker_pid=-1
   _zrush_worker_ready=0
@@ -913,11 +914,10 @@ _zrush_worker_start() {
 
   local base=${TMPDIR:-/tmp}/zrush-worker-$$-$RANDOM
   _zrush_worker_setup_req=$base.in
-  _zrush_worker_setup_resp=$base.out
   local fd
   exec {fd}< <(
     umask 077
-    if command mkfifo "$_zrush_worker_setup_req" "$_zrush_worker_setup_resp" 2>/dev/null; then
+    if command mkfifo "$_zrush_worker_setup_req" 2>/dev/null; then
       print -rn -- 1
     else
       print -rn -- 0
@@ -940,41 +940,35 @@ _zrush_worker_start() {
 _zrush_worker_finish_start() {
   emulate -L zsh
   setopt localoptions no_monitor no_notify no_bg_nice
-  local req=$_zrush_worker_setup_req resp=$_zrush_worker_setup_resp
-  local req_anchor resp_anchor child_in child_out
+  local req=$_zrush_worker_setup_req
+  local req_anchor child_in
+  local -i failed=0
   if ! sysopen -rw -o cloexec -u req_anchor "$req" ||
      ! sysopen -r -o cloexec -u child_in "$req" ||
-     ! sysopen -w -o nonblock,cloexec -u _zrush_worker_wfd "$req" ||
-     ! sysopen -rw -o cloexec -u resp_anchor "$resp" ||
-     ! sysopen -r -o nonblock,cloexec -u _zrush_worker_rfd "$resp" ||
-     ! sysopen -w -o cloexec -u child_out "$resp"; then
+     ! sysopen -w -o nonblock,cloexec -u _zrush_worker_wfd "$req"; then
+    failed=1
+  else
+    # The substitution forks before sysopen runs, so record the pid whether or not
+    # sysopen succeeded: a failure here still has a worker to terminate.
+    sysopen -r -o nonblock,cloexec -u _zrush_worker_rfd \
+      <( exec "$ZRUSH_BIN" worker <&$child_in 2>>| "${ZRUSH_LOG:-/dev/null}" ) || failed=1
+    _zrush_worker_pid=${sysparams[procsubstpid]:--1}
+  fi
+  if (( failed )); then
+    _zrush_worker_terminate $_zrush_worker_pid
+    _zrush_worker_pid=-1
     _zrush_close_internal_fd ${req_anchor:--1}
-    _zrush_close_internal_fd ${resp_anchor:--1}
     _zrush_close_internal_fd ${child_in:--1}
-    _zrush_close_internal_fd ${child_out:--1}
     _zrush_close_internal_fd $_zrush_worker_wfd
     _zrush_close_internal_fd $_zrush_worker_rfd
     _zrush_worker_wfd=-1 _zrush_worker_rfd=-1
     return 1
   fi
 
-  (
-    exec 0<&$child_in 1>&$child_out
-    _zrush_close_internal_fd $req_anchor
-    _zrush_close_internal_fd $resp_anchor
-    _zrush_close_internal_fd $child_in
-    _zrush_close_internal_fd $child_out
-    _zrush_close_internal_fd $_zrush_worker_rfd
-    _zrush_close_internal_fd $_zrush_worker_wfd
-    exec "$ZRUSH_BIN" worker 2>>| "${ZRUSH_LOG:-/dev/null}"
-  ) &
-  _zrush_worker_pid=$!
   _zrush_close_internal_fd $req_anchor
-  _zrush_close_internal_fd $resp_anchor
   _zrush_close_internal_fd $child_in
-  _zrush_close_internal_fd $child_out
-  command rm -f "$req" "$resp" >/dev/null 2>&1 &!
-  _zrush_worker_setup_req= _zrush_worker_setup_resp=
+  command rm -f "$req" >/dev/null 2>&1 &!
+  _zrush_worker_setup_req=
   if ! zle -F -w $_zrush_worker_rfd _zrush-worker-on-data 2>/dev/null; then
     _zrush_worker_session_fail "data fd registration failed"
     return 1
@@ -992,7 +986,7 @@ _zrush_worker_consume_setup() {
   zle -F $_zrush_worker_setup_fd 2>/dev/null
   _zrush_close_internal_fd $_zrush_worker_setup_fd
   _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
-  _zrush_worker_terminate_and_reap $setup_pid
+  _zrush_worker_terminate $setup_pid
   [[ $signal == 1 ]] || return 1
   _zrush_worker_finish_start
 }


### PR DESCRIPTION
## Summary

The persistent worker was started with a plain `( ... ) &`, which registers it as a running job in the interactive shell's job table. With `CHECK_JOBS` and `CHECK_RUNNING_JOBS` (both on by default in zsh native emulation), the first `exit` in any shell where the worker had started was refused with `zsh: you have running jobs.`; a second `exit` was needed. `no_monitor` / `no_notify` only suppress the asynchronous job notification and do not prevent job-table registration.

The worker now starts through a process substitution, as gitstatus does, with its pid taken from `$sysparams[procsubstpid]`. Process-substitution children never enter the job table.

- start the worker via `sysopen -r -o nonblock,cloexec -u <rfd> <( exec zrush worker <&$child_in )`
- drop the response FIFO together with its `resp_anchor` / `child_out` descriptors; the asynchronous setup now creates one FIFO instead of two
- replace `wait`-based reclaim with a disappearance check, since `wait` does not apply to a process-substitution child (zsh still reaps it, so no zombie is left)
- terminate an already-forked worker when the descriptor open that follows it fails
- document the job-table invariant and reword the shutdown wording that presumed `wait`

The wire protocol and the Rust side are unchanged, so `tests/zsh/vectors.zsh` needed no edits.

## Verification

Apple M3 / macOS 27.0 / arm64 / zsh 5.9.

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test` — 192 + 18 + 3 passed
- `zsh -f tests/zsh/driver.zsh <sandbox>` — 140 passed, 0 failed
- `zsh -f tests/zsh/driver-coexist.zsh <sandbox>` — 37 passed, 0 failed, 0 skipped

`tests/zsh/driver.zsh` gains `(worker-job-table)`, which starts a dedicated host, confirms `CHECK_JOBS` and `CHECK_RUNNING_JOBS` are on, starts the worker, and asserts that a single `exit` terminates the shell without the refusal. `(worker-1e)`, `(err-setup)`, and `(err-1a)` previously asserted reclaim by requiring the logged `wait` status to differ from 127 — exactly what `wait` now returns — and check process disappearance instead.

Closes #35