### PR TITLE
feat!: embed the zsh script and load it via zrush init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: cargo build (release)
         run: cargo build --release
-      - name: cargo test
-        run: cargo test
       - name: Install zsh (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y zsh
+      - name: cargo test
+        run: cargo test
       - name: zle driver
         run: zsh -f tests/zsh/driver.zsh "$(mktemp -d)"
       - name: zsh plan-decoder vectors

--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -20,8 +20,11 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 - **PROTOCOL_VERSION = 6**
 - `zrush config` の出力に `ZRUSH_PROTOCOL_VERSION` が含まれる。
-  zrush.zsh は自身が期待する版番号と照合し、不一致なら警告を 1 回表示して zrush を無効化する
-  (git pull 後の rebuild し忘れ検知)。
+  zrush.zsh は自身が期待する版番号と照合し、不一致なら警告を 1 回表示して zrush を無効化する。
+  zrush.zsh はバイナリに埋め込まれて配布される(「zrush init」節)ため、
+  読み込んだスクリプトとバイナリの版がずれることは構造的に無い。
+  この照合が検知するのは、既に起動中のシェルが rebuild 前の古いスクリプトを読み込んだままで、
+  かつ古い版の常駐 worker を保持している状況である。
 - 照合の機会を保証するため、zrush.zsh は **source 時に無条件で `zrush config` を 1 回実行**する
   (config.toml の mtime 変化だけをトリガにすると、バイナリのみ更新された場合に照合されない)。
 - 互換性が壊れる変更(フィールドの追加・削除・意味変更、キー記法の変更)で版番号を上げる。
@@ -62,7 +65,8 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 - 対話シェルごとに `zrush worker` を最大 1 プロセス常駐させ、複数のプラン要求を同じ
   stdin/stdout セッションで処理する。ワーカーは最初の実要求まで起動しない。
-  `zrush config` だけは設定の読み込みごとに one-shot で起動する。
+  `zrush config` は設定の読み込みごとに、`zrush init` はシェル起動(source)時に、
+  それぞれ one-shot で起動する。
 - 文字列はバイト列として扱い、エンコーディング変換をしない(ファイル名は任意バイト列であり得る)。
   マッチング・レイアウト計算の内部で lossy な UTF-8 解釈を行うのは構わないが、
   それはオフセット計算(文字数の数え上げ)のためだけに用いる。
@@ -78,12 +82,13 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 > 検証: `zrush worker` の in-band エラー応答 — `tests/vectors/plan/`(ランナーは `tests/vectors.rs`)。
 > `--help` の exit 0、未知サブコマンドと `zrush config` への余計な引数の exit 2 — `tests/cli.rs`。
+> `zrush init` の未指定・未知シェル・余計な引数の exit 2 — `tests/cli.rs`。
 > exit 1 と、`-h` / `help` サブコマンドを固定するテストは無い。
 
 | コード | 意味 |
 |---|---|
-| 0 | 成功。worker は frame 境界での stdin EOF、`zrush config` は設定ファイルの問題があっても既定値と警告を出力して成功する |
-| 1 | worker の session-fatal framing/I/O/内部エラー、または `zrush config` の内部エラー |
+| 0 | 成功。worker は frame 境界での stdin EOF、`zrush config` は設定ファイルの問題があっても既定値と警告を出力して成功する。`zrush init` は自身の絶対パス解決とスクリプト出力に成功する |
+| 1 | worker の session-fatal framing/I/O/内部エラー、`zrush config` の内部エラー、または `zrush init` の自身のパス解決失敗を含む内部エラー |
 | 2 | usage エラー(未知・不足・不正な引数、未知または未指定のサブコマンド) |
 
 `--help` / `-h`、および `help` サブコマンドは使用方法を表示して exit 0 する。
@@ -679,9 +684,49 @@ typeset -ga ZRUSH_CFG_WARNINGS=()
   (フック・キーバインドを登録しない。既定値表を zsh 側へ複製すると真実の二重化になるため)。
 - `zrush config` の stderr は端末に流さない(警告は `ZRUSH_CFG_WARNINGS` 経由が唯一の経路)。
 
+## zrush init
+
+> 検証: 起動パースと exit 2(未指定・未知シェル・余計な引数)、prelude 行の形とその後に続く
+> 埋め込みスクリプト本体がリポジトリの `zsh/zrush.zsh` とバイト一致すること — `tests/cli.rs`。
+> `$ZRUSH_BIN` が既に設定されている場合に prelude の `${ZRUSH_BIN:-...}` 展開が
+> それを優先して使う規範自体は通常の zsh パラメータ展開であり、`tests/cli.rs` は固定しない
+> (`tests/zsh/driver.zsh` がテスト用ランチャーを `$ZRUSH_BIN` に指定してこの経路を通しで使う)。
+
+zsh 側の `.zshrc` が source する zle 統合スクリプトを標準出力へ書き出す。
+スクリプト本体はビルド時にバイナリへ埋め込まれる。
+
+### 起動
+
+```
+zrush init zsh
+```
+
+- 受け付けるシェル値は `zsh` のみ。シェル引数の未指定・`zsh` 以外の値・余計な引数は
+  起動前に exit 2 で拒否する。
+
+### stdout
+
+1 行目は `ZRUSH_BIN` の prelude:
+
+```zsh
+typeset -g ZRUSH_BIN=${ZRUSH_BIN:-'<自身の絶対パス>'}
+```
+
+- `<自身の絶対パス>` の既定値は、この `zrush init` を実行したプロセス自身の絶対パス
+  (`current_exe` 相当)。クォート規律は「zrush config」節と同じ(`'...'` で囲み、値中の `'` を `'\''` に
+  エスケープする)。パスは非 UTF-8 バイト列であり得るため、バイト単位でクォートする。
+- 既に `$ZRUSH_BIN` が設定されている呼び出し元シェルでは、上記の zsh パラメータ展開
+  `${ZRUSH_BIN:-...}` によりその値が優先される(prelude 側は常にこの展開形で出力するのみで、
+  Rust 側で環境変数を分岐しない)。
+- 2 行目以降は、ビルド時に埋め込んだ `zsh/zrush.zsh` の内容をそのまま出力する。
+
+自身の絶対パスの解決、または標準出力への書き込みに失敗した場合は exit 1
+(`zrush config` の内部エラーと同じ扱い)。
+
 ## 想定シーケンス(参考・規範ではない)
 
-1. source 時: `zrush config` を実行して source、版番号を照合、キーバインドを適用。
+1. source 時: `.zshrc` の `source <(zrush init zsh)` が `$ZRUSH_BIN` prelude と埋め込みスクリプトを読み込む。
+   埋め込みスクリプト自身の source 時処理として `zrush config` を実行し、版番号を照合してキーバインドを適用する。
 2. プロンプト表示ごと: config.toml の mtime を確認し、変化していれば
    `zrush config` を再実行して source、キーバインドを再適用、警告があれば表示。
 3. 最初の実要求時: `zrush worker` を起動して `hello` / `ready` を交換する。

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -14,10 +14,18 @@ cd ~/path/to/zrush
 cargo build --release
 ```
 
+`target/release/zrush` を `$PATH` の通ったディレクトリに置く(シンボリックリンクでも可)。
+
 `.zshrc` に以下を追加する:
 
 ```sh
-source ~/path/to/zrush/zsh/zrush.zsh
+source <(zrush init zsh)
+```
+
+`zrush` を `$PATH` に置かない場合は、ビルドツリーの絶対パスで直接呼び出す:
+
+```sh
+source <(~/path/to/zrush/target/release/zrush init zsh)
 ```
 
 ### source の位置
@@ -27,8 +35,9 @@ source ~/path/to/zrush/zsh/zrush.zsh
 - zsh-abbr より後、zsh-syntax-highlighting より前に置く。
 - zsh-autocomplete とは併用しない(置き換え)。
 
-バイナリは zrush.zsh の位置から `../target/release/zrush` を自動解決する。
-別の場所に置く場合は `$ZRUSH_BIN` で明示する。
+`zrush init zsh` は自身の絶対パスを `$ZRUSH_BIN` として埋め込んで出力する。
+テストや特殊な配置で別のバイナリを使わせたい場合は、source する前に `$ZRUSH_BIN` を設定すれば、
+埋め込まれたパスより優先される。
 
 ## 更新
 
@@ -37,9 +46,10 @@ git pull
 cargo build --release
 ```
 
-zsh スクリプトとバイナリの版がずれると、source 時または最初の補完時に警告が出て、
-そのシェルでは zrush が無効になる。警告が出たら rebuild し、新しいシェルを起動する
-(実行中の worker は rebuild だけでは置き換わらない)。複数環境(SSH 先など)ではそれぞれの環境でビルドする。
+zsh スクリプトはバイナリに埋め込まれているため、スクリプトとバイナリの版がずれることは構造的に起きない。
+ただし既に起動中のシェルは rebuild 前の古いスクリプトと、それが起動した常駐 worker を保持し続ける。
+版番号の照合はその古い worker(または古い読み込み済みスクリプト)を検知するためのものであり、
+警告が出たら新しいシェルを起動する。複数環境(SSH 先など)ではそれぞれの環境でビルドする。
 
 ## デバッグ
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,70 @@
+//! `zrush init zsh` (cli-protocol.md "zrush init").
+//!
+//! Emits a `ZRUSH_BIN` prelude line followed by the zle-integration script,
+//! embedded into the binary at build time (`.zshrc` sources this command's
+//! output: `source <(zrush init zsh)`).
+
+/// The zle-integration script, embedded at build time.
+const ZRUSH_ZSH: &str = include_str!("../zsh/zrush.zsh");
+
+/// Single-quote a byte string for zsh source output (cli-protocol.md
+/// quoting discipline, same as `config::sq`): wrap in `'...'` and escape
+/// embedded `'` as `'\''`. Byte-level (rather than `str`-based like
+/// `config::sq`) because a binary path need not be valid UTF-8.
+fn sq_bytes(s: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len() + 2);
+    out.push(b'\'');
+    for &b in s {
+        if b == b'\'' {
+            out.extend_from_slice(b"'\\''");
+        } else {
+            out.push(b);
+        }
+    }
+    out.push(b'\'');
+    out
+}
+
+/// Build the full `zrush init zsh` stdout: the `ZRUSH_BIN` prelude line
+/// (default = `bin_path`, overridable by an already-set `$ZRUSH_BIN`)
+/// followed by the embedded script.
+pub fn zsh_output(bin_path: &[u8]) -> Vec<u8> {
+    let mut out = b"typeset -g ZRUSH_BIN=${ZRUSH_BIN:-".to_vec();
+    out.extend(sq_bytes(bin_path));
+    out.extend_from_slice(b"}\n");
+    out.extend_from_slice(ZRUSH_ZSH.as_bytes());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prelude_quotes_plain_path() {
+        let out = zsh_output(b"/opt/zrush/target/release/zrush");
+        let prelude = out.split(|&b| b == b'\n').next().unwrap();
+        assert_eq!(
+            prelude,
+            b"typeset -g ZRUSH_BIN=${ZRUSH_BIN:-'/opt/zrush/target/release/zrush'}"
+        );
+    }
+
+    #[test]
+    fn prelude_escapes_embedded_single_quote() {
+        let out = zsh_output(b"/opt/it's/zrush");
+        let prelude = out.split(|&b| b == b'\n').next().unwrap();
+        assert_eq!(
+            prelude,
+            b"typeset -g ZRUSH_BIN=${ZRUSH_BIN:-'/opt/it'\\''s/zrush'}"
+        );
+    }
+
+    #[test]
+    fn output_embeds_the_zsh_script_verbatim_after_the_prelude() {
+        let out = zsh_output(b"/bin/zrush");
+        let mut lines = out.splitn(2, |&b| b == b'\n');
+        lines.next().unwrap();
+        assert_eq!(lines.next().unwrap(), ZRUSH_ZSH.as_bytes());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Subcommands per docs/internal/contracts/cli-protocol.md (source of truth):
 //! - `zrush worker` persistently builds render plans for session requests.
 //! - `zrush config` emits zsh-sourceable settings.
+//! - `zrush init zsh` emits the embedded zle-integration script.
 //!
 //! Argument parsing uses clap's derive API. Session requests remain raw bytes:
 //! user input mid-composition and filesystem paths need not be UTF-8.
@@ -11,6 +12,7 @@
 
 mod config;
 mod framing;
+mod init;
 mod insert;
 mod keybind;
 mod layout;
@@ -23,9 +25,10 @@ mod worker;
 pub mod wire;
 
 use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 /// Exit codes per cli-protocol.md. Usage errors (invalid/missing/unknown
 /// arguments or subcommand) are exit 2, handled by clap's default error
@@ -48,6 +51,17 @@ enum Command {
     Worker,
     /// Emit zsh-sourceable settings (cli-protocol.md "zrush config").
     Config,
+    /// Emit the zsh integration script for `.zshrc` to source
+    /// (cli-protocol.md "zrush init"): `source <(zrush init zsh)`.
+    Init {
+        /// Shell to emit an integration script for. Only `zsh` is supported.
+        shell: Shell,
+    },
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Shell {
+    Zsh,
 }
 
 /// Run the command-line interface and return its process exit code.
@@ -55,6 +69,7 @@ pub fn run() -> ExitCode {
     match Cli::parse().command {
         Command::Worker => cmd_worker(),
         Command::Config => cmd_config(),
+        Command::Init { shell: Shell::Zsh } => cmd_init_zsh(),
     }
 }
 
@@ -70,6 +85,21 @@ fn cmd_config() -> ExitCode {
     let result = config::load();
     let out = config::to_zsh(&result);
     if std::io::stdout().write_all(out.as_bytes()).is_err() {
+        return ExitCode::from(EXIT_INTERNAL);
+    }
+    ExitCode::SUCCESS
+}
+
+/// Per cli-protocol.md "zrush init": the `ZRUSH_BIN` prelude defaults to
+/// this process's own path, so failing to resolve it is an internal error
+/// like `cmd_config`'s stdout-write failure.
+fn cmd_init_zsh() -> ExitCode {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return ExitCode::from(EXIT_INTERNAL),
+    };
+    let out = init::zsh_output(exe.as_os_str().as_bytes());
+    if std::io::stdout().write_all(&out).is_err() {
         return ExitCode::from(EXIT_INTERNAL);
     }
     ExitCode::SUCCESS

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -541,6 +541,80 @@ fn config_rejects_arguments_with_exit_2() {
     assert_eq!(out.status.code(), Some(2));
 }
 
+// ---- zrush init ----
+
+/// Independent copy of the byte-level quoting discipline (cli-protocol.md
+/// "zrush init" / "zrush config") for cross-checking the real process's
+/// output, matching the golden-copy pattern used for "zrush config" below.
+fn sq_bytes(s: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len() + 2);
+    out.push(b'\'');
+    for &b in s {
+        if b == b'\'' {
+            out.extend_from_slice(b"'\\''");
+        } else {
+            out.push(b);
+        }
+    }
+    out.push(b'\'');
+    out
+}
+
+#[test]
+fn init_zsh_prelude_and_body_match_binary_and_source() {
+    let bin = env!("CARGO_BIN_EXE_zrush");
+    let out = zrush()
+        .args(["init", "zsh"])
+        .output()
+        .expect("run zrush init zsh");
+    assert_eq!(out.status.code(), Some(0));
+
+    let mut expected = b"typeset -g ZRUSH_BIN=${ZRUSH_BIN:-".to_vec();
+    expected.extend(sq_bytes(bin.as_bytes()));
+    expected.extend_from_slice(b"}\n");
+    let script =
+        std::fs::read(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("zsh/zrush.zsh"))
+            .expect("read zsh/zrush.zsh");
+    expected.extend_from_slice(&script);
+    assert_eq!(out.stdout, expected);
+}
+
+#[test]
+fn init_zsh_output_parses_as_zsh() {
+    let out = zrush()
+        .args(["init", "zsh"])
+        .output()
+        .expect("run zrush init zsh");
+    assert_eq!(out.status.code(), Some(0));
+
+    let path = std::env::temp_dir().join(format!("zrush-init-it-{}.zsh", std::process::id()));
+    std::fs::write(&path, &out.stdout).expect("write init output");
+    let check = Command::new("zsh")
+        .arg("-fn")
+        .arg(&path)
+        .output()
+        .expect("run zsh -fn (zsh is a test prerequisite)");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        check.status.success(),
+        "zsh -fn rejected init output: {}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+}
+
+#[test]
+fn init_missing_or_unknown_shell_or_extra_args_exit_2() {
+    let cases: [&[&str]; 3] = [&["init"], &["init", "bash"], &["init", "zsh", "extra"]];
+    for args in cases {
+        let out = zrush()
+            .args(args)
+            .stderr(Stdio::null())
+            .output()
+            .expect("run");
+        assert_eq!(out.status.code(), Some(2), "{args:?}");
+    }
+}
+
 #[test]
 fn help_flag_exits_0() {
     // Human-facing affordance (cli-protocol.md "終了コード"): zsh never

--- a/tests/zsh/driver-coexist.zsh
+++ b/tests/zsh/driver-coexist.zsh
@@ -44,6 +44,7 @@ if [[ ! -r $ABBR_SRC || ! -r $ZSYH_SRC || ! -x $TMUX_BIN ]]; then
   exit 0
 fi
 [[ -x $REPO/target/release/zrush ]] || { print -u2 "FATAL: zrush binary not found"; exit 1 }
+[[ $REPO/zsh/zrush.zsh -nt $REPO/target/release/zrush ]] && { print -u2 "FATAL: zsh/zrush.zsh is newer than the built binary; run cargo build --release"; exit 1 }
 
 # The memo=zrush region_highlight tag (used to distinguish this plugin's own
 # entries from z-sy-h's) only exists on zsh 5.9+; the coexistence check below
@@ -70,7 +71,7 @@ export TERM=xterm-256color
 export LC_ALL=en_US.UTF-8
 export HOME=$PLAYGROUND
 export XDG_CONFIG_HOME=$WORK/xdg
-export ZRUSH_REPO=$REPO
+export ZRUSH_REAL_BIN=$REPO/target/release/zrush
 mkdir -p $WORK/xdg
 
 # Idempotent fixtures for full-width and resize checks
@@ -142,12 +143,12 @@ export ABBR_USER_ABBREVIATIONS_FILE=\$ZRUSH_TEST_TMP/abbr-user
 touch \$ABBR_USER_ABBREVIATIONS_FILE
 source $ABBR_SRC
 abbr -S zzz='print ABBR-EXPANDED-OK' >/dev/null
-source $REPO/zsh/zrush.zsh
+source <($REPO/target/release/zrush init zsh)
 $DUMPW
 print MARK-RC-DONE")
 
 typeset -g ZDOT_ZSYH=$(mk_zdot zsyh "$RC_COMMON
-source $REPO/zsh/zrush.zsh
+source <($REPO/target/release/zrush init zsh)
 $DUMPW
 source $ZSYH_SRC
 print MARK-RC-DONE")
@@ -157,7 +158,7 @@ export ABBR_USER_ABBREVIATIONS_FILE=\$ZRUSH_TEST_TMP/abbr-user
 touch \$ABBR_USER_ABBREVIATIONS_FILE
 source $ABBR_SRC
 abbr -S zzz='print ABBR-EXPANDED-OK' >/dev/null
-source $REPO/zsh/zrush.zsh
+source <($REPO/target/release/zrush init zsh)
 $DUMPW
 source $ZSYH_SRC
 print MARK-RC-DONE")
@@ -364,7 +365,7 @@ basic_flow() {  # $1=label prefix
     # Re-source while z-sy-h owns wrappers above zrush. The transport and
     # zrush registrations are rebuilt, but third-party wrappers/predecessors
     # must remain in the chain.
-    send_line "source $REPO/zsh/zrush.zsh"
+    send_line "source <($REPO/target/release/zrush init zsh)"
     sync_prompt
     send_keys 'qqqqxx'
     if expect '*'$'\e''\[31m*' 8; then
@@ -481,7 +482,7 @@ basic_flow() {  # $1=label prefix
   local TLOG=$WORK/tmux.log
   local TMERR=$WORK/tmux-start.err
   tm new-session -d -s coex -x 100 -y 30 \
-    "ZDOTDIR=$ZDOT_MIN XDG_CONFIG_HOME=$WORK/xdg HOME=$PLAYGROUND ZRUSH_REPO=$REPO ZRUSH_TEST_TMP=$WORK/t-tmux ZRUSH_LOG=$TLOG exec zsh -d -i" 2>$TMERR
+    "ZDOTDIR=$ZDOT_MIN XDG_CONFIG_HOME=$WORK/xdg HOME=$PLAYGROUND ZRUSH_REAL_BIN=$REPO/target/release/zrush ZRUSH_TEST_TMP=$WORK/t-tmux ZRUSH_LOG=$TLOG exec zsh -d -i" 2>$TMERR
   if tm_wait '*HP>*' 15; then
     ok "(4) host started inside tmux (TERM=$(tm display-message -p -t coex '#{client_termname}' 2>/dev/null || print '?'))"
     tm send-keys -t coex -l ' print -r -- TERM-INSIDE-$TERM'

--- a/tests/zsh/driver-latency.zsh
+++ b/tests/zsh/driver-latency.zsh
@@ -40,6 +40,7 @@ typeset -g REPO=${HERE:h:h}
 typeset -g PLAYGROUND=${1:?usage: driver-latency.zsh <playground-dir>}
 [[ -d $PLAYGROUND/docs ]] || { print -u2 "FATAL: invalid playground: $PLAYGROUND"; exit 1 }
 [[ -x $REPO/target/release/zrush ]] || { print -u2 "FATAL: zrush binary not found"; exit 1 }
+[[ $REPO/zsh/zrush.zsh -nt $REPO/target/release/zrush ]] && { print -u2 "FATAL: zsh/zrush.zsh is newer than the built binary; run cargo build --release"; exit 1 }
 typeset -g ZAC_SRC=~/.zsh/zsh-autocomplete/zsh-autocomplete.plugin.zsh
 
 typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-lat.XXXXXX)
@@ -228,7 +229,7 @@ EOF
 
 start_min_zrush() {  # $1=host label $2=XDG directory with configuration
   HOST=$1 HOSTLOG=$WORK/$1.log CURXDG=$2
-  export ZRUSH_REPO=$REPO ZRUSH_TEST_TMP=$WORK/t-$1 ZDOTDIR=$WORK/zdot-$1
+  export ZRUSH_REAL_BIN=$REPO/target/release/zrush ZRUSH_TEST_TMP=$WORK/t-$1 ZDOTDIR=$WORK/zdot-$1
   export XDG_CONFIG_HOME=$2 ZRUSH_LOG=$HOSTLOG
   mkdir -p $ZDOTDIR $ZRUSH_TEST_TMP $2/zrush
   print "source $REPO/tests/zsh/rc/minimal.zshrc" > $ZDOTDIR/.zshrc
@@ -291,7 +292,7 @@ stop_host() { zpty -d $HOST 2>/dev/null; HOSTFD=-1 }
 # (config-schema.md "[history]", max 20000).
 start_hist_latency() {  # $1=host label $2=N fixture entries $3=long(0/1) [$4=history.limit override]
   HOST=$1 HOSTLOG=$WORK/$1.log CURXDG=$WORK/xdg-$1
-  export ZRUSH_REPO=$REPO ZRUSH_TEST_TMP=$WORK/t-$1 ZDOTDIR=$WORK/zdot-$1
+  export ZRUSH_REAL_BIN=$REPO/target/release/zrush ZRUSH_TEST_TMP=$WORK/t-$1 ZDOTDIR=$WORK/zdot-$1
   export XDG_CONFIG_HOME=$CURXDG ZRUSH_LOG=$HOSTLOG
   export ZRUSH_HIST_N=$2 ZRUSH_HIST_LONG=$3
   mkdir -p $ZDOTDIR $ZRUSH_TEST_TMP $CURXDG/zrush

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -37,6 +37,7 @@ typeset -g REPO=${HERE:h:h}
 typeset -g PLAYGROUND=${1:?usage: driver.zsh <playground-dir>}
 [[ -d $PLAYGROUND ]] || { print -u2 "FATAL: invalid playground: $PLAYGROUND"; exit 1 }
 [[ -x $REPO/target/release/zrush ]] || { print -u2 "FATAL: zrush binary not found (cargo build --release)"; exit 1 }
+[[ $REPO/zsh/zrush.zsh -nt $REPO/target/release/zrush ]] && { print -u2 "FATAL: zsh/zrush.zsh is newer than the built binary; run cargo build --release"; exit 1 }
 
 typeset -gi PASS=0 FAIL=0
 out() { print -r -u2 -- "$@" }
@@ -51,7 +52,6 @@ export TERM=vt100
 unset EDITOR VISUAL
 export LC_ALL=en_US.UTF-8   # match POSTDISPLAY printability checks to real UTF-8 use
 export HOME=$PLAYGROUND     # isolated; never the real home
-export ZRUSH_REPO=$REPO
 export ZRUSH_TEST_TMP=$WORK
 export ZDOTDIR=$WORK/zdot
 export XDG_CONFIG_HOME=$WORK/xdg   # no config.toml is written: every test runs on defaults
@@ -369,7 +369,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   fi
 
   local -i seq_before_resource=${${worker_after_successive#*seq=}%% *}
-  send_line "source $REPO/zsh/zrush.zsh"
+  send_line "source <($ZRUSH_REAL_BIN init zsh)"
   sync_prompt
   if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == "pid=-1 ready=0 seq=$seq_before_resource "* && $REPLY == *'rfd=-1 wfd=-1 ack=-1 pending=0' ]]; then
     ok "(worker-1d) re-source tears down transport while preserving the request counter"

--- a/tests/zsh/rc/history-latency.zshrc
+++ b/tests/zsh/rc/history-latency.zshrc
@@ -1,5 +1,5 @@
 # Host rc for the history-menu latency cases in tests/zsh/driver-latency.zsh.
-# Required environment: ZRUSH_REPO, ZRUSH_TEST_TMP, and:
+# Required environment: ZRUSH_REAL_BIN, ZRUSH_TEST_TMP, and:
 #   ZRUSH_HIST_N     number of fixture history entries to generate (default 5000)
 #   ZRUSH_HIST_LONG  1 = pad each entry to a long single line; 0 = short entries
 # Isolated HISTFILE + SAVEHIST=0, same as tests/zsh/rc/history.zshrc.
@@ -11,7 +11,7 @@ HISTSIZE=$(( _zrt_n + 100 ))
 SAVEHIST=0
 autoload -Uz compinit
 compinit -u -d ${ZRUSH_TEST_TMP:-${TMPDIR:-/tmp}}/zcompdump-zrush-histlat
-source $ZRUSH_REPO/zsh/zrush.zsh
+source <($ZRUSH_REAL_BIN init zsh)
 
 # Bulk-generate fixture history rather than writing thousands of literal
 # print -s lines; behavior.md "履歴メニュー" measures against realistic

--- a/tests/zsh/rc/history-limit.zshrc
+++ b/tests/zsh/rc/history-limit.zshrc
@@ -3,14 +3,14 @@
 # small, deliberately ordered fixture set so the newest-N-raw-entries scan
 # window (config's [history].limit, written to this host's own
 # XDG_CONFIG_HOME/zrush/config.toml by the driver) is easy to reason about
-# exactly. Required environment: ZRUSH_REPO, ZRUSH_TEST_TMP.
+# exactly. Required environment: ZRUSH_REAL_BIN, ZRUSH_TEST_TMP.
 PS1='HP> '
 HISTFILE=$ZRUSH_TEST_TMP/histfile-hist-limit
 HISTSIZE=1000
 SAVEHIST=0
 autoload -Uz compinit
 compinit -u -d ${ZRUSH_TEST_TMP:-${TMPDIR:-/tmp}}/zcompdump-zrush-histlimit
-source $ZRUSH_REPO/zsh/zrush.zsh
+source <($ZRUSH_REAL_BIN init zsh)
 
 _zrt_dump_postdisplay() { _zlog "TESTPOST=${(qqqq)POSTDISPLAY}" }
 zle -N _zrt-dump-postdisplay _zrt_dump_postdisplay

--- a/tests/zsh/rc/history.zshrc
+++ b/tests/zsh/rc/history.zshrc
@@ -1,7 +1,7 @@
 # Host rc for the headless history-menu regression scenarios in
 # tests/zsh/driver.zsh (issue #9: docs/internal/specs/behavior.md "履歴メニュー",
 # docs/internal/contracts/cli-protocol.md "history profile").
-# Required environment: ZRUSH_REPO, ZRUSH_TEST_TMP (see tests/zsh/rc/minimal.zshrc).
+# Required environment: ZRUSH_REAL_BIN, ZRUSH_TEST_TMP (see tests/zsh/rc/minimal.zshrc).
 # Isolated HISTFILE + SAVEHIST=0: the fixture history below lives only in this
 # throwaway shell's memory and is never written out or read back from the
 # real ~/.zsh_history (AGENTS.md guardrail).
@@ -11,7 +11,7 @@ HISTSIZE=1000
 SAVEHIST=0
 autoload -Uz compinit
 compinit -u -d ${ZRUSH_TEST_TMP:-${TMPDIR:-/tmp}}/zcompdump-zrush-histtest
-source $ZRUSH_REPO/zsh/zrush.zsh
+source <($ZRUSH_REAL_BIN init zsh)
 
 # Test-only dump widgets (see tests/zsh/rc/minimal.zshrc for the ^Xb/^Xp precedent).
 _zrt_dump_buffer() { _zlog "TESTBUF=${(qqqq)BUFFER}" }

--- a/tests/zsh/rc/minimal.zshrc
+++ b/tests/zsh/rc/minimal.zshrc
@@ -1,9 +1,9 @@
 # Host rc for headless regression tests, loaded by tests/zsh/driver.zsh through ZDOTDIR
-# Required environment: ZRUSH_REPO (repository root), ZRUSH_TEST_TMP (isolated tmp)
+# Required environment: ZRUSH_REAL_BIN (built zrush binary), ZRUSH_TEST_TMP (isolated tmp)
 PS1='HP> '
 autoload -Uz compinit
 compinit -u -d ${ZRUSH_TEST_TMP:-${TMPDIR:-/tmp}}/zcompdump-zrush-test
-source $ZRUSH_REPO/zsh/zrush.zsh
+source <($ZRUSH_REAL_BIN init zsh)
 
 # Test-only dump widgets that write internal state to ZRUSH_LOG so drivers can
 # assert on it precisely. Not production code.

--- a/zsh/verify.zsh
+++ b/zsh/verify.zsh
@@ -3,9 +3,11 @@
 #
 # Usage:
 #   zsh -f zsh/verify.zsh [working-directory]
+#   Prerequisite: cargo build --release completed.
 #
 # This never touches the user's ~/.zshrc, history, or config. It starts an interactive
-# shell with only compinit and zrush.zsh under an isolated ZDOTDIR.
+# shell with only compinit and the embedded zrush script (via `zrush init zsh`)
+# under an isolated ZDOTDIR.
 #   - To test configuration, write zrush/config.toml below the printed
 #     $XDG_CONFIG_HOME; changes apply at the next prompt.
 #   - For debug traces, set ZRUSH_LOG=<file> before launch.
@@ -13,6 +15,9 @@
 emulate -L zsh
 
 local here=${${(%):-%N}:A:h}
+local bin=$here/../target/release/zrush
+[[ -x $bin ]] || { print -u2 "FATAL: zrush binary not found (cargo build --release)"; exit 1 }
+[[ $here/zrush.zsh -nt $bin ]] && { print -u2 "FATAL: zsh/zrush.zsh is newer than the built binary; run cargo build --release"; exit 1 }
 local work=$(mktemp -d ${TMPDIR:-/tmp}/zrush-verify.XXXXXX)
 mkdir -p $work/zdot $work/xdg
 
@@ -22,7 +27,7 @@ print -r -- "  config changes in $work/xdg/zrush/config.toml are applied automat
 cat > $work/zdot/.zshrc <<EOF
 autoload -Uz compinit
 compinit -u -d $work/zcompdump
-source $here/zrush.zsh
+source <($bin init zsh)
 PS1='zrush-verify %1~ %# '
 EOF
 

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -1,7 +1,9 @@
 # zrush.zsh — ZLE integration for asynchronous completion
 #
 # Requirements: zsh 5.8+, source after compinit, after zsh-abbr, and before
-# zsh-syntax-highlighting. $ZRUSH_BIN overrides ../target/release/zrush.
+# zsh-syntax-highlighting. This file is embedded into the `zrush` binary and
+# loaded via `source <(zrush init zsh)` (cli-protocol.md "zrush init"), which
+# injects $ZRUSH_BIN ahead of this file; an already-set $ZRUSH_BIN overrides it.
 #
 # zsh captures compsys candidates in a forked shell and hands the raw
 # capture stream to the persistent Rust worker, which performs matching,
@@ -14,9 +16,6 @@
 # See docs/internal/contracts/cli-protocol.md for the zsh/Rust boundary.
 #
 # Set ZRUSH_LOG=<file> to append timestamped debug traces; unset is a no-op.
-
-# Capture the source directory; re-sourcing is allowed and reinitializes state.
-typeset -g _zrush_source_dir=${${(%):-%N}:A:h}
 
 # ---------------------------------------------------------------- Re-source teardown
 # This runs while the previous definitions and ledgers are still available.
@@ -52,7 +51,7 @@ if (( ${_zrush_installed:-0} || ( ${+_zrush_bound} && $#_zrush_bound ) )); then
 fi
 
 # ---------------------------------------------------------------- Global state
-typeset -g  ZRUSH_BIN=${ZRUSH_BIN:-$_zrush_source_dir/../target/release/zrush}
+typeset -g  ZRUSH_BIN=${ZRUSH_BIN:-}
 typeset -gi _zrush_enabled=0
 typeset -gi _ZRUSH_EXPECTED_PROTO=6
 typeset -g  _zrush_cfg_path= _zrush_cfg_mtime=
@@ -2074,7 +2073,7 @@ _zrush_init() {
   emulate -L zsh
 
   if [[ ! -x $ZRUSH_BIN ]]; then
-    _zrush_warn "binary not found or not executable: $ZRUSH_BIN (set \$ZRUSH_BIN or run 'cargo build --release'); zrush disabled"
+    _zrush_warn "binary not found or not executable: $ZRUSH_BIN (load via 'source <(zrush init zsh)' or set \$ZRUSH_BIN); zrush disabled"
     return 1
   fi
 


### PR DESCRIPTION
Closes #58.

zsh スクリプトとバイナリを別ファイルとして配布する現行の形を廃し、`zsh/zrush.zsh` を `include_str!` でバイナリに埋め込んで新設の `zrush init zsh` サブコマンドで標準出力へ書き出す。
`.zshrc` の統合は `source <(zrush init zsh)` の 1 行になり、配布物はバイナリ 1 個で完結する(理由と設計判断の詳細は #58 本文とコメント)。

## 変更点

- **Rust**: `init` サブコマンド新設(`src/init.rs`)。出力は `typeset -g ZRUSH_BIN=${ZRUSH_BIN:-'<自身の絶対パス>'}` の prelude + 埋め込みスクリプト本体。クォートは `zrush config` と同じ単引用符規律(非 UTF-8 パス対応のためバイト単位)。
- **zsh**: `_zrush_source_dir` と `../target/release/zrush` の相対解決を削除。直接 source した場合は `ZRUSH_BIN` が空になり、既存の実行可能性チェックが警告して無効化する。
- **ロード経路の一本化**: テストドライバの rc・re-source テスト・`zsh/verify.zsh` もすべて init 経由に変更。`$ZRUSH_BIN` の env 上書きは存続するため、fake ランチャーの差し込み(`tests/zsh/fake-worker.py`)は無変更で機能する。
- **鮮度ガード**: `driver*.zsh` と `verify.zsh` の冒頭に「`zsh/zrush.zsh` がバイナリより新しければ FATAL」を追加(リビルド忘れで古い埋め込みが動く事故の検出)。
- **CI**: `tests/cli.rs` が `zsh -fn` によるパース検証を行うため、zsh のインストールを `cargo test` より前へ移動。
- **docs**: `install.md` を PATH 前提の `source <(zrush init zsh)` 主体に書き換え。`cli-protocol.md` に `zrush init` 節を追加し、終了コード表・one-shot 記述・プロトコル版チェックの役割(rebuild 後の stale worker 検知)を追従。
- プロトコル版は据え置き(ワイヤ形式に変更なし)。

## 検証

- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --release` / `cargo test`(195 + 21 + 3)all green
- `tests/zsh/driver.zsh` PASS=144 / `driver-coexist.zsh` PASS=37 / `vectors.zsh` PASS=73 / `transport.zsh` PASS=7、すべて FAIL=0(macOS 15 / zsh 5.9 ローカル)
- 変異検査: `zsh/zrush.zsh` の touch で鮮度ガード 4 本が発火すること、init 出力の破壊で `tests/cli.rs` のバイト一致テストと `zsh -fn` パーステストが実際に落ちることを確認

## レビュー時の注意

- `.zshrc` に書く行が変わるユーザー可視の破壊的変更(`feat!`)。マージ後は各環境で rebuild と `.zshrc` の統合行の更新が必要。
- `tests/zsh/vectors.zsh` / `transport.zsh` は `ZRUSH_NO_INIT=1` でリポジトリのファイルを直接 source する形を維持(バイナリに触れない関数単体のテストシームのため)。
- `zrush.zsh` の複数ファイル分割(#21)は本 PR の対象外。分割時の結合方式は #21 側で決める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
