### PR TITLE
refactor: type char-offset spans as end-exclusive ranges

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -6,13 +6,13 @@
 //! module owns grouping, the column-major grid, cell truncation/padding,
 //! and every offset computed against the listing text; it does not know
 //! about matching -- match spans (char offsets over a candidate's
-//! match-text, from matching::QueryMatcher::spans) are supplied by the
-//! caller and only get clipped/repositioned here. The caller also supplies
-//! the producer-selected layout style defined by the same contract.
+//! match-text) are supplied by the caller and only get clipped/
+//! repositioned here. The caller also supplies the producer-selected
+//! layout style defined by the same contract.
 //!
 //! Mixing char counts and display widths is a recurring source of offset
 //! bugs, which is why the contract spells out the split explicitly:
-//! highlight/cell-range `start`/`len` are always char counts over the
+//! every char interval this module computes is a [`CharSpan`] over the
 //! lossy-UTF-8 reading of the listing text, while cell padding/truncation
 //! is always display width (unicode-width). The two are computed from the
 //! same lossy decoding pass (`lossy_chars`) so they can never drift apart
@@ -24,6 +24,7 @@ use std::ops::Range;
 use unicode_width::UnicodeWidthChar;
 
 use crate::record::{Batch, Candidate};
+use crate::span::CharSpan;
 
 /// Column cap and gutter width: Rust-internal constants, not part of the
 /// protocol (cli-protocol.md "列数").
@@ -70,14 +71,14 @@ impl Role {
     }
 }
 
-/// One "role pos start len" render-plan entry. `start`/`len` are char offsets
-/// over the full listing text (rows joined by `\n`, no leading newline).
+/// One "role pos start len" render-plan entry. `span` is a char range
+/// over the full listing text (rows joined by `\n`, no leading newline);
+/// plan.rs's serializer turns it into the wire's `start len`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Highlight {
     pub role: Role,
     pub pos: usize,
-    pub start: usize,
-    pub len: usize,
+    pub span: CharSpan,
 }
 
 /// One "next prev left right" render-plan entry, absolute position numbers
@@ -99,9 +100,9 @@ pub(crate) struct Plan {
     pub rows: Vec<Vec<u8>>,
     /// H highlight entries.
     pub highlights: Vec<Highlight>,
-    /// P entries: (start, len) char range of the position's real (post-
-    /// truncation, pre-padding) cell text within the listing text.
-    pub cell_ranges: Vec<(usize, usize)>,
+    /// P entries: char range of the position's real (post-truncation,
+    /// pre-padding) cell text within the listing text.
+    pub cell_ranges: Vec<CharSpan>,
     /// P entries: navigation targets.
     pub nav: Vec<Nav>,
     /// P entries: index into the `candidates` slice passed to `build`,
@@ -113,16 +114,16 @@ pub(crate) struct Plan {
 ///
 /// `candidates` must already be in rank order (matching.rs + ranking.rs);
 /// this module does not re-sort. `spans[i]` are `matching::QueryMatcher::
-/// spans()`'s (start, end) 0-based end-exclusive char ranges (NOT
-/// (start, len)) over `candidates[i].match_text()`, aligned by index; a
-/// missing or empty entry means no match decoration for that candidate.
+/// spans()`'s char ranges over `candidates[i].match_text()`, aligned by
+/// index; a missing or empty entry means no match decoration for that
+/// candidate.
 /// `row_budget`/`width` are `--rows`/`--width` (cli-protocol.md
 /// "起動"), assumed >= 1 by the caller but handled gracefully at 0 too.
 /// `style` is the producer-specific geometry from the contract.
 pub(crate) fn build(
     candidates: &[Candidate<'_>],
     batches: &[Batch<'_>],
-    spans: &[Vec<(usize, usize)>],
+    spans: &[Vec<CharSpan>],
     row_budget: usize,
     width: usize,
     style: Style,
@@ -176,7 +177,7 @@ pub(crate) fn build(
     // both char offsets within the composed source. The history profile
     // guarantees ASCII digits, padding and delimiter, so their byte and char
     // lengths coincide.
-    let mut number_ranges: Vec<Option<(usize, usize)>> = Vec::with_capacity(candidates.len());
+    let mut number_ranges: Vec<Option<CharSpan>> = Vec::with_capacity(candidates.len());
     let mut match_offsets: Vec<usize> = Vec::with_capacity(candidates.len());
     let sources: Vec<Vec<u8>> = candidates
         .iter()
@@ -194,7 +195,7 @@ pub(crate) fn build(
             source.extend_from_slice(number);
             source.extend_from_slice(b"  ");
             source.extend_from_slice(&base);
-            number_ranges.push(Some((pad, number.len())));
+            number_ranges.push(Some(CharSpan::new(pad, pad + number.len())));
             match_offsets.push(width + 2);
             source
         })
@@ -349,47 +350,45 @@ pub(crate) fn build(
             highlights.push(Highlight {
                 role: Role::Heading,
                 pos: 0,
-                start: row_start[h.row],
-                len: h.len,
+                span: CharSpan::new(row_start[h.row], row_start[h.row] + h.len),
             });
         }
     }
-    let mut cell_ranges = vec![(0usize, 0usize); positions.len()];
+    let mut cell_ranges = vec![CharSpan::default(); positions.len()];
     for cm in &cell_marks {
+        // Cell-local char spans become listing-wide ones by shifting past
+        // everything before the cell; both are clipped to the cell's real
+        // (post-truncation) content first.
         let start = row_start[cm.row] + cm.in_row_start;
-        cell_ranges[cm.pos - 1] = (start, cm.content_chars);
-        if let Some(&(number_start, number_len)) = number_ranges[cm.candidate].as_ref() {
-            let ns = number_start.min(cm.content_chars);
-            let ne = (number_start + number_len).min(cm.content_chars);
-            if ne > ns {
+        cell_ranges[cm.pos - 1] = CharSpan::new(start, start + cm.content_chars);
+        if let Some(number) = number_ranges[cm.candidate] {
+            let span = number.clip(cm.content_chars).shift(start);
+            if !span.is_empty() {
                 highlights.push(Highlight {
                     role: Role::HistoryNumber,
                     pos: cm.pos,
-                    start: start + ns,
-                    len: ne - ns,
+                    span,
                 });
             }
         }
         // Match decoration only on cells showing match-text verbatim
-        // (contract: "display-text 表示セルには発行されない").
+        // (contract: "display-text 表示セルには発行されない"). The
+        // candidate's spans index its match-text, which starts after the
+        // history-number prefix when present.
         if candidates[cm.candidate].d.is_none()
             && let Some(cand_spans) = spans.get(cm.candidate)
         {
-            // matching.rs `spans()`: (start, end), 0-based end-exclusive
-            // char range -- NOT (start, len). Clip both ends to the
-            // visible command-text char count, after the history-number
-            // prefix when present.
             let match_offset = match_offsets[cm.candidate];
             let visible_match_chars = cm.content_chars.saturating_sub(match_offset);
-            for &(s, e) in cand_spans {
-                let cs = s.min(visible_match_chars);
-                let ce = e.min(visible_match_chars);
-                if ce > cs {
+            for &cand_span in cand_spans {
+                let span = cand_span
+                    .clip(visible_match_chars)
+                    .shift(start + match_offset);
+                if !span.is_empty() {
                     highlights.push(Highlight {
                         role: Role::Match,
                         pos: cm.pos,
-                        start: start + match_offset + cs,
-                        len: ce - cs,
+                        span,
                     });
                 }
             }
@@ -626,7 +625,7 @@ mod tests {
     fn build(
         candidates: &[Candidate<'_>],
         batches: &[Batch<'_>],
-        spans: &[Vec<(usize, usize)>],
+        spans: &[Vec<CharSpan>],
         row_budget: usize,
         width: usize,
     ) -> Plan {
@@ -715,8 +714,13 @@ mod tests {
         assert_eq!((cols, grows, gcount), (1, 5, 5));
     }
 
-    fn spans_none(n: usize) -> Vec<Vec<(usize, usize)>> {
+    fn spans_none(n: usize) -> Vec<Vec<CharSpan>> {
         vec![Vec::new(); n]
+    }
+
+    /// A `[start, end)` char range, the shape every offset in a plan has.
+    fn span(start: usize, end: usize) -> CharSpan {
+        CharSpan::new(start, end)
     }
 
     // ---- grouping ----
@@ -779,7 +783,7 @@ mod tests {
             .unwrap();
         // Offset is char count (2), not display width (4) -- same
         // char/width split as cell offsets.
-        assert_eq!((h.start, h.len), (0, 2));
+        assert_eq!(h.span, span(0, 2));
     }
 
     // ---- budget: heading omission and group drop ----
@@ -834,9 +838,9 @@ mod tests {
         // Row 1: "ab" padded to width 6 -> "ab" + 4 spaces.
         assert_eq!(plan.rows[1], b"ab    ");
         // Cell range length is CHAR count (3), not display width (6).
-        assert_eq!(plan.cell_ranges[0], (0, 3));
+        assert_eq!(plan.cell_ranges[0], span(0, 3));
         // Row 1 starts after "日本語" (3 chars) + 1 newline = char offset 4.
-        assert_eq!(plan.cell_ranges[1], (4, 2));
+        assert_eq!(plan.cell_ranges[1], span(4, 6));
     }
 
     #[test]
@@ -868,10 +872,10 @@ mod tests {
         assert_eq!(
             plan.cell_ranges,
             vec![
-                (4, 1),  // 日: row2, col1
-                (9, 1),  // 本: row3, col1
-                (7, 1),  // 語: row2, col2 (after "日  ")
-                (12, 1), // 字: row3, col2 (after "本  ")
+                span(4, 5),   // 日: row2, col1
+                span(9, 10),  // 本: row3, col1
+                span(7, 8),   // 語: row2, col2 (after "日  ")
+                span(12, 13), // 字: row3, col2 (after "本  ")
             ]
         );
     }
@@ -925,7 +929,7 @@ mod tests {
         assert_eq!(plan.rows[0], raw); // bytes preserved verbatim, never re-encoded
         // "a", "b", one replacement char for all 3 trailing bytes = 3
         // chars -- not 5 (if each trailing byte were its own U+FFFD).
-        assert_eq!(plan.cell_ranges[0], (0, 3));
+        assert_eq!(plan.cell_ranges[0], span(0, 3));
     }
 
     // ---- highlight span clipping ----
@@ -934,10 +938,9 @@ mod tests {
     fn match_span_is_clipped_to_truncated_cell() {
         let batches = [batch(b"", b"")];
         let cands = [cand(b"abcdef", None, None, 0)];
-        // matching::spans() tuples are (start, end), 0-based
-        // end-exclusive -- chars [1,5) = "bcde", reaching past the
-        // truncation point (width budget 3).
-        let spans = vec![vec![(1usize, 5usize)]];
+        // chars [1,5) = "bcde", reaching past the truncation point
+        // (width budget 3).
+        let spans = vec![vec![span(1, 5)]];
         let plan = build(&cands, &batches, &spans, 10, 3);
         assert_eq!(plan.rows[0], b"abc");
         let m = plan
@@ -946,22 +949,24 @@ mod tests {
             .find(|h| h.role == Role::Match)
             .unwrap();
         // Clipped to the 3 retained chars: [1,3) = "bc".
-        assert_eq!((m.start, m.len), (1, 2));
+        assert_eq!(m.span, span(1, 3));
     }
 
     #[test]
     fn match_span_uses_end_exclusive_semantics_not_start_len() {
-        // Regression: layout.rs once misread matching::spans()'s (start,
-        // end) tuples as (start, len), which happened to be
-        // indistinguishable whenever start == 0. "cargo" matched by "g"
-        // (substring, found at char index 3) produces the real span
-        // matching.rs::spans() would emit: (3, 4) = chars [3,4) = "g"
-        // alone, i.e. len 1 -- not len 4 (mistaken as start=3,len=4) and
-        // not len 2 (the bug actually observed: end misread as start+len
-        // saturating past the candidate).
+        // Regression: layout.rs once misread matching::spans()'s
+        // end-exclusive ranges as (start, len), which happened to be
+        // indistinguishable whenever start == 0. CharSpan now makes that
+        // misreading unspellable, and this pins the arithmetic that
+        // survives it. "cargo" matched by "g" (substring, found at char
+        // index 3) produces the real span matching.rs::spans() would
+        // emit: chars [3,4) = "g" alone, i.e. wire len 1 -- not len 4
+        // (mistaken as start=3,len=4) and not len 2 (the bug actually
+        // observed: end misread as start+len saturating past the
+        // candidate).
         let batches = [batch(b"", b"")];
         let cands = [cand(b"cargo", None, None, 0)];
-        let spans = vec![vec![(3usize, 4usize)]];
+        let spans = vec![vec![span(3, 4)]];
         let plan = build(&cands, &batches, &spans, 10, 40); // no truncation
         assert_eq!(plan.rows[0], b"cargo");
         let m = plan
@@ -969,7 +974,8 @@ mod tests {
             .iter()
             .find(|h| h.role == Role::Match)
             .unwrap();
-        assert_eq!((m.start, m.len), (3, 1));
+        assert_eq!(m.span, span(3, 4));
+        assert_eq!(m.span.len(), 1); // the wire's `len` field
     }
 
     #[test]
@@ -978,7 +984,7 @@ mod tests {
         let cands = [cand(b"raw", None, Some(b"shown"), 0)];
         // Non-zero start: a d-tag cell must suppress match decoration
         // regardless of what the (otherwise unused) span would resolve to.
-        let spans = vec![vec![(1usize, 3usize)]];
+        let spans = vec![vec![span(1, 3)]];
         let plan = build(&cands, &batches, &spans, 10, 40);
         assert_eq!(plan.rows[0], b"shown");
         assert!(plan.highlights.iter().all(|h| h.role != Role::Match));
@@ -992,7 +998,7 @@ mod tests {
             history_cand(b"two", b"123"),
             history_cand(b"three", b"123456"),
         ];
-        let spans = vec![Vec::new(), vec![(1, 3)], Vec::new()];
+        let spans = vec![Vec::new(), vec![span(1, 3)], Vec::new()];
         let plan = build(&cands, &batches, &spans, 10, 13);
         assert_eq!(
             plan.rows,
@@ -1002,21 +1008,27 @@ mod tests {
                 b"123456  three".to_vec(),
             ]
         );
-        assert_eq!(plan.cell_ranges, vec![(0, 11), (14, 11), (28, 13)]);
+        assert_eq!(
+            plan.cell_ranges,
+            vec![span(0, 11), span(14, 25), span(28, 41)]
+        );
         let numbers: Vec<_> = plan
             .highlights
             .iter()
             .filter(|h| h.role == Role::HistoryNumber)
-            .map(|h| (h.pos, h.start, h.len))
+            .map(|h| (h.pos, h.span))
             .collect();
-        assert_eq!(numbers, vec![(1, 5, 1), (2, 17, 3), (3, 28, 6)]);
+        assert_eq!(
+            numbers,
+            vec![(1, span(5, 6)), (2, span(17, 20)), (3, span(28, 34))]
+        );
         let m = plan
             .highlights
             .iter()
             .find(|h| h.role == Role::Match)
             .unwrap();
         // Row 2 starts at 14; its command starts after 6 columns + 2 spaces.
-        assert_eq!((m.pos, m.start, m.len), (2, 23, 2));
+        assert_eq!((m.pos, m.span), (2, span(23, 25)));
     }
 
     #[test]
@@ -1025,11 +1037,11 @@ mod tests {
         let cands = [history_cand(b"command", b"9")];
         let plan = build(&cands, &batches, &spans_none(1), 10, 5);
         assert_eq!(plan.rows, vec![b"    9".to_vec()]);
-        assert_eq!(plan.cell_ranges, vec![(0, 5)]);
+        assert_eq!(plan.cell_ranges, vec![span(0, 5)]);
         assert!(
             plan.highlights
                 .iter()
-                .any(|h| { (h.role, h.pos, h.start, h.len) == (Role::HistoryNumber, 1, 4, 1) })
+                .any(|h| { (h.role, h.pos, h.span) == (Role::HistoryNumber, 1, span(4, 5)) })
         );
     }
 
@@ -1145,11 +1157,11 @@ mod tests {
         assert_eq!(
             plan.cell_ranges,
             vec![
-                (0, 1),  // a: row0, col1
-                (8, 1),  // b: row1, col1
-                (3, 1),  // c: row0, col2 (after "a  ")
-                (11, 1), // d: row1, col2 (after "b  ")
-                (6, 1),  // e: row0, col3 (after "a  c  ")
+                span(0, 1),   // a: row0, col1
+                span(8, 9),   // b: row1, col1
+                span(3, 4),   // c: row0, col2 (after "a  ")
+                span(11, 12), // d: row1, col2 (after "b  ")
+                span(6, 7),   // e: row0, col3 (after "a  c  ")
             ]
         );
         // nav: next/prev walk positions 1..=5 sequentially; left/right
@@ -1216,7 +1228,7 @@ mod tests {
         assert_eq!(plan.positions, vec![0, 1, 2, 3, 4]);
         assert_eq!(
             plan.cell_ranges,
-            vec![(8, 1), (6, 1), (4, 1), (2, 1), (0, 1)]
+            vec![span(8, 9), span(6, 7), span(4, 5), span(2, 3), span(0, 1)]
         );
         assert_eq!(
             plan.nav,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod matching;
 mod plan;
 mod ranking;
 mod record;
+mod span;
 mod worker;
 
 pub mod wire;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -21,6 +21,8 @@ use std::cmp::Reverse;
 
 use nucleo_matcher::{Config as NucleoConfig, Matcher, Utf32Str};
 
+use crate::span::CharSpan;
+
 /// Matching strength, cumulative.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
@@ -264,14 +266,13 @@ impl QueryMatcher {
     /// `hit` `classify` returned for that same candidate (passing another
     /// candidate's hit is a caller bug). For the stdout match-spans field
     /// (cli-protocol.md): char offsets over the lossy UTF-8 reading,
-    /// 0-based end-exclusive, sorted and merged; empty = no position
-    /// info (empty query).
+    /// 0-based, sorted and merged; empty = no position info (empty query).
     ///
     /// Second pass by design: callers run this only on the top-ranked
     /// (at most max-lines) candidates, so the fuzzy tier's re-match --
     /// the one thing the hit cannot carry -- stays cheap, and `classify`
     /// stays allocation-free for the full set.
-    pub fn spans(&mut self, cand_raw: &[u8], hit: TierHit) -> Vec<(usize, usize)> {
+    pub fn spans(&mut self, cand_raw: &[u8], hit: TierHit) -> Vec<CharSpan> {
         let q_len = self.query.bytes.len();
         if q_len == 0 {
             return Vec::new();
@@ -280,15 +281,15 @@ impl QueryMatcher {
         // so the offsets in `hit` index `cand_raw` identically; only the
         // fuzzy re-match needs the folded form again.
         match hit {
-            TierHit::Prefix { .. } => vec![(0, char_count(&cand_raw[..q_len]))],
-            TierHit::Substring { pos } => vec![(
+            TierHit::Prefix { .. } => vec![CharSpan::new(0, char_count(&cand_raw[..q_len]))],
+            TierHit::Substring { pos } => vec![CharSpan::new(
                 char_count(&cand_raw[..pos]),
                 char_count(&cand_raw[..pos + q_len]),
             )],
             TierHit::Edit(em) => {
                 // The aligned (corrected-query) prefix of the candidate.
                 let consumed = cand_raw.len() - em.suffix_len;
-                vec![(0, char_count(&cand_raw[..consumed]))]
+                vec![CharSpan::new(0, char_count(&cand_raw[..consumed]))]
             }
             TierHit::Fuzzy { .. } => {
                 let cand = fold_hay(&mut self.hay, &self.query, cand_raw);
@@ -296,12 +297,12 @@ impl QueryMatcher {
                 self.fuzzy.indices(&self.query, cand, &mut indices);
                 indices.sort_unstable();
                 indices.dedup();
-                let mut out: Vec<(usize, usize)> = Vec::new();
+                let mut out: Vec<CharSpan> = Vec::new();
                 for i in indices {
                     let i = i as usize;
                     match out.last_mut() {
-                        Some(last) if last.1 == i => last.1 = i + 1,
-                        _ => out.push((i, i + 1)),
+                        Some(last) if last.end == i => last.end = i + 1,
+                        _ => out.push(CharSpan::new(i, i + 1)),
                     }
                 }
                 out
@@ -452,12 +453,15 @@ mod tests {
         classify(q.as_bytes(), cand.as_bytes(), mode, true).map(TierHit::tier)
     }
 
+    /// Spans as `(start, end)` pairs, so the cases below read as the
+    /// char ranges they are.
     fn spans(q: &[u8], cand: &[u8], mode: Mode) -> Vec<(usize, usize)> {
         let mut qm = QueryMatcher::new(q, mode, true);
-        match qm.classify(cand) {
+        let spans = match qm.classify(cand) {
             Some(hit) => qm.spans(cand, hit),
             None => Vec::new(),
-        }
+        };
+        spans.into_iter().map(|s| (s.start, s.end)).collect()
     }
 
     #[test]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -21,6 +21,7 @@
 use std::io::Write;
 
 use crate::matching::{Mode, QueryMatcher, Tier};
+use crate::span::CharSpan;
 use crate::{insert, layout, ranking, record};
 
 /// Snapshot of a plan request's scalar fields; producer selects result
@@ -103,7 +104,7 @@ pub(crate) fn run(
     // spans() is a second pass by design (matching.rs docs): only run it
     // on the ranked subset that actually reaches layout, and derive it
     // from the hit that candidate was already classified by.
-    let spans: Vec<Vec<(usize, usize)>> = candidates
+    let spans: Vec<Vec<CharSpan>> = candidates
         .iter()
         .zip(&ranked)
         .map(|(c, &(_, hit))| qm.spans(c.match_text(), hit))
@@ -149,12 +150,21 @@ fn serialize(common_prefix: &[u8], plan: &layout::Plan, insert_texts: &[Vec<u8>]
     }
     let _ = write!(out, "{}", plan.highlights.len());
     out.push(0);
+    // The end-exclusive spans become the wire's `start len` here, and
+    // only here (span.rs).
     for h in &plan.highlights {
-        let _ = write!(out, "{} {} {} {}", h.role.as_str(), h.pos, h.start, h.len);
+        let _ = write!(
+            out,
+            "{} {} {} {}",
+            h.role.as_str(),
+            h.pos,
+            h.span.start,
+            h.span.len()
+        );
         out.push(0);
     }
-    for &(start, len) in &plan.cell_ranges {
-        let _ = write!(out, "{start} {len}");
+    for cell in &plan.cell_ranges {
+        let _ = write!(out, "{} {}", cell.start, cell.len());
         out.push(0);
     }
     for n in &plan.nav {
@@ -601,9 +611,11 @@ mod tests {
     #[test]
     fn match_highlight_offset_is_non_trivial_for_a_mid_string_match() {
         // Regression: a start==0 span can't distinguish a correct
-        // (start, end) reading from a buggy (start, start+len) one.
-        // "ar" is a substring of "cargo" at char index 1 (a-r), so
-        // matching::spans() emits (1, 3) -- start != 0, len != 1.
+        // end-exclusive reading from a buggy (start, start+len) one, and
+        // this is the end-to-end check of the one span -> wire `start len`
+        // conversion (span.rs). "ar" is a substring of "cargo" at char
+        // index 1 (a-r), so matching::spans() emits chars [1,3) --
+        // start != 0, len != 1.
         let stdin = {
             let mut s = header(&[]);
             s.extend(word("cargo"));

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,0 +1,92 @@
+//! End-exclusive char-offset spans.
+//!
+//! Char intervals travel in two shapes: the render-plan wire format writes
+//! `start len` (cli-protocol.md "ハイライト"), while everything that
+//! computes offsets -- matching's match spans, layout's cell ranges --
+//! works in `[start, end)`. Both are pairs of usize, so reading one as the
+//! other type-checks and has produced real bugs (layout.rs's
+//! `match_span_uses_end_exclusive_semantics_not_start_len` pins one).
+//!
+//! The end-exclusive form therefore travels as this type, and
+//! [`CharSpan::len`] is the single place the wire's `len` is derived from
+//! it.
+
+/// A `[start, end)` range of chars over the lossy UTF-8 reading of some
+/// text -- the offset unit of cli-protocol.md "オフセット規律", never a
+/// display width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct CharSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl CharSpan {
+    /// `start..end`. An inverted range is an empty span at `start`, so
+    /// `len` can never underflow.
+    pub fn new(start: usize, end: usize) -> Self {
+        CharSpan {
+            start,
+            end: end.max(start),
+        }
+    }
+
+    /// The wire format's `len` field: the one place the end-exclusive
+    /// form becomes a length.
+    pub fn len(self) -> usize {
+        self.end - self.start
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+
+    /// This span cut down to the first `limit` chars of the text it
+    /// indexes.
+    pub fn clip(self, limit: usize) -> Self {
+        CharSpan {
+            start: self.start.min(limit),
+            end: self.end.min(limit),
+        }
+    }
+
+    /// This span moved `by` chars later, to index an enclosing text.
+    pub fn shift(self, by: usize) -> Self {
+        CharSpan {
+            start: self.start + by,
+            end: self.end + by,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn len_is_the_end_exclusive_width() {
+        assert_eq!(CharSpan::new(3, 7).len(), 4);
+        assert_eq!(CharSpan::new(0, 0).len(), 0);
+        assert!(CharSpan::new(2, 2).is_empty());
+        assert!(!CharSpan::new(2, 3).is_empty());
+    }
+
+    #[test]
+    fn inverted_input_is_an_empty_span() {
+        assert_eq!(CharSpan::new(5, 2), CharSpan::new(5, 5));
+        assert_eq!(CharSpan::new(5, 2).len(), 0);
+    }
+
+    #[test]
+    fn clip_cuts_both_ends_to_the_visible_text() {
+        assert_eq!(CharSpan::new(1, 5).clip(3), CharSpan::new(1, 3));
+        assert_eq!(CharSpan::new(1, 5).clip(9), CharSpan::new(1, 5));
+        // entirely past the limit: empty, not a wrapped range
+        assert!(CharSpan::new(4, 6).clip(2).is_empty());
+    }
+
+    #[test]
+    fn shift_moves_the_whole_span() {
+        assert_eq!(CharSpan::new(1, 3).shift(10), CharSpan::new(11, 13));
+        assert_eq!(CharSpan::new(1, 3).shift(0), CharSpan::new(1, 3));
+    }
+}


### PR DESCRIPTION
Closes #54

char オフセットの区間表現が、`matching::spans()` の返す **(start, end)**(end-exclusive)と、`layout.rs` の cell range・`Highlight` が使う **(start, len)** とで異なるにもかかわらず、どちらも生の `(usize, usize)` タプルで流通していた。両者の取り違えは実際に起きており、`layout.rs` の回帰テスト `match_span_uses_end_exclusive_semantics_not_start_len` が「spans() の (start, end) を (start, len) と誤読した」バグを固定している。

end-exclusive の span 型 `CharSpan { start, end }` を導入し、matching → plan → layout 間を型で区別された値として流すようにした。取り違えはコンパイルエラーになる。動作変更はない。

#53 (score/spans の classify 統合) に依存する変更で、そちらは #66 でマージ済み。

## Details

- **`src/span.rs` を新設**して `CharSpan` を置いた。matching が生成し layout が消費する共有語彙なので、どちらのモジュールにも寄せていない(layout.rs の「matching を知らない」設計とも矛盾しない)。API は `len()` / `is_empty()` / `clip(limit)` / `shift(by)` で、`new` は逆転区間を空区間に正規化するため `len()` が underflow しない。
- **render-plan ワイヤ形式は `start len` のまま**で、cli-protocol.md は触っていない。`(start, end) → (start, len)` の変換は `plan::serialize` が呼ぶ `CharSpan::len()` の一箇所に固定された。
- **layout 内部の `Highlight`・`cell_ranges`・`number_ranges` も `CharSpan`** にした。ヒストリ番号のクリップとマッチスパンのクリップが、どちらも `clip(visible_chars).shift(offset)` という同じ形になり、手書きの min / 比較が消えている。
- `wire.rs`(デコーダ)はワイヤ通り `start len` のまま。ここは「ワイヤをそのまま読む」層なので型を変える理由がない。
- **スコープ外**: 1-indexed 表示位置(`pos`)や候補インデックスの newtype 化は含めていない(issue 記載のとおり)。

`layout.rs` の差分が大きく見えるのは、大半がテストの期待値を `(start, len)` から `[start, end)` に書き直したものであるため。

## Spec updates

なし。ワイヤ形式・意味論ともに変更はない。

## Tests

- 既存スイートと `tests/vectors` のゴールデンが無変更のまま通過(ワイヤ出力に変化なし)。
- 回帰テスト `match_span_uses_end_exclusive_semantics_not_start_len` は名前と意図を保って存置した。型が誤読を書けなくする一方、クリップと位置合わせの算術は依然テスト対象なので意味が残る。ワイヤ側の `len` を直接確認するアサーションを 1 行足している。
- `plan.rs` の `match_highlight_offset_is_non_trivial_for_a_mid_string_match` が、span → ワイヤ `start len` 変換の end-to-end チェックになっている旨をコメントに明記した。
- `span.rs` に `CharSpan` 自体の単体テスト(len/is_empty、逆転入力、clip、shift)を追加。

検証: `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --release` / `cargo test` に加え、zsh 側の `tests/zsh/driver.zsh` (PASS=144 FAIL=0) / `vectors.zsh` (PASS=74) / `transport.zsh` (PASS=7) もローカルで通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XX8Jx7LHPQJCCVGN44cKey

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8Jx7LHPQJCCVGN44cKey)_