### PR TITLE
fix(worker): hand each outbound frame to a forked writer child

### DIFF
--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -41,26 +41,49 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   `../contracts/cli-protocol.md` が定める。
 - worker は対話シェルの job table に登録せず、動作中でもシェルの `exit` を妨げない。
 - 通常の補完経路では、worker の cold start と握手を待たない。起動処理は ZLE へ直ちに制御を返し、
-  `hello` も outbound queue から nonblocking に送り、残りの送信と `ready` の受信を fd callback / 非同期 retry で進める。
+  `hello` も outbound queue の先頭フレームとして、他の plan 要求と同じく後述の writer child 経由で送る。
+  `ready` の受信は worker stdout の既存の `zle -F` callback で進める。
   握手中に生じた plan 要求は `hello` より後ろの outbound queue に置く。
   同期的に worker を待ってよいのは履歴メニューだけであり、その待機も後述の 1 本の絶対 100ms deadline 内に限る。
-- worker stdin は nonblocking とし、通常の補完経路は要求全体を書けるまで ZLE callback 内で待たない。
-  nested-netstring 化した message を outbound queue に保持し、partial write では書けた接頭辞だけを取り除き、
-  `EAGAIN` / `EWOULDBLOCK` では残りを次の fd-ready callback または非同期 retry へ回して直ちに戻る。
-  busy loop と blocking write は行わない。worker は受信した plan を直列に処理するため、queue も request_id 順を保つ。
+- worker stdin への送信はフレーム単位で行う。
+  フレームは不可分な送信単位であり、outbound queue は完成済みフレームのリストを持つだけで、
+  対話シェル側に送信オフセットは存在しない。
+  対話シェルは worker stdin(request FIFO)への blocking な write fd を worker 起動時に確保し、
+  FIFO パスの unlink 前に開いた上で cloexec を付けて worker には継承させない
+  (fork した子は cloexec の性質上、exec するまで fd を引き継ぐ)。
+  1 フレームの送信は、この blocking fd を渡して fork した短命な writer child に委譲する。
+  writer child は 1 回の `syswrite` でフレーム全体を書き切り、書き終えたら通知用パイプへ
+  ack バイトを 1 個書く。
+  writer child は worker と同じく対話シェルの job table に登録しない。
+  対話シェルは通知 fd を `zle -F` で監視するだけで、blocking write を一切行わず
+  ZLE callback 内で書き込み完了を待たない。
+  in-flight の writer child は常に高々 1 個であり、次のフレームは直前の child が
+  ack バイトを書いた時点で送る。
+  worker は受信した plan を直列に処理するため、この直列送信によって queue も request_id 順を保つ。
+  busy loop は行わない。
 - queue に入った通常の補完要求は、新しい要求で coalesce・置換・除去しない。
   送信時点ですでに stale でも同じ session 上で順に送り、worker の終端応答まで読み取って UI への適用だけを捨てる。
-  backpressure は ZLE を止める理由にならず、queue の残りを後続 callback で送る。
+  request FIFO の backpressure が及ぶのは writer child の `syswrite` だけであり、ZLE を止める理由にはならない。
+  queue の残りは、writer child からの ack を受けてから次のフレームとして送る。
 - `request_id` は zsh が所有し、実 plan 要求ごとに増やす。同じシェルセッションでは worker の再起動後も
   リセット・再利用しない。新しい実要求を開始した後に古い request_id の正常応答が届いても stale として捨て、
   表示には適用しない。worker は受け取った各要求へ `ok` / `error` を 1 個返し、zsh 側の stale 判定を理由に
   応答を省略させない。
-- 外側/nested framing の破損、stdout の EOF/read error、stdin の write error、予期しない終了、
-  要求と対応しない応答、仕様を満たさない `ok` の描画プラン、履歴交換の deadline 超過は
-  **worker セッション失敗**である。その session に割り当て済みで終端応答のない要求を、partial write 中・
-  outbound queue 内・送信済みの区別なくすべて破棄し、既存一覧も消す。いずれも自動 replay しない。
-  worker プロセスが残っていれば終了させて消滅を確認し、`zle -F` watcher を解除して stdin/stdout pipe fd を閉じ、
-  head-of-line blocking を残さない。この cleanup が完了するまで代替 worker を起動せず、worker を重複させない。
+- 外側/nested framing の破損、stdout の EOF/read error、writer child の通知 fd が ack バイトなしで
+  EOF に達すること(stdin の write 失敗)、予期しない終了、要求と対応しない応答、
+  仕様を満たさない `ok` の描画プラン、履歴交換の deadline 超過は **worker セッション失敗**である。
+  stdin の write 失敗は通知 fd の EOF/ack のみで判定し、writer child の終了ステータスからは
+  一切推測しない。
+  その session に割り当て済みで終端応答のない要求を、writer child に渡して送信中のフレーム・
+  outbound queue 内のフレーム・送信済みの要求の区別なくすべて破棄し、既存一覧も消す。
+  いずれも自動 replay しない。
+  in-flight の writer child がいれば、未送信のフレームを queue から破棄したうえで
+  その child の終了を有界時間だけ待ち、なお終了しなければ TERM してから KILL する。
+  フレーム送信の途中で kill された child は request FIFO に不完全なフレームを残すが、
+  これは worker がフレーミングエラーとして検出する想定内の abort 挙動であり、正常な EOF とは区別できる。
+  worker プロセスが残っていれば終了させて消滅を確認し、`zle -F` watcher を解除して
+  stdin/stdout pipe fd と通知 fd を閉じ、head-of-line blocking を残さない。
+  この cleanup が完了するまで代替 worker を起動せず、worker を重複させない。
 - 連続 worker セッション失敗回数は、正常に形成された終端 `ok` / `error` を受けたときだけ 0 に戻す。
   握手成功だけでは戻さない。1 回目の失敗後は worker 不在のままにし、**次の実要求**で 1 個だけ代替 worker を
   遅延起動する。終端応答を 1 個も受けないまま 2 回目のセッション失敗が起きたら、そのシェルでは zrush を無効化する。

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -55,8 +55,10 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   writer child は 1 回の `syswrite` でフレーム全体を書き切り、書き終えたら通知用パイプへ
   ack バイトを 1 個書く。
   writer child は worker と同じく対話シェルの job table に登録しない。
-  対話シェルは通知 fd を `zle -F` で監視するだけで、blocking write を一切行わず
+  対話シェルは通知 fd を `zle -F` で監視し、blocking write を一切行わず
   ZLE callback 内で書き込み完了を待たない。
+  ack の消費は通知 fd の readiness を確認したうえで行い、通知 fd の `zle -F` callback・
+  worker 応答の受信時・同期履歴ループのいずれから行ってもよい。
   in-flight の writer child は常に高々 1 個であり、次のフレームは直前の child が
   ack バイトを書いた時点で送る。
   worker は受信した plan を直列に処理するため、この直列送信によって queue も request_id 順を保つ。

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -45,6 +45,10 @@ ng()  { out "FAIL: $1"; (( ++FAIL )) }
 
 typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-test.XXXXXX)
 export TERM=vt100
+# zsh links the vi keymap to main when $VISUAL/$EDITOR contains "vi"; the host
+# keys this driver sends (^U, ^P, ^V, ...) are emacs-keymap bindings, so the
+# invoking environment must not decide which keymap the host gets.
+unset EDITOR VISUAL
 export LC_ALL=en_US.UTF-8   # match POSTDISPLAY printability checks to real UTF-8 use
 export HOME=$PLAYGROUND     # isolated; never the real home
 export ZRUSH_REPO=$REPO
@@ -98,14 +102,19 @@ mkdir -p $PLAYGROUND/fx/longcol
 : >| $PLAYGROUND/fx/longcol/"item-${(l:90::x:)}-3.txt"
 
 # fx/overflow: enough entries that a single compsys capture's candidate_payload
-# comfortably exceeds the 8192-byte macOS request-FIFO buffer (behavior.md
-# worker-lifecycle "フレームは不可分な送信単位"), regardless of what this
-# playground happens to already contain. 0000-marker.txt sorts before every
-# item-*.txt entry (macOS default glob order), so it is always the first
-# candidate and lands in the rendered listing no matter how the grid clips.
+# comfortably exceeds the request-FIFO buffer on either platform this driver
+# runs on -- 8192 bytes on macOS, 65536 on Linux (behavior.md worker-lifecycle
+# "フレームは不可分な送信単位") -- regardless of what this playground happens to
+# already contain. 0000-marker.txt sorts before every item-*.txt entry (macOS
+# default glob order), so it is always the first candidate and lands in the
+# rendered listing no matter how the grid clips. This many entries put the
+# frame around 112 KB, i.e. ~1.7x the larger of the two capacities. The entries
+# are created in a loop rather than one touch(1) call: that many absolute paths
+# can outgrow ARG_MAX for a deeply nested playground.
 mkdir -p $PLAYGROUND/fx/overflow
 : >| $PLAYGROUND/fx/overflow/0000-marker.txt
-touch $PLAYGROUND/fx/overflow/item-{0001..2000}.txt
+for OVERFLOW_ITEM in $PLAYGROUND/fx/overflow/item-{0001..7000}.txt; do : >| $OVERFLOW_ITEM; done
+unset OVERFLOW_ITEM
 
 typeset -gi HOSTFD=-1
 typeset -g TRANSCRIPT= EXPECT_BUF= STDIO_BASELINE=
@@ -407,11 +416,12 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   drain 0.3
 
   # ================================================================ FIFO-capacity frame delegation
-  # (fifo-1a/b) fx/overflow's candidate_payload is well over the 8192-byte
-  # macOS request-FIFO buffer, so it can only reach the worker if the writer
-  # child actually delegates the whole frame in one syswrite (behavior.md
-  # worker-lifecycle "1 フレームの送信は... 委譲する"); a naive blocking write
-  # from the parent would deadlock instead of rendering.
+  # (fifo-1a/b) fx/overflow's candidate_payload is well over the request-FIFO
+  # buffer on either platform (8192 bytes on macOS, 65536 on Linux), so it can
+  # only reach the worker if the writer child actually delegates the whole
+  # frame in one syswrite (behavior.md worker-lifecycle "1 フレームの送信は...
+  # 委譲する"); a naive blocking write from the parent would deadlock instead
+  # of rendering.
   log_count 'worker: queued request_id='; local -i overflow_queued_before=$REPLY
   send_keys 'ls fx/overflow/'
   if expect '*0000-marker.txt*' 15; then
@@ -422,10 +432,10 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   if wait_log 'worker: queued request_id=' $overflow_queued_before 5; then
     local overflow_queued_line=$(grep -F 'worker: queued request_id=' $ZRUSH_LOG 2>/dev/null | tail -1)
     local -i overflow_frame_bytes=${${overflow_queued_line##*bytes=}%% *}
-    if (( overflow_frame_bytes > 8192 )); then
-      ok "(fifo-1b) the queued frame's byte count ($overflow_frame_bytes) actually exceeded the FIFO buffer"
+    if (( overflow_frame_bytes > 65536 )); then
+      ok "(fifo-1b) the queued frame's byte count ($overflow_frame_bytes) actually exceeded the FIFO buffer on both platforms (8192 macOS / 65536 Linux)"
     else
-      ng "(fifo-1b) queued frame was not actually over-capacity: bytes=$overflow_frame_bytes line=${overflow_queued_line:-<none>}"
+      ng "(fifo-1b) queued frame was not actually over-capacity (need > 65536): bytes=$overflow_frame_bytes line=${overflow_queued_line:-<none>}"
     fi
   else
     ng "(fifo-1b) no 'worker: queued request_id=' log line for the overflow request"
@@ -1616,12 +1626,21 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
         local -i inflight_writer_pid=${${inflight_sending_line##*writer_pid=}%% *}
         log_count 'worker: frame sent'; local -i inflight_sent_at_dispatch=$REPLY
         # No drain here: the whole point is to tear down as close as possible
-        # to the writer-child spawn, before its ack can land. ^C only
-        # abandons the still-uncommitted 'ls fx/overflow/' buffer text (the
-        # capture already finished -- that's how the frame got queued -- so
-        # there is nothing left for it to cancel); it does not touch the
-        # transport itself (only _zrush_worker_transport_teardown does).
-        send_keys $'\C-c'
+        # to the writer-child spawn, before its ack can land. ^U
+        # (kill-whole-line) only discards the still-uncommitted
+        # 'ls fx/overflow/' buffer text so that `exit` runs on an empty line;
+        # the capture already finished -- that's how the frame got queued --
+        # and an empty buffer collects nothing (behavior.md 候補収集), so no
+        # new request races the exit. The transport is untouched (only
+        # _zrush_worker_transport_teardown touches it).
+        #
+        # ^C would clear the buffer just as well but must not be used here:
+        # zsh 5.9 defers a SIGINT that arrives while a `zle -F` watcher
+        # callback is running -- precisely the window this case aims at --
+        # until the next input byte, and the deferred send-break then swallows
+        # that byte, eating the 'e' of the following `exit`. kill-whole-line
+        # is a plain widget keystroke with no such hazard.
+        send_keys $'\C-u'
         send_line exit
         local -F inflight_exit_deadline=$(( SECONDS + 5 ))
         local -i inflight_exit_eof=0 inflight_exit_status=0

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -272,12 +272,12 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   assert_host_stdio "(fd-1a) source leaves host fd 0/1/2 attached and writable"
 
   if dump_get $'\C-xj' TESTAUX \
-     && [[ $REPLY == 'closed=1 retry=-1 drain=-1 timer=-1' ]]; then
-    ok "(fd-1b) timer/retry/drain descriptors close through shared teardown"
+     && [[ $REPLY == 'closed=1 ack=-1 drain=-1 timer=-1' ]]; then
+    ok "(fd-1b) timer/ack/drain descriptors close through shared teardown"
   else
     ng "(fd-1b) auxiliary fd teardown mismatch: ${REPLY:-<none>}"
   fi
-  assert_host_stdio "(fd-1c) timer/retry/drain teardown preserves host fd 0/1/2"
+  assert_host_stdio "(fd-1c) timer/ack/drain teardown preserves host fd 0/1/2"
 
   # ================================================================ (1) Capture fork -> candidate records
   # (cap-1a) A real compsys fork collects candidates, ships candidate records
@@ -336,7 +336,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   local -i seq_before_resource=${${worker_after_successive#*seq=}%% *}
   send_line "source $REPO/zsh/zrush.zsh"
   sync_prompt
-  if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == "pid=-1 ready=0 seq=$seq_before_resource "* && $REPLY == *'rfd=-1 wfd=-1 retry=-1 pending=0' ]]; then
+  if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == "pid=-1 ready=0 seq=$seq_before_resource "* && $REPLY == *'rfd=-1 wfd=-1 ack=-1 pending=0' ]]; then
     ok "(worker-1d) re-source tears down transport while preserving the request counter"
   else
     ng "(worker-1d) bad post-resource state: ${REPLY:-<none>}"

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -97,6 +97,16 @@ mkdir -p $PLAYGROUND/fx/longcol
 : >| $PLAYGROUND/fx/longcol/"item-${(l:90::x:)}-2.txt"
 : >| $PLAYGROUND/fx/longcol/"item-${(l:90::x:)}-3.txt"
 
+# fx/overflow: enough entries that a single compsys capture's candidate_payload
+# comfortably exceeds the 8192-byte macOS request-FIFO buffer (behavior.md
+# worker-lifecycle "フレームは不可分な送信単位"), regardless of what this
+# playground happens to already contain. 0000-marker.txt sorts before every
+# item-*.txt entry (macOS default glob order), so it is always the first
+# candidate and lands in the rendered listing no matter how the grid clips.
+mkdir -p $PLAYGROUND/fx/overflow
+: >| $PLAYGROUND/fx/overflow/0000-marker.txt
+touch $PLAYGROUND/fx/overflow/item-{0001..2000}.txt
+
 typeset -gi HOSTFD=-1
 typeset -g TRANSCRIPT= EXPECT_BUF= STDIO_BASELINE=
 
@@ -132,7 +142,12 @@ drain() {  # $1=seconds to wait while reading the pty
 }
 
 clear_line() { send_keys $'\C-u'; drain 0.2 }
-sync_prompt() { expect '*HP>*' ${1:-5} >/dev/null; drain 0.1 }
+sync_prompt() {  # $1=timeout(s); returns expect's status (drain still always runs)
+  expect '*HP>*' ${1:-5} >/dev/null
+  local -i st=$?
+  drain 0.1
+  return st
+}
 press() { send_keys $1; drain 0.3 }
 
 log_count() {  # $1=fixed string -> REPLY: occurrence count in ZRUSH_LOG
@@ -387,6 +402,33 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
     ok "(cap-2b) a normal completion right after a zero-candidate one still works (compsys/tail-call state intact)"
   else
     ng "(cap-2b) completion broke after a zero-candidate collection"
+  fi
+  clear_line
+  drain 0.3
+
+  # ================================================================ FIFO-capacity frame delegation
+  # (fifo-1a/b) fx/overflow's candidate_payload is well over the 8192-byte
+  # macOS request-FIFO buffer, so it can only reach the worker if the writer
+  # child actually delegates the whole frame in one syswrite (behavior.md
+  # worker-lifecycle "1 フレームの送信は... 委譲する"); a naive blocking write
+  # from the parent would deadlock instead of rendering.
+  log_count 'worker: queued request_id='; local -i overflow_queued_before=$REPLY
+  send_keys 'ls fx/overflow/'
+  if expect '*0000-marker.txt*' 15; then
+    ok "(fifo-1a) a candidate_payload larger than the FIFO buffer still crosses in one delegated write and renders"
+  else
+    ng "(fifo-1a) list not displayed for an over-capacity payload"
+  fi
+  if wait_log 'worker: queued request_id=' $overflow_queued_before 5; then
+    local overflow_queued_line=$(grep -F 'worker: queued request_id=' $ZRUSH_LOG 2>/dev/null | tail -1)
+    local -i overflow_frame_bytes=${${overflow_queued_line##*bytes=}%% *}
+    if (( overflow_frame_bytes > 8192 )); then
+      ok "(fifo-1b) the queued frame's byte count ($overflow_frame_bytes) actually exceeded the FIFO buffer"
+    else
+      ng "(fifo-1b) queued frame was not actually over-capacity: bytes=$overflow_frame_bytes line=${overflow_queued_line:-<none>}"
+    fi
+  else
+    ng "(fifo-1b) no 'worker: queued request_id=' log line for the overflow request"
   fi
   clear_line
   drain 0.3
@@ -1534,6 +1576,106 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
     fi
   else
     ng "(worker-job-table) dedicated exit host failed to start"
+  fi
+
+  # ================================================================ Teardown while a frame is in flight
+  # Dedicated host (same exit pattern as "Worker job-table isolation" above)
+  # so exiting mid-request doesn't disturb any other case. fx/overflow (added
+  # above for (fifo-1a/b)) makes the writer child's single syswrite take long
+  # enough to plausibly still be delegated -- unacked, possibly still writing
+  # -- when we tear down; (inflight-1c) reports (OBSV, non-failing) whether
+  # this run actually won that race, since the exact window isn't guaranteed.
+  #
+  # The previous case just let its own dedicated "host" pty session exit for
+  # real (as opposed to every other transition in this driver, which deletes
+  # a still-live session via `zpty -d host`). start_hist_host always issues
+  # its own `zpty -d host 2>/dev/null` before spawning anew; issuing that
+  # exact call -- with stderr redirected -- as the *first* deletion of an
+  # already-dead real-worker session reproducibly kills this outer zsh
+  # process outright (a zpty/job-control interaction, not a zrush bug).
+  # Reaping it here first, without redirecting stderr, avoids the crash;
+  # start_hist_host's own redundant delete of the now-already-gone session
+  # is then a harmless no-op.
+  zpty -d host
+  mkdir -p $WORK/zdot-inflight $WORK/xdg-inflight/zrush
+  print "source $REPO/tests/zsh/rc/minimal.zshrc" > $WORK/zdot-inflight/.zshrc
+  if start_hist_host $WORK/zdot-inflight $WORK/xdg-inflight $WORK/host-inflight.log; then
+    send_line '[[ -o checkjobs && -o checkrunningjobs ]] && print CHECK-JOBS-ENABLED'
+    if expect '*CHECK-JOBS-ENABLED*HP>*' 5; then
+      # Warm the persistent worker up on a small request first so handshake/
+      # startup latency cannot masquerade as "frame in flight" below.
+      send_keys 'ls fx/basic/al'
+      expect '*alpha.txt*' 10 >/dev/null
+      clear_line
+      drain 0.3
+      log_count 'worker: sending frame'; local -i inflight_sending_before=$REPLY
+      log_count 'worker: frame sent'; local -i inflight_sent_before=$REPLY
+      send_keys 'ls fx/overflow/'
+      if wait_log 'worker: sending frame' $inflight_sending_before 15; then
+        local inflight_sending_line=$(grep -F 'worker: sending frame' $ZRUSH_LOG 2>/dev/null | tail -1)
+        local -i inflight_writer_pid=${${inflight_sending_line##*writer_pid=}%% *}
+        log_count 'worker: frame sent'; local -i inflight_sent_at_dispatch=$REPLY
+        # No drain here: the whole point is to tear down as close as possible
+        # to the writer-child spawn, before its ack can land. ^C only
+        # abandons the still-uncommitted 'ls fx/overflow/' buffer text (the
+        # capture already finished -- that's how the frame got queued -- so
+        # there is nothing left for it to cancel); it does not touch the
+        # transport itself (only _zrush_worker_transport_teardown does).
+        send_keys $'\C-c'
+        send_line exit
+        local -F inflight_exit_deadline=$(( SECONDS + 5 ))
+        local -i inflight_exit_eof=0 inflight_exit_status=0
+        local inflight_exit_output= inflight_exit_chunk=
+        while (( SECONDS < inflight_exit_deadline )); do
+          if zselect -t 20 -r $HOSTFD 2>/dev/null; then
+            inflight_exit_chunk=
+            zpty -r host inflight_exit_chunk 2>/dev/null; inflight_exit_status=$?
+            (( inflight_exit_status == 0 )) && inflight_exit_output+=$inflight_exit_chunk
+            if (( inflight_exit_status == 2 )); then
+              inflight_exit_eof=1
+              break
+            fi
+          fi
+        done
+        local inflight_visible_output=${inflight_exit_output//$'\e['[0-9;]#m/}
+        if (( inflight_exit_eof )) \
+           && [[ $inflight_visible_output != *'zsh: you have running jobs.'* ]] \
+           && [[ $inflight_visible_output != *'Terminated'* && $inflight_visible_output != *'Done'* ]]; then
+          ok "(inflight-1a) exit while the writer child is still delegated produces no job-control output"
+        else
+          ng "(inflight-1a) job-control output leaked during in-flight teardown: eof=$inflight_exit_eof output=${(qqqq)inflight_visible_output}"
+        fi
+        if (( inflight_writer_pid > 1 )); then
+          local -F inflight_gone_deadline=$(( SECONDS + 2 ))
+          local -i inflight_writer_gone=0
+          while (( SECONDS < inflight_gone_deadline )); do
+            if ! kill -0 $inflight_writer_pid 2>/dev/null; then
+              inflight_writer_gone=1
+              break
+            fi
+            zselect -t 5 2>/dev/null
+          done
+          if (( inflight_writer_gone )); then
+            ok "(inflight-1b) the delegated writer child (pid=$inflight_writer_pid) is gone after teardown"
+          else
+            ng "(inflight-1b) writer child pid=$inflight_writer_pid still alive after teardown"
+          fi
+        else
+          ng "(inflight-1b) could not parse a writer_pid from: ${inflight_sending_line:-<none>}"
+        fi
+        if (( inflight_sent_at_dispatch == inflight_sent_before )); then
+          out "OBSV: (inflight-1c) teardown was dispatched before this frame's ack was consumed (writer child genuinely still delegated)"
+        else
+          out "OBSV: (inflight-1c) this frame's ack had already landed before teardown; (inflight-1a/b) still ran but not against a strictly unacked frame"
+        fi
+      else
+        ng "(inflight-1) dedicated host never delegated a writer child for the overflow request"
+      fi
+    else
+      ng "(inflight-1) dedicated host did not enable CHECK_JOBS and CHECK_RUNNING_JOBS"
+    fi
+  else
+    ng "(inflight-1) dedicated in-flight-teardown host failed to start"
   fi
 
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"

--- a/tests/zsh/rc/minimal.zshrc
+++ b/tests/zsh/rc/minimal.zshrc
@@ -25,7 +25,7 @@ bindkey '^Xh' _zrt-dump-rh
 # ^Xw: persistent-worker lifecycle state. This exposes only stable invariants
 # needed by driver.zsh (lazy start, reuse, monotonic ids, and clean teardown).
 _zrt_dump_worker() {
-  _zlog "TESTWORKER=pid=$_zrush_worker_pid ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled warned=$_zrush_worker_warned rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd retry=$_zrush_worker_retry_fd pending=$#_zrush_worker_pending"
+  _zlog "TESTWORKER=pid=$_zrush_worker_pid ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled warned=$_zrush_worker_warned rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending"
 }
 zle -N _zrt-dump-worker _zrt_dump_worker
 bindkey '^Xw' _zrt-dump-worker
@@ -63,21 +63,22 @@ _zrt_probe_stdio() {
 zle -N _zrt-probe-stdio _zrt_probe_stdio
 bindkey '^Xf' _zrt-probe-stdio
 
-# ^Xj: synthesize the timer/retry/drain descriptors and exercise their shared
+# ^Xj: synthesize the timer/ack/drain descriptors and exercise their shared
 # teardown paths without depending on timing or kernel backpressure.
 _zrt_close_aux_fds() {
   emulate -L zsh
-  local -i retry_fd drain_fd timer_fd closed=1
-  exec {retry_fd}< <( print )
+  local -i ack_fd drain_fd timer_fd closed=1
+  exec {ack_fd}< <( print )
   exec {drain_fd}< <( print )
   exec {timer_fd}< <( print )
-  _zrush_worker_retry_fd=$retry_fd
+  _zrush_worker_ack_fd=$ack_fd
   _zrush_worker_drain_fd=$drain_fd
   _zrush_timer_fd=$timer_fd
-  _zrush_worker_disarm_retry
+  _zrush_worker_release_writer
+  _zrush_worker_disarm_drain
   _zrush_disarm_timer
-  [[ -e /dev/fd/$retry_fd || -e /dev/fd/$drain_fd || -e /dev/fd/$timer_fd ]] && closed=0
-  _zlog "TESTAUX=closed=$closed retry=$_zrush_worker_retry_fd drain=$_zrush_worker_drain_fd timer=$_zrush_timer_fd"
+  [[ -e /dev/fd/$ack_fd || -e /dev/fd/$drain_fd || -e /dev/fd/$timer_fd ]] && closed=0
+  _zlog "TESTAUX=closed=$closed ack=$_zrush_worker_ack_fd drain=$_zrush_worker_drain_fd timer=$_zrush_timer_fd"
 }
 zle -N _zrt-close-aux-fds _zrt_close_aux_fds
 bindkey '^Xj' _zrt-close-aux-fds

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -24,6 +24,9 @@
 #   - The ZLE callback never runs headless, so the shared consume path
 #     (_zrush_worker_consume_ack) is called directly, exactly as the synchronous
 #     history loop calls it.
+#   - ZRUSH_LOG points at a file under the temp directory, so that teardown's
+#     classification of the writer child (signal it, or leave its pid alone)
+#     can be read back.
 #   - The notification fd is duplicated before consuming, so that "exactly one
 #     ack byte" and "EOF without an ack byte" can be observed independently of
 #     the code under test. The writer child is never `wait`ed on and its exit
@@ -67,6 +70,18 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   typeset -ga WARNINGS=()
   _zrush_warn() { WARNINGS+=( "$1" ) }   # test seam: record instead of printing
 
+  # _zlog appends only when ZRUSH_LOG is set (zsh/zrush.zsh); point it at the
+  # temp directory so teardown's writer classification is observable.
+  typeset -g LOGFILE=$WORK/zrush.log
+  typeset -g ZRUSH_LOG=$LOGFILE
+  : >| $LOGFILE
+  log_reset() { : >| $LOGFILE }
+  log_has() { command grep -qF -- "$1" $LOGFILE }
+  log_lines() {  # append the whole log to the failure reasons, for diagnosis
+    local l
+    for l in ${(f)"$(command cat $LOGFILE 2>/dev/null)"}; do WHY+=( "log| $l" ); done
+  }
+
   # ------------------------------------------------------------- assertions
   typeset -ga WHY=()
   eq() {  # $1=what $2=actual $3=expected
@@ -87,6 +102,32 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   # ------------------------------------------------------------- fixtures
   typeset -gi RFD=-1 ANCHOR=-1
   typeset -g FIFO=
+
+  # A writer child forked by _zrush_worker_flush inherits this runner's reader
+  # fds on the FIFO, so a child left blocked inside syswrite by a failing
+  # implementation would never see EPIPE and would outlive the run holding the
+  # runner's stdout. Remember the pids and reap the survivors at exit; never an
+  # oracle, only a safety net for failing runs.
+  typeset -ga SPAWNED=()
+  remember_writer() { (( _zrush_worker_writer_pid > 1 )) && SPAWNED+=( $_zrush_worker_writer_pid ); return 0 }
+  flush_now() {
+    _zrush_worker_flush
+    local -i s=$?
+    remember_writer
+    return $s
+  }
+  reap_spawned() {
+    local -i p
+    local pp
+    for p in ${(@)SPAWNED}; do
+      kill -0 $p 2>/dev/null || continue
+      # Only ever signal a pid that is still one of this runner's own children,
+      # so a recycled pid cannot be hit.
+      pp=${${(f)"$(command ps -o ppid= -p $p 2>/dev/null)"}//[[:space:]]/}
+      [[ $pp == $$ ]] && kill -KILL $p 2>/dev/null
+    done
+    SPAWNED=()
+  }
 
   # Reset every transport global the write path reads, so each case starts from
   # a clean session with no worker process behind it.
@@ -197,7 +238,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   build_frame; typeset -g FRAME=$REPLY
   print -rn -- "$FRAME" >| $WORK/one.expected
   _zrush_worker_txq=( "$FRAME" )
-  _zrush_worker_flush; typeset -gi st=$?
+  flush_now; typeset -gi st=$?
   eq "flush status" $st 0
   eq "queue drained into the child" $#_zrush_worker_txq 0
   (( _zrush_worker_ack_fd >= 0 )) || note "no notification fd after flush"
@@ -241,7 +282,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   print -rn -- "$FRAME_A" >| $WORK/order.a.expected
   print -rn -- "$FRAME_B" >| $WORK/order.b.expected
   _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
-  _zrush_worker_flush; st=$?
+  flush_now; st=$?
   typeset -gi ACK_A=$_zrush_worker_ack_fd PID_A=$_zrush_worker_writer_pid
   eq "flush status" $st 0
   eq "second frame still queued" $#_zrush_worker_txq 1
@@ -249,7 +290,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   (( PID_A > 1 )) || note "no writer child for frame A"
   # A is larger than the FIFO's 8192-byte capacity and nothing drains yet, so A
   # is still in flight here. A second flush must not hand B to another child.
-  _zrush_worker_flush; st=$?
+  flush_now; st=$?
   eq "flush while a child is in flight" $st 0
   eq "notification fd unchanged" $_zrush_worker_ack_fd $ACK_A
   eq "writer pid unchanged" $_zrush_worker_writer_pid $PID_A
@@ -264,6 +305,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   eq "B still queued before A's ack" $#_zrush_worker_txq 1
   if readable $_zrush_worker_ack_fd $WAIT_CS; then
     _zrush_worker_consume_ack; cst=$?
+    remember_writer   # consume_ack flushed B itself
     eq "consume_ack status for A" $cst 0
     eq "B handed to a child on A's ack" $#_zrush_worker_txq 0
     (( _zrush_worker_ack_fd >= 0 )) || note "no notification fd for frame B"
@@ -296,7 +338,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   fifo_setup killed
   build_frame 40000; typeset -g FRAME_BIG=$REPLY
   _zrush_worker_txq=( "$FRAME_BIG" )
-  _zrush_worker_flush; st=$?
+  flush_now; st=$?
   eq "flush status" $st 0
   typeset -gi VICTIM=$_zrush_worker_writer_pid
   if (( VICTIM > 1 )) && kill -0 $VICTIM 2>/dev/null && peek_open; then
@@ -334,7 +376,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   typeset -g ODD=$'-cvar\1-f\0--\2 -s 1'
   print -rn -- "$ODD" >| $WORK/opaque.expected
   _zrush_worker_txq=( "$ODD" )
-  _zrush_worker_flush; st=$?
+  flush_now; st=$?
   eq "flush status" $st 0
   if drain_bytes $RFD $WORK/opaque.actual ${#ODD}; then
     cmp -s $WORK/opaque.expected $WORK/opaque.actual || note "option-like frame bytes differ"
@@ -352,19 +394,28 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   verdict "frame: option-like leading bytes are written verbatim, not parsed by syswrite"
 
   # ============================================================ case 5
-  # Teardown drops the unsent queue and lets go of the in-flight child.
+  # Teardown drops the unsent queue and signals the child that is still inside
+  # its blocking syswrite: nothing readable on the notification fd is the only
+  # state in which the recorded pid is still the writer child's.
   fifo_setup drop
   build_frame 40000; FRAME_A=$REPLY
   build_frame;       FRAME_B=$REPLY
   _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
-  _zrush_worker_flush; st=$?
+  flush_now; st=$?
   eq "flush status" $st 0
+  typeset -gi PID_BLOCKED=$_zrush_worker_writer_pid
   if peek_open; then
+    log_reset
     _zrush_worker_transport_teardown failure
     eq "queued frames dropped" $#_zrush_worker_txq 0
     eq "notification fd released" $_zrush_worker_ack_fd -1
     eq "writer pid released" $_zrush_worker_writer_pid -1
     eq "request fd closed" $_zrush_worker_wfd -1
+    if ! log_has "worker: teardown terminating writer pid=$PID_BLOCKED"; then
+      note "teardown did not signal the child blocked in syswrite"
+      log_lines
+    fi
+    log_has "teardown writer done" && note "teardown classified a blocked child as done"
     if readable $PEEK $WAIT_CS; then
       peek_read
       eq "in-flight child gone without an ack" $PEEK_ST 5
@@ -377,10 +428,75 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   fi
   peek_close
   fifo_teardown
-  verdict "teardown: unsent frames are dropped and the in-flight child is released"
+  verdict "teardown: unsent frames are dropped and the blocked child is signalled"
+
+  # ============================================================ case 6
+  # A child that already acked owns nothing any more, even when the ack byte has
+  # not been consumed yet: teardown must not signal that pid, which by then may
+  # belong to an unrelated process.
+  fifo_setup acked
+  build_frame; FRAME=$REPLY
+  _zrush_worker_txq=( "$FRAME" )
+  flush_now; st=$?
+  eq "flush status" $st 0
+  typeset -gi PID_DONE=$_zrush_worker_writer_pid
+  if drain_bytes $RFD $WORK/acked.actual ${#FRAME}; then
+    if readable $_zrush_worker_ack_fd $WAIT_CS; then
+      # The ack byte is deliberately left unconsumed: teardown, not
+      # _zrush_worker_consume_ack, has to classify it.
+      log_reset
+      _zrush_worker_transport_teardown failure
+      if ! log_has "worker: teardown writer done pid=$PID_DONE status=0"; then
+        note "teardown did not classify the acked child as done"
+        log_lines
+      fi
+      log_has "teardown terminating writer" && note "teardown signalled a child that had already acked"
+      eq "notification fd released" $_zrush_worker_ack_fd -1
+      eq "writer pid released" $_zrush_worker_writer_pid -1
+      eq "queue emptied" $#_zrush_worker_txq 0
+    else
+      note "no ack within ${WAIT_CS}cs"
+    fi
+  else
+    note "reader did not observe the frame within ${WAIT_CS}cs"
+  fi
+  fifo_teardown
+  verdict "teardown: a child that already acked is never signalled"
+
+  # ============================================================ case 7
+  # Same classification at the other end: a child that died mid-frame leaves the
+  # notification fd at EOF, and a dead pid must not be signalled either.
+  fifo_setup gone
+  build_frame 40000; FRAME_BIG=$REPLY
+  _zrush_worker_txq=( "$FRAME_BIG" )
+  flush_now; st=$?
+  eq "flush status" $st 0
+  VICTIM=$_zrush_worker_writer_pid
+  if (( VICTIM > 1 )) && kill -0 $VICTIM 2>/dev/null && peek_open; then
+    kill -KILL $VICTIM 2>/dev/null || note "cannot kill the writer child"
+    if readable $PEEK $WAIT_CS; then
+      log_reset
+      _zrush_worker_transport_teardown failure
+      if ! log_has "worker: teardown writer done pid=$VICTIM status=5"; then
+        note "teardown did not classify the EOF as a finished child"
+        log_lines
+      fi
+      log_has "teardown terminating writer" && note "teardown signalled a child that had already died"
+      eq "notification fd released" $_zrush_worker_ack_fd -1
+      eq "writer pid released" $_zrush_worker_writer_pid -1
+    else
+      note "notification fd did not reach EOF within ${WAIT_CS}cs after the kill"
+    fi
+  else
+    note "no live writer child to kill"
+  fi
+  peek_close
+  fifo_teardown
+  verdict "teardown: a child already at EOF is never signalled"
 
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"
 } always {
+  (( $+functions[reap_spawned] )) && reap_spawned
   [[ -n $WORK && $WORK == */zrush-transport.* ]] && rm -rf $WORK
 }
 (( FAIL == 0 ))

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -1,27 +1,38 @@
 #!/bin/zsh -f
-# Non-pty unit tests for the zsh-side worker transport write path:
-# _zrush_worker_flush's `syswrite` call that ships the pending transmit
-# buffer to the worker process.
+# Non-pty unit tests for the zsh-side worker transport write path: the outbound
+# frame queue, the short-lived writer child that _zrush_worker_flush forks, and
+# the ack/EOF notification fd that _zrush_worker_consume_ack reads.
 #
 # Usage:
 #   zsh -f tests/zsh/transport.zsh
 #     No arguments, no pty, no terminal. The zrush binary is NOT needed and no
 #     worker process is started: this runner only sources zsh/zrush.zsh with
-#     ZRUSH_NO_INIT=1 (the test seam at the end of that file) and calls
-#     _zrush_worker_flush directly against an fd opened on a temp file.
+#     ZRUSH_NO_INIT=1 (the test seam at the end of that file) and drives the
+#     transport functions directly against a FIFO it owns, standing in for the
+#     worker's request FIFO.
 #     $HOME and $XDG_CONFIG_HOME are redirected to a fresh mktemp directory,
 #     so the real ~/.zshrc, shell history and ~/.config/zrush are untouched.
 #
-# Scope: vectors.zsh covers the capture encoder and the plan decoder; this
-# file is the home for non-pty unit tests of the zsh-side worker transport
-# instead. Specifically: _zrush_worker_flush passes its data argument to
-# `syswrite` after `--`, so that syswrite's own option parser never inspects
-# the transmit buffer's bytes, no matter what they are (see
-# docs/internal/specs/behavior.md's partial-write/backpressure section for
-# why the buffer can start anywhere after a short write).
+# Scope: vectors.zsh covers the capture encoder and the plan decoder; this file
+# is the home for non-pty unit tests of the zsh-side worker transport instead.
+# The behavior under test is specified in docs/internal/specs/behavior.md,
+# section "worker ライフサイクル".
+#
+# Test seams used here, none of which touch zsh/zrush.zsh:
+#   - _zrush_warn is replaced by a recorder, so warnings are asserted instead of
+#     printed into the runner's output.
+#   - The ZLE callback never runs headless, so the shared consume path
+#     (_zrush_worker_consume_ack) is called directly, exactly as the synchronous
+#     history loop calls it.
+#   - The notification fd is duplicated before consuming, so that "exactly one
+#     ack byte" and "EOF without an ack byte" can be observed independently of
+#     the code under test. The writer child is never `wait`ed on and its exit
+#     status is never used as an oracle.
 emulate -L zsh
-setopt extended_glob
+setopt extended_glob nomultibyte
+export LC_ALL=C
 zmodload zsh/system || { print -u2 FATAL: system; exit 1 }
+zmodload zsh/zselect || { print -u2 FATAL: zselect; exit 1 }
 
 typeset -g HERE=${${(%):-%N}:A:h}
 typeset -g REPO=${HERE:h:h}
@@ -30,6 +41,11 @@ typeset -gi PASS=0 FAIL=0
 out() { print -r -u2 -- "$@" }
 ok()  { out "PASS: $1"; (( ++PASS )) }
 ng()  { out "FAIL: $1"; (( ++FAIL )) }
+
+# Bounded waits: WAIT_CS for "this must happen", IDLE_CS for "this must not
+# happen". Both are centiseconds (zselect's unit); no sleep is ever used for
+# synchronization.
+typeset -gi WAIT_CS=300 IDLE_CS=20
 
 typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-transport.XXXXXX)
 export HOME=$WORK/home             # isolated; never the real home
@@ -42,78 +58,326 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   typeset -g ZRUSH_NO_INIT=1
   source $REPO/zsh/zrush.zsh || { out "FATAL: cannot source zrush.zsh"; exit 1 }
   unset ZRUSH_NO_INIT
-  (( $+functions[_zrush_worker_flush] )) || { out "FATAL: _zrush_worker_flush undefined after source"; exit 1 }
-  (( $+functions[_zrush_encode_message] )) || { out "FATAL: _zrush_encode_message undefined after source"; exit 1 }
+  for fn in _zrush_worker_flush _zrush_worker_consume_ack _zrush_worker_release_writer \
+            _zrush_worker_transport_teardown _zrush_encode_message; do
+    (( $+functions[$fn] )) || { out "FATAL: $fn undefined after source"; exit 1 }
+  done
   (( _zrush_enabled )) && { out "FATAL: ZRUSH_NO_INIT did not suppress initialization"; exit 1 }
 
-  # Build a representative nested-netstring message body (see
-  # _zrush_encode_message, zsh/zrush.zsh:800): a "plan" request carrying
-  # candidate-style fields ("w"$'\1' tag), the first of which has value $1,
-  # then return only the tail of the encoded bytes starting at that value.
-  # This stands in for the buffer _zrush_worker_flush is left holding after a
-  # short write landed mid-field: it opens mid-value and runs to the end of
-  # the message, so the candidates after the marker are part of the remainder.
-  tail_from_field() {  # $1=field value (must appear verbatim exactly once) -> REPLY
+  typeset -ga WARNINGS=()
+  _zrush_warn() { WARNINGS+=( "$1" ) }   # test seam: record instead of printing
+
+  # ------------------------------------------------------------- assertions
+  typeset -ga WHY=()
+  eq() {  # $1=what $2=actual $3=expected
+    [[ $2 == "$3" ]] || WHY+=( "$1: got ${(qqq)2}, want ${(qqq)3}" )
+  }
+  note() { WHY+=( "$1" ) }
+  verdict() {  # $1=case label
+    if (( $#WHY == 0 )); then
+      ok "$1"
+    else
+      ng "$1"
+      local w
+      for w in "${(@)WHY}"; do out "      - $w"; done
+    fi
+    WHY=()
+  }
+
+  # ------------------------------------------------------------- fixtures
+  typeset -gi RFD=-1 ANCHOR=-1
+  typeset -g FIFO=
+
+  # Reset every transport global the write path reads, so each case starts from
+  # a clean session with no worker process behind it.
+  transport_reset() {
+    typeset -g  _zrush_worker_txq=() _zrush_worker_rx= _zrush_worker_setup_req=
+    typeset -gi _zrush_worker_ack_fd=-1 _zrush_worker_writer_pid=-1
+    typeset -gi _zrush_worker_rfd=-1 _zrush_worker_wfd=-1
+    typeset -gi _zrush_worker_drain_fd=-1 _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
+    typeset -gi _zrush_worker_pid=-1 _zrush_worker_ready=0
+    typeset -gi _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0
+    typeset -gA _zrush_worker_pending=()
+    WARNINGS=()
+  }
+
+  # A FIFO standing in for the worker's request FIFO. The anchor is opened
+  # read-write so neither the reader nor the writer open blocks, and the write
+  # fd is blocking + cloexec exactly as _zrush_worker_finish_start opens it: the
+  # forked writer child keeps it because cloexec acts at exec, not at fork.
+  fifo_setup() {  # $1=case name
     emulate -L zsh
-    setopt nomultibyte
+    FIFO=$WORK/$1.fifo
+    command mkfifo $FIFO || { out "FATAL: mkfifo $FIFO"; exit 1 }
+    sysopen -rw -o cloexec -u ANCHOR $FIFO || { out "FATAL: anchor open"; exit 1 }
+    sysopen -r -u RFD $FIFO || { out "FATAL: read open"; exit 1 }
+    transport_reset
+    sysopen -w -o cloexec -u _zrush_worker_wfd $FIFO || { out "FATAL: write open"; exit 1 }
+  }
+
+  fifo_teardown() {
+    emulate -L zsh
+    local -i fd
+    for fd in $_zrush_worker_wfd $RFD $ANCHOR; do
+      (( fd > 2 )) && { exec {fd}>&- } 2>/dev/null
+    done
+    _zrush_worker_wfd=-1 RFD=-1 ANCHOR=-1
+    [[ -n $FIFO ]] && command rm -f $FIFO
+    FIFO=
+  }
+
+  # A representative encoded plan request. Fields carry the bytes the transport
+  # must ship verbatim: option-like values ("-f", "-cvar"), and NUL / SOH / STX,
+  # which cli-protocol.md allows anywhere in a payload. $1 pads the frame past
+  # the FIFO's 8192-byte capacity so the writer child blocks inside syswrite.
+  build_frame() {  # $1=pad bytes (default 0) -> REPLY
+    emulate -L zsh
+    setopt localoptions nomultibyte
     local LC_ALL=C
-    local marker=$1
-    _zrush_encode_message plan 1 /some/path compsys somequery fuzzy 0 1 24 80 \
-      "w"$'\1'"$marker" "w"$'\1'"README.md" "w"$'\1'"Makefile"
-    local full=$REPLY
-    local prefix=${full%%$marker*}
-    typeset -g REPLY=${full[$#prefix+1,-1]}
+    local -i pad=${1:-0}
+    local -a fields=(
+      plan 1 /some/path compsys somequery fuzzy 0 1 24 80
+      "w"$'\1'"-f"
+      "w"$'\1'"-cvar"
+      "w"$'\2'"README.md"$'\0'"after-nul"
+    )
+    (( pad > 0 )) && fields+=( "w"$'\1'"${${(l:40000::x:)}[1,pad]}" )
+    _zrush_encode_message "${(@)fields}"
   }
 
-  # Drive _zrush_worker_flush directly: point _zrush_worker_wfd at a temp
-  # file, prime _zrush_worker_tx with $2, flush once, and leave the result in
-  # $flush_st / $WORK/$1.bin for the caller to check.
-  flush_case() {  # $1=label $2=tx-buffer
+  # ------------------------------------------------------------- fd helpers
+  readable() {  # $1=fd $2=centiseconds -> 0 if readable within the budget
     emulate -L zsh
-    local label=$1 tx=$2
-    local -i wfd
-    exec {wfd}> $WORK/$label.bin
-    typeset -g _zrush_worker_wfd=$wfd _zrush_worker_rfd=-1 _zrush_worker_setup_fd=-1
-    typeset -g _zrush_worker_retry_fd=-1 _zrush_worker_drain_fd=-1
-    typeset -g _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1 _zrush_worker_setup_req=
-    typeset -g _zrush_worker_tx=$tx
-    _zrush_worker_flush
-    typeset -gi flush_st=$?
-    # On success the fd is still open (nothing failed); on failure
-    # _zrush_worker_session_fail already closed it via the transport
-    # teardown. Either way, don't touch it again here.
+    zselect -t $2 -r $1 >/dev/null 2>&1
   }
 
-  # ---------------- dash-led buffer: unknown-option case ----------------
-  # A buffer beginning with -f (e.g. a dash-led completion candidate such as
-  # -f/--force reaching the head of the buffer after a short write) must not
-  # be parsed as a syswrite option.
-  tail_from_field -f
-  local case_f=$REPLY
-  print -rn -- "$case_f" >| $WORK/dash-f.expected.bin
-  flush_case dash-f "$case_f"
-  if (( flush_st == 0 )) && cmp -s $WORK/dash-f.expected.bin $WORK/dash-f.bin \
-     && [[ -z $_zrush_worker_tx ]]; then
-    ok "flush: buffer beginning with -f is written verbatim, not parsed as an option"
-  else
-    ng "flush: dash-f case status=$flush_st tx-remaining=${#_zrush_worker_tx}"
-  fi
+  # Copy exactly $3 bytes off $1 into the file $2, never blocking unbounded.
+  drain_bytes() {  # $1=fd $2=outfile $3=byte count
+    emulate -L zsh
+    setopt localoptions nomultibyte
+    local LC_ALL=C
+    local -i fd=$1 want=$3 got=0 cnt=0 st=0 outfd=-1
+    exec {outfd}>| $2 || return 1
+    while (( got < want )); do
+      if ! readable $fd $WAIT_CS; then
+        { exec {outfd}>&- } 2>/dev/null
+        return 1
+      fi
+      cnt=0
+      sysread -c cnt -i $fd -o $outfd -s 65536; st=$?
+      (( st == 0 )) || { { exec {outfd}>&- } 2>/dev/null; return 1 }
+      (( got += cnt ))
+    done
+    { exec {outfd}>&- } 2>/dev/null
+    return 0
+  }
 
-  # ---------------- dash-led buffer: bundled-option case ----------------
-  # -c takes an argument, so without the separator a buffer beginning with
-  # -cvar bundles as `-c var` and swallows the data word itself. That is a
-  # different syswrite parse path from the unknown-option case above: it fails
-  # on a missing argument rather than on the leading byte.
-  tail_from_field -cvar
-  local case_c=$REPLY
-  print -rn -- "$case_c" >| $WORK/dash-c.expected.bin
-  flush_case dash-c "$case_c"
-  if (( flush_st == 0 )) && cmp -s $WORK/dash-c.expected.bin $WORK/dash-c.bin \
-     && [[ -z $_zrush_worker_tx ]]; then
-    ok "flush: buffer beginning with -cvar is written verbatim, not bundled as -c var"
+  # Duplicate the notification fd so the ack byte / EOF can be observed without
+  # racing the code under test for it.
+  peek_open() {  # -> PEEK
+    typeset -gi PEEK=-1
+    (( _zrush_worker_ack_fd >= 0 )) || return 1
+    exec {PEEK}<&$_zrush_worker_ack_fd
+  }
+  peek_close() {
+    (( PEEK > 2 )) && { exec {PEEK}>&- } 2>/dev/null
+    PEEK=-1
+  }
+  # Reads whatever the notification pipe still holds. status 4 = nothing yet,
+  # 0 = bytes available (in PEEK_BYTES), 5 = EOF.
+  peek_read() {  # -> PEEK_ST / PEEK_BYTES
+    typeset -g PEEK_BYTES=
+    sysread -t 0 -i $PEEK PEEK_BYTES
+    typeset -gi PEEK_ST=$?
+  }
+
+  # ============================================================ case 1
+  # One frame: the child ships it whole and acks exactly once.
+  fifo_setup one
+  build_frame; typeset -g FRAME=$REPLY
+  print -rn -- "$FRAME" >| $WORK/one.expected
+  _zrush_worker_txq=( "$FRAME" )
+  _zrush_worker_flush; typeset -gi st=$?
+  eq "flush status" $st 0
+  eq "queue drained into the child" $#_zrush_worker_txq 0
+  (( _zrush_worker_ack_fd >= 0 )) || note "no notification fd after flush"
+  (( _zrush_worker_writer_pid > 1 )) || note "no writer child pid after flush"
+  if peek_open; then
+    if drain_bytes $RFD $WORK/one.actual ${#FRAME}; then
+      cmp -s $WORK/one.expected $WORK/one.actual || note "frame bytes differ from what was queued"
+    else
+      note "reader did not observe ${#FRAME} bytes within ${WAIT_CS}cs"
+    fi
+    readable $RFD $IDLE_CS && note "extra bytes followed the frame"
+    if readable $_zrush_worker_ack_fd $WAIT_CS; then
+      _zrush_worker_consume_ack; typeset -gi cst=$?
+      eq "consume_ack status" $cst 0
+      # consume_ack read the whole ack byte string: any second byte would have
+      # made it "11" and failed the session. The dup then shows EOF, so exactly
+      # one ack byte was ever written.
+      peek_read
+      eq "notification fd after the ack" $PEEK_ST 5
+      eq "bytes after the ack" ${#PEEK_BYTES} 0
+      eq "in-flight notification fd released" $_zrush_worker_ack_fd -1
+      eq "in-flight writer pid released" $_zrush_worker_writer_pid -1
+      eq "session failures" $_zrush_worker_failures 0
+      eq "warnings" $#WARNINGS 0
+    else
+      note "no ack within ${WAIT_CS}cs"
+    fi
   else
-    ng "flush: dash-c case status=$flush_st tx-remaining=${#_zrush_worker_tx}"
+    note "cannot duplicate the notification fd"
   fi
+  peek_close
+  fifo_teardown
+  verdict "frame: shipped byte-for-byte and acked exactly once"
+
+  # ============================================================ case 2
+  # Two frames: the second waits for the first frame's ack, and the reader sees
+  # the first frame complete before any byte of the second.
+  fifo_setup order
+  build_frame 40000; typeset -g FRAME_A=$REPLY
+  build_frame;       typeset -g FRAME_B=$REPLY
+  print -rn -- "$FRAME_A" >| $WORK/order.a.expected
+  print -rn -- "$FRAME_B" >| $WORK/order.b.expected
+  _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
+  _zrush_worker_flush; st=$?
+  typeset -gi ACK_A=$_zrush_worker_ack_fd PID_A=$_zrush_worker_writer_pid
+  eq "flush status" $st 0
+  eq "second frame still queued" $#_zrush_worker_txq 1
+  eq "queued frame is B" "$_zrush_worker_txq[1]" "$FRAME_B"
+  (( PID_A > 1 )) || note "no writer child for frame A"
+  # A is larger than the FIFO's 8192-byte capacity and nothing drains yet, so A
+  # is still in flight here. A second flush must not hand B to another child.
+  _zrush_worker_flush; st=$?
+  eq "flush while a child is in flight" $st 0
+  eq "notification fd unchanged" $_zrush_worker_ack_fd $ACK_A
+  eq "writer pid unchanged" $_zrush_worker_writer_pid $PID_A
+  eq "B still queued while A is in flight" $#_zrush_worker_txq 1
+  if drain_bytes $RFD $WORK/order.a.actual ${#FRAME_A}; then
+    cmp -s $WORK/order.a.expected $WORK/order.a.actual || note "frame A bytes differ"
+  else
+    note "reader did not observe frame A within ${WAIT_CS}cs"
+  fi
+  # Nothing of B may be in the FIFO before A is acked.
+  readable $RFD $IDLE_CS && note "bytes of B reached the FIFO before A was acked"
+  eq "B still queued before A's ack" $#_zrush_worker_txq 1
+  if readable $_zrush_worker_ack_fd $WAIT_CS; then
+    _zrush_worker_consume_ack; cst=$?
+    eq "consume_ack status for A" $cst 0
+    eq "B handed to a child on A's ack" $#_zrush_worker_txq 0
+    (( _zrush_worker_ack_fd >= 0 )) || note "no notification fd for frame B"
+    (( _zrush_worker_writer_pid > 1 && _zrush_worker_writer_pid != PID_A )) ||
+      note "frame B did not get its own writer child"
+    if drain_bytes $RFD $WORK/order.b.actual ${#FRAME_B}; then
+      cmp -s $WORK/order.b.expected $WORK/order.b.actual || note "frame B bytes differ"
+    else
+      note "reader did not observe frame B within ${WAIT_CS}cs"
+    fi
+    if readable $_zrush_worker_ack_fd $WAIT_CS; then
+      _zrush_worker_consume_ack; cst=$?
+      eq "consume_ack status for B" $cst 0
+      eq "notification fd released after B" $_zrush_worker_ack_fd -1
+      eq "writer pid released after B" $_zrush_worker_writer_pid -1
+      eq "session failures" $_zrush_worker_failures 0
+      eq "warnings" $#WARNINGS 0
+    else
+      note "no ack for frame B within ${WAIT_CS}cs"
+    fi
+  else
+    note "no ack for frame A within ${WAIT_CS}cs"
+  fi
+  fifo_teardown
+  verdict "queue: the next frame is sent only on the previous frame's ack, in order"
+
+  # ============================================================ case 3
+  # A child killed mid-frame: EOF without an ack byte is a worker session
+  # failure, never a silently truncated success.
+  fifo_setup killed
+  build_frame 40000; typeset -g FRAME_BIG=$REPLY
+  _zrush_worker_txq=( "$FRAME_BIG" )
+  _zrush_worker_flush; st=$?
+  eq "flush status" $st 0
+  typeset -gi VICTIM=$_zrush_worker_writer_pid
+  if (( VICTIM > 1 )) && kill -0 $VICTIM 2>/dev/null && peek_open; then
+    # Nothing drains the FIFO, so the child is blocked inside its single
+    # syswrite with the frame only partly written.
+    readable $_zrush_worker_ack_fd $IDLE_CS && note "acked before the frame could have been written"
+    kill -KILL $VICTIM 2>/dev/null || note "cannot kill the writer child"
+    if readable $PEEK $WAIT_CS; then
+      peek_read
+      eq "notification fd reached EOF" $PEEK_ST 5
+      eq "ack bytes before EOF" ${#PEEK_BYTES} 0
+      typeset -gi BEFORE=$_zrush_worker_failures
+      _zrush_worker_consume_ack; cst=$?
+      eq "consume_ack reports failure" $cst 1
+      eq "session failure counted" $_zrush_worker_failures $(( BEFORE + 1 ))
+      eq "warned once" $#WARNINGS 1
+      eq "no in-flight notification fd left" $_zrush_worker_ack_fd -1
+      eq "no in-flight writer pid left" $_zrush_worker_writer_pid -1
+      eq "queue discarded" $#_zrush_worker_txq 0
+      eq "request fd closed by the teardown" $_zrush_worker_wfd -1
+    else
+      note "notification fd did not reach EOF within ${WAIT_CS}cs after the kill"
+    fi
+  else
+    note "no live writer child to kill"
+  fi
+  peek_close
+  fifo_teardown
+  verdict "kill: a child killed mid-frame fails the session instead of truncating silently"
+
+  # ============================================================ case 4
+  # Frames are opaque byte units: whatever leading bytes a frame has, syswrite
+  # never parses them as its own options.
+  fifo_setup opaque
+  typeset -g ODD=$'-cvar\1-f\0--\2 -s 1'
+  print -rn -- "$ODD" >| $WORK/opaque.expected
+  _zrush_worker_txq=( "$ODD" )
+  _zrush_worker_flush; st=$?
+  eq "flush status" $st 0
+  if drain_bytes $RFD $WORK/opaque.actual ${#ODD}; then
+    cmp -s $WORK/opaque.expected $WORK/opaque.actual || note "option-like frame bytes differ"
+  else
+    note "reader did not observe the frame within ${WAIT_CS}cs"
+  fi
+  if readable $_zrush_worker_ack_fd $WAIT_CS; then
+    _zrush_worker_consume_ack; cst=$?
+    eq "consume_ack status" $cst 0
+    eq "session failures" $_zrush_worker_failures 0
+  else
+    note "no ack within ${WAIT_CS}cs"
+  fi
+  fifo_teardown
+  verdict "frame: option-like leading bytes are written verbatim, not parsed by syswrite"
+
+  # ============================================================ case 5
+  # Teardown drops the unsent queue and lets go of the in-flight child.
+  fifo_setup drop
+  build_frame 40000; FRAME_A=$REPLY
+  build_frame;       FRAME_B=$REPLY
+  _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
+  _zrush_worker_flush; st=$?
+  eq "flush status" $st 0
+  if peek_open; then
+    _zrush_worker_transport_teardown failure
+    eq "queued frames dropped" $#_zrush_worker_txq 0
+    eq "notification fd released" $_zrush_worker_ack_fd -1
+    eq "writer pid released" $_zrush_worker_writer_pid -1
+    eq "request fd closed" $_zrush_worker_wfd -1
+    if readable $PEEK $WAIT_CS; then
+      peek_read
+      eq "in-flight child gone without an ack" $PEEK_ST 5
+      eq "ack bytes" ${#PEEK_BYTES} 0
+    else
+      note "in-flight child outlived the teardown"
+    fi
+  else
+    note "cannot duplicate the notification fd"
+  fi
+  peek_close
+  fifo_teardown
+  verdict "teardown: unsent frames are dropped and the in-flight child is released"
 
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"
 } always {

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -167,10 +167,16 @@ mkdir -p $HOME $XDG_CONFIG_HOME
     FIFO=
   }
 
+  # Padding that leaves the writer child blocked inside its single syswrite.
+  # A FIFO's buffer is 8192 bytes on macOS but 65536 on Linux, so a frame only
+  # blocks on both platforms if it exceeds the larger figure with margin; the
+  # cases below never hard-code a capacity, they pad by this amount.
+  typeset -gi BLOCK_PAD=131072
+
   # A representative encoded plan request. Fields carry the bytes the transport
   # must ship verbatim: option-like values ("-f", "-cvar"), and NUL / SOH / STX,
-  # which cli-protocol.md allows anywhere in a payload. $1 pads the frame past
-  # the FIFO's 8192-byte capacity so the writer child blocks inside syswrite.
+  # which cli-protocol.md allows anywhere in a payload. $1 pads the frame; pass
+  # $BLOCK_PAD when the case needs a writer child blocked inside syswrite.
   build_frame() {  # $1=pad bytes (default 0) -> REPLY
     emulate -L zsh
     setopt localoptions nomultibyte
@@ -182,7 +188,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
       "w"$'\1'"-cvar"
       "w"$'\2'"README.md"$'\0'"after-nul"
     )
-    (( pad > 0 )) && fields+=( "w"$'\1'"${${(l:40000::x:)}[1,pad]}" )
+    (( pad > 0 )) && fields+=( "w"$'\1'"${(l:pad::x:)}" )
     _zrush_encode_message "${(@)fields}"
   }
 
@@ -277,7 +283,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   # Two frames: the second waits for the first frame's ack, and the reader sees
   # the first frame complete before any byte of the second.
   fifo_setup order
-  build_frame 40000; typeset -g FRAME_A=$REPLY
+  build_frame $BLOCK_PAD; typeset -g FRAME_A=$REPLY
   build_frame;       typeset -g FRAME_B=$REPLY
   print -rn -- "$FRAME_A" >| $WORK/order.a.expected
   print -rn -- "$FRAME_B" >| $WORK/order.b.expected
@@ -288,8 +294,8 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   eq "second frame still queued" $#_zrush_worker_txq 1
   eq "queued frame is B" "$_zrush_worker_txq[1]" "$FRAME_B"
   (( PID_A > 1 )) || note "no writer child for frame A"
-  # A is larger than the FIFO's 8192-byte capacity and nothing drains yet, so A
-  # is still in flight here. A second flush must not hand B to another child.
+  # A outgrows the FIFO's buffer on either platform and nothing drains yet, so
+  # A is still in flight here. A second flush must not hand B to another child.
   flush_now; st=$?
   eq "flush while a child is in flight" $st 0
   eq "notification fd unchanged" $_zrush_worker_ack_fd $ACK_A
@@ -336,7 +342,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   # A child killed mid-frame: EOF without an ack byte is a worker session
   # failure, never a silently truncated success.
   fifo_setup killed
-  build_frame 40000; typeset -g FRAME_BIG=$REPLY
+  build_frame $BLOCK_PAD; typeset -g FRAME_BIG=$REPLY
   _zrush_worker_txq=( "$FRAME_BIG" )
   flush_now; st=$?
   eq "flush status" $st 0
@@ -398,7 +404,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   # its blocking syswrite: nothing readable on the notification fd is the only
   # state in which the recorded pid is still the writer child's.
   fifo_setup drop
-  build_frame 40000; FRAME_A=$REPLY
+  build_frame $BLOCK_PAD; FRAME_A=$REPLY
   build_frame;       FRAME_B=$REPLY
   _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
   flush_now; st=$?
@@ -467,7 +473,7 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   # Same classification at the other end: a child that died mid-frame leaves the
   # notification fd at EOF, and a dead pid must not be signalled either.
   fifo_setup gone
-  build_frame 40000; FRAME_BIG=$REPLY
+  build_frame $BLOCK_PAD; FRAME_BIG=$REPLY
   _zrush_worker_txq=( "$FRAME_BIG" )
   flush_now; st=$?
   eq "flush status" $st 0

--- a/tests/zsh/vectors.zsh
+++ b/tests/zsh/vectors.zsh
@@ -206,7 +206,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   _zrush_timer_fd=$exit_timer_fd _zrush_rfd=$exit_rfd _zrush_wfd=$exit_wfd
   _zrush_pty= _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1
   _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_setup_fd=-1
-  _zrush_worker_retry_fd=-1 _zrush_worker_drain_fd=-1
+  _zrush_worker_ack_fd=-1 _zrush_worker_drain_fd=-1
   _zrush_zshexit
   if (( _zrush_timer_fd == -1 && _zrush_rfd == -1 && _zrush_wfd == -1 )) \
      && [[ ! -e /dev/fd/$exit_timer_fd && ! -e /dev/fd/$exit_rfd \
@@ -391,25 +391,25 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   # disable immediately; it is not counted as the first retryable failure.
   _zrush_worker_ready=0 _zrush_worker_failures=0 _zrush_disabled=0 _zrush_enabled=1
   _zrush_worker_warned=0 _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1
-  local -i mismatch_rfd mismatch_wfd mismatch_setup_fd mismatch_retry_fd mismatch_drain_fd
+  local -i mismatch_rfd mismatch_wfd mismatch_setup_fd mismatch_ack_fd mismatch_drain_fd
   exec {mismatch_rfd}< /dev/null
   exec {mismatch_wfd}> /dev/null
   exec {mismatch_setup_fd}< /dev/null
-  exec {mismatch_retry_fd}< /dev/null
+  exec {mismatch_ack_fd}< /dev/null
   exec {mismatch_drain_fd}< /dev/null
   _zrush_worker_rfd=$mismatch_rfd _zrush_worker_wfd=$mismatch_wfd
   _zrush_worker_setup_fd=$mismatch_setup_fd
-  _zrush_worker_retry_fd=$mismatch_retry_fd _zrush_worker_drain_fd=$mismatch_drain_fd
+  _zrush_worker_ack_fd=$mismatch_ack_fd _zrush_worker_drain_fd=$mismatch_drain_fd
   _zrush_encode_message incompatible 7
   local mismatch_frame=$REPLY
   _zrush_netstring_take "$mismatch_frame"
   _zrush_worker_handle_message "$REPLY" 2>/dev/null
   if (( _zrush_disabled && !_zrush_enabled && _zrush_worker_failures == 0 \
         && _zrush_worker_warned && _zrush_worker_rfd == -1 && _zrush_worker_wfd == -1 \
-        && _zrush_worker_setup_fd == -1 && _zrush_worker_retry_fd == -1 \
+        && _zrush_worker_setup_fd == -1 && _zrush_worker_ack_fd == -1 \
         && _zrush_worker_drain_fd == -1 )) \
      && [[ ! -e /dev/fd/$mismatch_rfd && ! -e /dev/fd/$mismatch_wfd \
-           && ! -e /dev/fd/$mismatch_setup_fd && ! -e /dev/fd/$mismatch_retry_fd \
+           && ! -e /dev/fd/$mismatch_setup_fd && ! -e /dev/fd/$mismatch_ack_fd \
            && ! -e /dev/fd/$mismatch_drain_fd ]]; then
     ok "worker lifecycle: protocol mismatch disables immediately and closes every transport fd"
   else

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -1236,6 +1236,13 @@ _zrush_worker_read() {  # async | sync [absolute-deadline]
 _zrush_worker_on_data() {
   emulate -L zsh
   (( $1 == _zrush_worker_rfd )) || return 0
+  # The ack is usually ready in the same wakeup as the response it precedes.
+  # Consuming it before the plan is painted leaves the ack watcher's own
+  # dispatch with nothing to do, because work running in a callback after a
+  # paint holds a SIGINT that zsh 5.9 defers onto the next input byte.
+  if (( _zrush_worker_ack_fd >= 0 )); then
+    _zrush_worker_consume_ack || return 0
+  fi
   _zrush_worker_read async
   return 0
 }

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -855,14 +855,26 @@ _zrush_worker_transport_teardown() {
   setopt localoptions no_bg_nice
   _zrush_worker_disarm_drain
   _zrush_worker_txq=()
+  # _zrush_worker_writer_pid is >1 only while an ack fd exists, so signalling
+  # belongs inside this branch. Nothing readable after the bounded wait is the
+  # only state in which the child still owns that pid; once its single write is
+  # over the pid may already have been reused by an unrelated process.
   if (( _zrush_worker_ack_fd >= 0 )); then
+    local ack=
+    local -i ack_st
     zle -F $_zrush_worker_ack_fd 2>/dev/null
-    # Bounded wait: the notification fd becomes readable on the ack byte and on
-    # the child's death alike, so this cannot outlast the child.
+    # The notification fd becomes readable on the ack byte and on the child's
+    # death alike, so this bounded wait cannot outlast the child.
     zselect -t 1 -r $_zrush_worker_ack_fd >/dev/null 2>&1
+    sysread -t 0 -i $_zrush_worker_ack_fd ack; ack_st=$?
     _zrush_worker_release_writer
+    if (( ack_st == 4 )); then
+      _zlog "worker: teardown terminating writer pid=$_zrush_worker_writer_pid"
+      _zrush_worker_terminate $_zrush_worker_writer_pid
+    else
+      _zlog "worker: teardown writer done pid=$_zrush_worker_writer_pid status=$ack_st"
+    fi
   fi
-  _zrush_worker_terminate $_zrush_worker_writer_pid
   _zrush_worker_writer_pid=-1
   if (( _zrush_worker_setup_fd >= 0 )); then
     zle -F $_zrush_worker_setup_fd 2>/dev/null

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -80,10 +80,12 @@ typeset -g  _zrush_last_buffer=
 typeset -gi _zrush_last_cursor=-1
 
 # Persistent Rust worker transport.
-typeset -gi _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_retry_fd=-1
+typeset -gi _zrush_worker_rfd=-1 _zrush_worker_wfd=-1
 typeset -gi _zrush_worker_drain_fd=-1
+typeset -gi _zrush_worker_ack_fd=-1 _zrush_worker_writer_pid=-1
 typeset -gi _zrush_worker_pid=-1 _zrush_worker_ready=0
-typeset -g  _zrush_worker_rx= _zrush_worker_tx=
+typeset -g  _zrush_worker_rx=
+typeset -ga _zrush_worker_txq=()      # complete outbound frames; no send offset exists
 typeset -gi _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
 typeset -g  _zrush_worker_setup_req=
 typeset -gA _zrush_worker_pending=()
@@ -813,12 +815,7 @@ _zrush_worker_warn_once() {
   _zrush_worker_warned=1
 }
 
-_zrush_worker_disarm_retry() {
-  if (( _zrush_worker_retry_fd >= 0 )); then
-    zle -F $_zrush_worker_retry_fd 2>/dev/null
-    _zrush_close_internal_fd $_zrush_worker_retry_fd
-    _zrush_worker_retry_fd=-1
-  fi
+_zrush_worker_disarm_drain() {
   if (( _zrush_worker_drain_fd >= 0 )); then
     zle -F $_zrush_worker_drain_fd 2>/dev/null
     _zrush_close_internal_fd $_zrush_worker_drain_fd
@@ -842,10 +839,31 @@ _zrush_worker_terminate() {
   return 0
 }
 
+# Releases the notification fd of a writer child that has finished with the
+# frame it was handed; the child itself is never waited on (behavior.md
+# "worker ライフサイクル").
+_zrush_worker_release_writer() {
+  (( _zrush_worker_ack_fd >= 0 )) || return 0
+  zle -F $_zrush_worker_ack_fd 2>/dev/null
+  _zrush_close_internal_fd $_zrush_worker_ack_fd
+  _zrush_worker_ack_fd=-1
+  return 0
+}
+
 _zrush_worker_transport_teardown() {
   emulate -L zsh
   setopt localoptions no_bg_nice
-  _zrush_worker_disarm_retry
+  _zrush_worker_disarm_drain
+  _zrush_worker_txq=()
+  if (( _zrush_worker_ack_fd >= 0 )); then
+    zle -F $_zrush_worker_ack_fd 2>/dev/null
+    # Bounded wait: the notification fd becomes readable on the ack byte and on
+    # the child's death alike, so this cannot outlast the child.
+    zselect -t 1 -r $_zrush_worker_ack_fd >/dev/null 2>&1
+    _zrush_worker_release_writer
+  fi
+  _zrush_worker_terminate $_zrush_worker_writer_pid
+  _zrush_worker_writer_pid=-1
   if (( _zrush_worker_setup_fd >= 0 )); then
     zle -F $_zrush_worker_setup_fd 2>/dev/null
     _zrush_close_internal_fd $_zrush_worker_setup_fd
@@ -872,7 +890,6 @@ _zrush_worker_transport_teardown() {
   _zrush_worker_pid=-1
   _zrush_worker_ready=0
   _zrush_worker_rx=
-  _zrush_worker_tx=
   _zrush_worker_pending=()
   _zrush_current_request=0
   _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
@@ -926,9 +943,9 @@ _zrush_worker_start() {
   _zrush_worker_setup_fd=$fd
   _zrush_worker_setup_pid=${sysparams[procsubstpid]:--1}
   _zrush_worker_ready=0
-  _zrush_worker_rx= _zrush_worker_tx=
+  _zrush_worker_rx=
   _zrush_encode_message hello "$_ZRUSH_EXPECTED_PROTO"
-  _zrush_worker_tx=$REPLY
+  _zrush_worker_txq=( "$REPLY" )
   if ! zle -F -w $fd _zrush-worker-on-setup 2>/dev/null; then
     _zrush_worker_session_fail "setup fd registration failed"
     return 1
@@ -945,7 +962,7 @@ _zrush_worker_finish_start() {
   local -i failed=0
   if ! sysopen -rw -o cloexec -u req_anchor "$req" ||
      ! sysopen -r -o cloexec -u child_in "$req" ||
-     ! sysopen -w -o nonblock,cloexec -u _zrush_worker_wfd "$req"; then
+     ! sysopen -w -o cloexec -u _zrush_worker_wfd "$req"; then
     failed=1
   else
     # The substitution forks before sysopen runs, so record the pid whether or not
@@ -1006,73 +1023,63 @@ _zrush_worker_consume_setup_checked() {
   _zrush_worker_session_fail "pipe setup failed"
 }
 
-_zrush_worker_arm_retry() {
-  (( _zrush_worker_retry_fd < 0 )) || return 0
-  local fd
-  exec {fd}< <( zselect -t 1; print )
-  _zrush_worker_retry_fd=$fd
-  zle -F -w $fd _zrush-worker-on-write 2>/dev/null || {
-    _zrush_close_internal_fd $fd
-    _zrush_worker_retry_fd=-1
-    _zrush_worker_session_fail "write retry fd registration failed"
-    return 1
-  }
-  return 0
-}
-
+# Hands the head frame to a short-lived writer child and returns to ZLE at
+# once; the interactive shell itself never writes to the request FIFO.
+# `--` keeps syswrite's option parser away from the frame's bytes, and the
+# child inherits the cloexec write fd because cloexec acts at exec, not fork.
 _zrush_worker_flush() {
   emulate -L zsh
+  setopt localoptions no_monitor no_notify no_bg_nice
   local LC_ALL=C
-  [[ -n $_zrush_worker_tx ]] || { _zrush_worker_disarm_retry; return 0 }
+  (( $#_zrush_worker_txq )) || return 0
+  (( _zrush_worker_ack_fd >= 0 )) && return 0
   if (( _zrush_worker_wfd < 0 )); then
     (( _zrush_worker_setup_fd >= 0 )) && return 0
     return 1
   fi
-  local -i wrote=0 st
-  local write_errno=
-  syswrite -c wrote -o $_zrush_worker_wfd -- "$_zrush_worker_tx"
-  st=$? write_errno=$ERRNO
-  (( wrote > 0 )) && _zrush_worker_tx=${_zrush_worker_tx[wrote+1,-1]}
-  if (( st == 0 )); then
-    if [[ -n $_zrush_worker_tx ]]; then
-      _zrush_worker_arm_retry || return 1
-    else
-      _zrush_worker_disarm_retry
-    fi
-    return 0
+  local frame=$_zrush_worker_txq[1] fd=
+  exec {fd}< <( syswrite -o $_zrush_worker_wfd -- "$frame" && print -rn -- 1 )
+  # An unset fd means no child exists; assigning it would leave the integer
+  # global at 0 and aim the watcher at the shell's own stdin.
+  if [[ -z $fd ]]; then
+    _zrush_worker_session_fail "writer child spawn failed"
+    return 1
   fi
-  if (( st == 2 )) && [[ $write_errno == 11 || $write_errno == 35 ]]; then
-    _zlog "worker: write backpressure errno=$write_errno wrote=$wrote remaining=${#_zrush_worker_tx}"
-    _zrush_worker_arm_retry || return 1
-    return 0
+  _zrush_worker_ack_fd=$fd
+  _zrush_worker_writer_pid=${sysparams[procsubstpid]:--1}
+  shift _zrush_worker_txq
+  if ! zle -F -w $fd _zrush-worker-on-ack 2>/dev/null; then
+    _zrush_worker_session_fail "ack fd registration failed"
+    return 1
   fi
-  if (( st == 2 )) && [[ -z $write_errno ]] && (( wrote > 0 )); then
-    _zlog "worker: macOS write backpressure wrote=$wrote remaining=${#_zrush_worker_tx}"
-    _zrush_worker_arm_retry || return 1
-    return 0
-  fi
-  if (( st == 2 )) && [[ -z $write_errno ]] && (( _zrush_worker_pid > 1 )) && \
-     kill -0 $_zrush_worker_pid 2>/dev/null; then
-    _zrush_worker_read async || return 1
-    (( _zrush_worker_wfd >= 0 && _zrush_worker_pid > 1 )) || return 1
-    kill -0 $_zrush_worker_pid 2>/dev/null || {
-      _zrush_worker_session_fail "worker died during zero-progress write"
-      return 1
-    }
-    _zlog "worker: macOS write backpressure wrote=0 remaining=${#_zrush_worker_tx}"
-    _zrush_worker_arm_retry || return 1
-    return 0
-  fi
-  _zrush_worker_session_fail "write error status=$st errno=${write_errno:-unknown} wrote=$wrote"
+  _zlog "worker: sending frame writer_pid=$_zrush_worker_writer_pid ackfd=$fd bytes=${#frame} queued=$#_zrush_worker_txq"
+  return 0
 }
 
-_zrush_worker_on_write() {
+# Shared by the ZLE callback and the synchronous history loop. The child's exit
+# status is never consulted: an ack byte means the frame reached the FIFO, EOF
+# without one means the write failed.
+_zrush_worker_consume_ack() {
   emulate -L zsh
-  local -i fd=$1
-  zle -F $fd 2>/dev/null
-  _zrush_close_internal_fd $fd
-  (( fd == _zrush_worker_retry_fd )) && _zrush_worker_retry_fd=-1
+  (( _zrush_worker_ack_fd >= 0 )) || return 0
+  local ack=
+  local -i st writer_pid=$_zrush_worker_writer_pid
+  sysread -t 0 -i $_zrush_worker_ack_fd ack; st=$?
+  (( st == 4 )) && return 0
+  _zrush_worker_release_writer
+  _zrush_worker_writer_pid=-1
+  if [[ $ack != 1 ]]; then
+    _zrush_worker_session_fail "frame write failed writer_pid=$writer_pid status=$st"
+    return 1
+  fi
+  _zlog "worker: frame sent writer_pid=$writer_pid queued=$#_zrush_worker_txq"
   _zrush_worker_flush
+}
+
+_zrush_worker_on_ack() {
+  emulate -L zsh
+  (( $1 == _zrush_worker_ack_fd )) || return 0
+  _zrush_worker_consume_ack
   return 0
 }
 
@@ -1273,8 +1280,8 @@ _zrush_request_plan() {  # payload producer query trailing-space
   fi
   _zrush_encode_message plan "$id" "$PWD" "$producer" "$query" \
     "$ZRUSH_CFG_MODE" "$ZRUSH_CFG_SMART_CASE" "$rows" "$width" "$tspace" "$payload"
-  _zrush_worker_tx+=$REPLY
-  _zlog "worker: queued request_id=$id producer=$producer bytes=${#REPLY}"
+  _zrush_worker_txq+=( "$REPLY" )
+  _zlog "worker: queued request_id=$id producer=$producer bytes=${#REPLY} queued=$#_zrush_worker_txq"
   _zrush_worker_flush || return 1
   typeset -g REPLY=$id
   return 0
@@ -1506,9 +1513,8 @@ _zrush_request_plan_sync() {
       _zrush_worker_consume_setup_checked || return 1
       continue
     fi
-    if [[ -n $_zrush_worker_tx ]]; then
-      zselect -t $cs -r $_zrush_worker_rfd -w $_zrush_worker_wfd >/dev/null 2>&1
-      _zrush_worker_flush || return 1
+    if (( _zrush_worker_ack_fd >= 0 )); then
+      zselect -t $cs -r $_zrush_worker_rfd -r $_zrush_worker_ack_fd >/dev/null 2>&1
     else
       zselect -t $cs -r $_zrush_worker_rfd >/dev/null 2>&1
     fi
@@ -1516,6 +1522,7 @@ _zrush_request_plan_sync() {
       _zrush_worker_session_fail "history deadline exceeded request_id=$target"
       return 1
     fi
+    _zrush_worker_consume_ack || return 1
     (( _zrush_worker_rfd >= 0 )) || return 1
     _zrush_worker_read sync "$deadline" || return 1
   done
@@ -2083,7 +2090,7 @@ _zrush_init() {
   zle -N _zrush-on-data _zrush_on_data
   zle -N _zrush-timer-fire _zrush_timer_fire
   zle -N _zrush-worker-on-data _zrush_worker_on_data
-  zle -N _zrush-worker-on-write _zrush_worker_on_write
+  zle -N _zrush-worker-on-ack _zrush_worker_on_ack
   zle -N _zrush-worker-on-drain _zrush_worker_on_drain
   zle -N _zrush-worker-on-setup _zrush_worker_on_setup
   zle -N _zrush-capture-entry _zrush_capture_entry


### PR DESCRIPTION
Closes #46.

The interactive shell no longer writes to the worker's request FIFO.
Each complete frame is handed to a short-lived forked writer child that owns a blocking write fd and ships the frame with a single `syswrite`, reporting completion by one ack byte on a notification pipe watched with `zle -F`.
At most one child is in flight, so `request_id` order is preserved; success is judged solely from the ack byte (EOF without an ack is a worker session failure), never from the child's exit status.
The outbound queue becomes a list of complete frames with no send offset, and the whole partial-write machinery — the 10 ms retry timer, the backpressure classification, and the tx re-slicing — is deleted.
The wire byte stream is unchanged, so the protocol version does not move.
`docs/internal/specs/behavior.md` is rewritten first (frame-atomic delegation replaces nonblocking stdin / partial writes / `EAGAIN` retry) and the code follows it.

Measured on the machine from #46 (macOS Darwin 27.0.0, Apple Silicon, zsh 5.9), paired runs of `tests/zsh/driver-latency.zsh` on the same playground under identical load, medians of 4 trials:

| case | main (ce128b9) | this branch |
|---|---|---|
| file completion, 3000-entry directory | 272 ms | 162 ms |
| command cache hit | 119 ms | 43 ms |
| file completion, delay-ms=0 | 417 ms | 202 ms |

## Commits

- `docs: rewrite worker stdin spec to frame-atomic writer-child delegation` — spec first; the deliberate spec change is that a writer child may block, while the interactive shell still never waits for a write.
- `fix(worker): hand each outbound frame to a forked writer child` — the transport itself, plus `tests/zsh/transport.zsh` rewritten against frame delegation (exact-once ack, order across frames, mid-frame kill → session failure, opaque option-like bytes, teardown; each case backed by mutation testing) and the test harness following the renamed transport state.
- `fix(worker): consume a ready ack before the response paints` — zsh 5.9 defers a SIGINT arriving inside any `zle -F` callback until the next input byte, which the deferred send-break then swallows (mechanism and no-zrush repro recorded in https://github.com/himadajin/zrush/issues/47#issuecomment-5172807156). The initial transport shape always left the ack callback firing right after a paint, turning that pre-existing hazard into a ~40% failure of driver case `(sb-1b)` on an idle machine; consuming an already-ready ack at the top of the response callback removes the systematic exposure (10/10 clean afterwards).
- `test(zsh): add driver cases for frame delegation; fix sync_prompt status` — end-to-end pty coverage: a request larger than the 8192-byte FIFO capacity completes and renders `(fifo-1a/b)`, and teardown with a frame in flight produces no job-control output and leaves no writer child behind `(inflight-1a/b/c)`. Also makes `sync_prompt` return `expect`'s status, so the four send-break cases that branch on it can actually fail.
- `fix(worker): never signal a writer pid after its ack or EOF` — external-audit finding: teardown TERM'd the recorded writer pid unconditionally, which on pid reuse could signal an unrelated process hours after the child exited (acks arriving outside zle are consumed only later). Teardown now classifies the notification fd first and signals only when nothing is readable after the bounded wait, i.e. only while the child demonstrably still owns the pid. Covered by three new transport cases (blocked / acked-unconsumed / EOF), mutation-tested.

## For the reviewer

- External audit (GPT 5.6 sol, high effort, two fresh passes) produced one confirmed finding (fixed above, re-audit clean) and one rejected finding: deferring response processing until the ack is consumed. Rejected because zsh commits the `zle -F` dispatch list at the start of each select round, so the ack watcher's same-round dispatch survives as an empty no-op (~0.1 ms) regardless — measured in 100% of runs — and the response callback itself already paints from inside a multi-ms callback on `main` too; the re-audit accepted this rationale after independent code inspection.
- During verification the load-sensitive history-deadline flake documented in #48 (`h24a`/`h19a`/`h20b`) appeared twice; it predates this change and is out of scope here.
- #49 (the #47 harness hardening) is planned to rebase on top of this branch; the only overlaps are the `sync_prompt` status fix and the new driver cases.
- Gates run locally: `cargo fmt --check` / `clippy --all-targets -- -D warnings` / `build --release` / `test`, `tests/zsh/transport.zsh` (7 PASS ×3), `tests/zsh/vectors.zsh` (73), `tests/zsh/driver.zsh` (144), `tests/zsh/driver-coexist.zsh` (37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
