### PR TITLE
fix(worker): take the setup subshell pid from sysparams, not $!

### DIFF
--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -924,7 +924,7 @@ _zrush_worker_start() {
     fi
   )
   _zrush_worker_setup_fd=$fd
-  _zrush_worker_setup_pid=$!
+  _zrush_worker_setup_pid=${sysparams[procsubstpid]:--1}
   _zrush_worker_ready=0
   _zrush_worker_rx= _zrush_worker_tx=
   _zrush_encode_message hello "$_ZRUSH_EXPECTED_PROTO"


### PR DESCRIPTION
Closes #39.

`_zrush_worker_start` recorded the pid of its asynchronous setup process substitution with `$!`, but zsh does not update `$!` for a process substitution — only `$sysparams[procsubstpid]` is set. The variable therefore captured whatever job the user last started with `&`, and the setup teardown (`_zrush_worker_consume_setup` / `_zrush_worker_transport_teardown` → `_zrush_worker_terminate`) sent SIGTERM/SIGKILL to that job. The first worker start in a shell where the user had ever backgrounded a job killed that job.

The fix takes the pid from `${sysparams[procsubstpid]:--1}`, the same form `_zrush_worker_finish_start` already uses for the worker process itself 28 lines later. One line changed; `zsh/system` (which provides `sysparams`) was already loaded.

Verification (macOS, Apple M3, zsh 5.9, on top of 7673dde):

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, `cargo test` — all pass
- `tests/zsh/driver.zsh` — PASS=140 FAIL=0
- `tests/zsh/driver-coexist.zsh` — PASS=37 FAIL=0 SKIP=0
- The reproduction from #39, run in an isolated `zsh -f`: with a `sleep 30 &` user job present, the pid recorded by the fixed line differs from the user job's pid, and the job survives a SIGTERM sent to the recorded pid during setup teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)