### PR TITLE
fix(worker): stop syswrite from parsing tx bytes as options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,5 @@ jobs:
         run: zsh -f tests/zsh/driver.zsh "$(mktemp -d)"
       - name: zsh plan-decoder vectors
         run: zsh -f tests/zsh/vectors.zsh
+      - name: zsh worker transport
+        run: zsh -f tests/zsh/transport.zsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ cargo build --release
 cargo test
 ```
 
-For changes touching `zsh/`, the zle-integration drivers `tests/zsh/driver.zsh` and `tests/zsh/driver-coexist.zsh` must also pass — run them locally; CI runs only the headless `driver.zsh`.
+For changes touching `zsh/`, the zle-integration drivers `tests/zsh/driver.zsh` and `tests/zsh/driver-coexist.zsh` must also pass — run them locally.
+CI runs the headless `driver.zsh`, `tests/zsh/vectors.zsh` (capture-encoder and plan-decoder golden vectors), and `tests/zsh/transport.zsh` (worker transport write path); `driver-coexist.zsh` remains local-only.
 `zsh/verify.zsh` launches an isolated shell for manual verification, and `tests/zsh/driver-latency.zsh` measures first-paint latency; each file's header documents prerequisites and usage.
 
 ## Commits, issues, and pull requests

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -1,0 +1,122 @@
+#!/bin/zsh -f
+# Non-pty unit tests for the zsh-side worker transport write path:
+# _zrush_worker_flush's `syswrite` call that ships the pending transmit
+# buffer to the worker process.
+#
+# Usage:
+#   zsh -f tests/zsh/transport.zsh
+#     No arguments, no pty, no terminal. The zrush binary is NOT needed and no
+#     worker process is started: this runner only sources zsh/zrush.zsh with
+#     ZRUSH_NO_INIT=1 (the test seam at the end of that file) and calls
+#     _zrush_worker_flush directly against an fd opened on a temp file.
+#     $HOME and $XDG_CONFIG_HOME are redirected to a fresh mktemp directory,
+#     so the real ~/.zshrc, shell history and ~/.config/zrush are untouched.
+#
+# Scope: vectors.zsh covers the capture encoder and the plan decoder; this
+# file is the home for non-pty unit tests of the zsh-side worker transport
+# instead. Specifically: _zrush_worker_flush passes its data argument to
+# `syswrite` after `--`, so that syswrite's own option parser never inspects
+# the transmit buffer's bytes, no matter what they are (see
+# docs/internal/specs/behavior.md's partial-write/backpressure section for
+# why the buffer can start anywhere after a short write).
+emulate -L zsh
+setopt extended_glob
+zmodload zsh/system || { print -u2 FATAL: system; exit 1 }
+
+typeset -g HERE=${${(%):-%N}:A:h}
+typeset -g REPO=${HERE:h:h}
+
+typeset -gi PASS=0 FAIL=0
+out() { print -r -u2 -- "$@" }
+ok()  { out "PASS: $1"; (( ++PASS )) }
+ng()  { out "FAIL: $1"; (( ++FAIL )) }
+
+typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-transport.XXXXXX)
+export HOME=$WORK/home             # isolated; never the real home
+export XDG_CONFIG_HOME=$WORK/xdg   # isolated; never the real ~/.config/zrush
+export HISTFILE=$WORK/histfile     # nothing writes history, but never the real one either
+unset ZDOTDIR
+mkdir -p $HOME $XDG_CONFIG_HOME
+
+{
+  typeset -g ZRUSH_NO_INIT=1
+  source $REPO/zsh/zrush.zsh || { out "FATAL: cannot source zrush.zsh"; exit 1 }
+  unset ZRUSH_NO_INIT
+  (( $+functions[_zrush_worker_flush] )) || { out "FATAL: _zrush_worker_flush undefined after source"; exit 1 }
+  (( $+functions[_zrush_encode_message] )) || { out "FATAL: _zrush_encode_message undefined after source"; exit 1 }
+  (( _zrush_enabled )) && { out "FATAL: ZRUSH_NO_INIT did not suppress initialization"; exit 1 }
+
+  # Build a representative nested-netstring message body (see
+  # _zrush_encode_message, zsh/zrush.zsh:800): a "plan" request carrying
+  # candidate-style fields ("w"$'\1' tag), the first of which has value $1,
+  # then return only the tail of the encoded bytes starting at that value.
+  # This stands in for the buffer _zrush_worker_flush is left holding after a
+  # short write landed mid-field: it opens mid-value and runs to the end of
+  # the message, so the candidates after the marker are part of the remainder.
+  tail_from_field() {  # $1=field value (must appear verbatim exactly once) -> REPLY
+    emulate -L zsh
+    setopt nomultibyte
+    local LC_ALL=C
+    local marker=$1
+    _zrush_encode_message plan 1 /some/path compsys somequery fuzzy 0 1 24 80 \
+      "w"$'\1'"$marker" "w"$'\1'"README.md" "w"$'\1'"Makefile"
+    local full=$REPLY
+    local prefix=${full%%$marker*}
+    typeset -g REPLY=${full[$#prefix+1,-1]}
+  }
+
+  # Drive _zrush_worker_flush directly: point _zrush_worker_wfd at a temp
+  # file, prime _zrush_worker_tx with $2, flush once, and leave the result in
+  # $flush_st / $WORK/$1.bin for the caller to check.
+  flush_case() {  # $1=label $2=tx-buffer
+    emulate -L zsh
+    local label=$1 tx=$2
+    local -i wfd
+    exec {wfd}> $WORK/$label.bin
+    typeset -g _zrush_worker_wfd=$wfd _zrush_worker_rfd=-1 _zrush_worker_setup_fd=-1
+    typeset -g _zrush_worker_retry_fd=-1 _zrush_worker_drain_fd=-1
+    typeset -g _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1 _zrush_worker_setup_req=
+    typeset -g _zrush_worker_tx=$tx
+    _zrush_worker_flush
+    typeset -gi flush_st=$?
+    # On success the fd is still open (nothing failed); on failure
+    # _zrush_worker_session_fail already closed it via the transport
+    # teardown. Either way, don't touch it again here.
+  }
+
+  # ---------------- dash-led buffer: unknown-option case ----------------
+  # A buffer beginning with -f (e.g. a dash-led completion candidate such as
+  # -f/--force reaching the head of the buffer after a short write) must not
+  # be parsed as a syswrite option.
+  tail_from_field -f
+  local case_f=$REPLY
+  print -rn -- "$case_f" >| $WORK/dash-f.expected.bin
+  flush_case dash-f "$case_f"
+  if (( flush_st == 0 )) && cmp -s $WORK/dash-f.expected.bin $WORK/dash-f.bin \
+     && [[ -z $_zrush_worker_tx ]]; then
+    ok "flush: buffer beginning with -f is written verbatim, not parsed as an option"
+  else
+    ng "flush: dash-f case status=$flush_st tx-remaining=${#_zrush_worker_tx}"
+  fi
+
+  # ---------------- dash-led buffer: bundled-option case ----------------
+  # -c takes an argument, so without the separator a buffer beginning with
+  # -cvar bundles as `-c var` and swallows the data word itself. That is a
+  # different syswrite parse path from the unknown-option case above: it fails
+  # on a missing argument rather than on the leading byte.
+  tail_from_field -cvar
+  local case_c=$REPLY
+  print -rn -- "$case_c" >| $WORK/dash-c.expected.bin
+  flush_case dash-c "$case_c"
+  if (( flush_st == 0 )) && cmp -s $WORK/dash-c.expected.bin $WORK/dash-c.bin \
+     && [[ -z $_zrush_worker_tx ]]; then
+    ok "flush: buffer beginning with -cvar is written verbatim, not bundled as -c var"
+  else
+    ng "flush: dash-c case status=$flush_st tx-remaining=${#_zrush_worker_tx}"
+  fi
+
+  out "SUMMARY: PASS=$PASS FAIL=$FAIL"
+} always {
+  [[ -n $WORK && $WORK == */zrush-transport.* ]] && rm -rf $WORK
+}
+(( FAIL == 0 ))

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -1030,7 +1030,7 @@ _zrush_worker_flush() {
   fi
   local -i wrote=0 st
   local write_errno=
-  syswrite -c wrote -o $_zrush_worker_wfd "$_zrush_worker_tx"
+  syswrite -c wrote -o $_zrush_worker_wfd -- "$_zrush_worker_tx"
   st=$? write_errno=$ERRNO
   (( wrote > 0 )) && _zrush_worker_tx=${_zrush_worker_tx[wrote+1,-1]}
   if (( st == 0 )); then


### PR DESCRIPTION
Closes #37.

`_zrush_worker_flush` wrote the pending transmit buffer with `syswrite -c wrote -o $_zrush_worker_wfd "$_zrush_worker_tx"`.
`syswrite` runs its own option parsing inside the builtin, so quoting does not protect the data argument:
whenever the buffer happened to begin with `-`, the call failed with `syswrite: bad option: -f` instead of writing.
That failure returns status 1 with `ERRNO` unset, so it bypassed every backpressure branch in `_zrush_worker_flush` (they all require status 2)
and fell through to `_zrush_worker_session_fail`, killing the worker for the rest of the session.

A freshly encoded message can never start with `-`: `_zrush_encode_message` wraps the payload in a netstring, so byte 1 is always a length digit.
The dash appears only after a partial write, because the trim `_zrush_worker_tx=${_zrush_worker_tx[wrote+1,-1]}` slices at a raw byte offset with no netstring awareness,
and the retry flush then starts mid-field.
The field that produces the observed `-f`/`-g` is the compsys candidate payload, whose dash-led option candidates follow a `w\x01` tag.

Terminating option parsing with `--` is the whole fix. It also closes the neighbouring class where `syswrite` bundles valid option letters (`-cvar` parses as `-c var`).

## Tests

The partial-write timing is not deterministically reproducible in the zsh drivers, but the property that matters is checkable without it:
`_zrush_worker_flush` must never let `syswrite` inspect the buffer's bytes as options, whatever they are.

`tests/zsh/transport.zsh` (new) calls the function directly, so it needs no binary, pty, zle or worker process:
it sources `zsh/zrush.zsh` through the `ZRUSH_NO_INIT=1` seam and flushes into an fd on a temp file.
It is the home for non-pty unit tests of the zsh-side worker transport, alongside `vectors.zsh` for the capture encoder and plan decoder.
Two buffers stand in for a short-write remainder that opens mid candidate value:
one beginning `-f` (unknown option) and one beginning `-cvar` (an option letter that takes an argument, so it swallows the data word instead).
Both must be written verbatim and leave the buffer empty.

Mutation-checked in both directions on zsh 5.9 (arm64-apple-darwin26.0):
removing the `--` fails both cases (`bad option: -f` / `not enough arguments`),
and keeping the `--` while corrupting one byte of the written data also fails both cases (status stays 0, the byte comparison catches it).

Full local run, all green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, `cargo test` (192+18+3),
`tests/zsh/transport.zsh` (2), `tests/zsh/vectors.zsh` (73), `tests/zsh/driver.zsh` (140), `tests/zsh/driver-coexist.zsh` (37, 0 skipped).

## Notes for the reviewer

`docs/` is unchanged on purpose: `docs/internal/specs/behavior.md` already specifies the partial-write and backpressure behavior, so this is code disagreeing with a correct spec, not a spec change.

`AGENTS.md`'s "Build and test" paragraph now lists what CI actually runs.
It previously said CI runs only `driver.zsh`, which had already stopped being true when `vectors.zsh` was added to the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
