### PR TITLE
test(zle): let expect observe pty output already consumed by drain

### DIFF
--- a/tests/zsh/driver-coexist.zsh
+++ b/tests/zsh/driver-coexist.zsh
@@ -186,26 +186,35 @@ start_host() {  # $1=host name $2=ZDOTDIR $3=log file $4=working tmp
   return 0
 }
 
-use_host() { HOST=$1; HOSTFD=${HFD[$1]}; CURLOG=${2:-$CURLOG} }
+# EXPECT_BUF is the observation window: everything the current host has emitted
+# since the last input we sent it. Sending input, and switching to another host
+# (a different output stream), are the only things that open a fresh window, so
+# output that an intervening drain happened to read is still there for a later
+# expect to match.
+use_host() { HOST=$1; HOSTFD=${HFD[$1]}; CURLOG=${2:-$CURLOG}; EXPECT_BUF= }
 stop_host() { zpty -d $1 2>/dev/null; unset "HFD[$1]" }
 
-send_line() { zpty -w  $HOST $1 }
-send_keys() { zpty -wn $HOST $1 }
+send_line() { EXPECT_BUF=; zpty -w  $HOST $1 }
+send_keys() { EXPECT_BUF=; zpty -wn $HOST $1 }
+
+buf_has() {  # $1=glob -> 0 when EXPECT_BUF already satisfies it
+  # Match the raw bytes first, so raw escape-sequence patterns get their
+  # chance, then again with SGR stripped: highlighting can split a word the
+  # pattern expects to be contiguous.
+  [[ $EXPECT_BUF == ${~1} || ${EXPECT_BUF//$'\e['[0-9;]#m/} == ${~1} ]]
+}
 
 expect() {
   local pat=$1
   local -F deadline=$(( SECONDS + ${2:-10} ))
-  EXPECT_BUF=
+  buf_has "$pat" && return 0
   local chunk
   while (( SECONDS < deadline )); do
     if zselect -t 20 -r $HOSTFD 2>/dev/null; then
       zpty -r $HOST chunk 2>/dev/null || return 2
       EXPECT_BUF+=$chunk
       TRANSCRIPT+=$chunk
-      [[ $EXPECT_BUF == ${~pat} ]] && return 0
-      # Match again after stripping SGR that may split words for highlighting.
-      # Raw escape-sequence patterns already had the first chance to match above.
-      [[ ${EXPECT_BUF//$'\e['[0-9;]#m/} == ${~pat} ]] && return 0
+      buf_has "$pat" && return 0
     fi
   done
   return 1
@@ -216,7 +225,7 @@ drain() {
   local chunk
   while (( SECONDS < dl )); do
     if zselect -t 10 -r $HOSTFD 2>/dev/null; then
-      zpty -r $HOST chunk 2>/dev/null && TRANSCRIPT+=$chunk
+      zpty -r $HOST chunk 2>/dev/null && { TRANSCRIPT+=$chunk; EXPECT_BUF+=$chunk }
     fi
   done
 }
@@ -307,7 +316,7 @@ basic_flow() {  # $1=label prefix
     ok "(1) abbr+zrush host started"
     send_keys 'zzz'
     drain 0.5
-    send_keys $ENTER          # press() would consume output while draining
+    send_keys $ENTER
     if expect '*ABBR-EXPANDED-OK*' 8; then
       ok "(1a) abbreviation expansion works on Enter without selection (via predecessor chain)"
     else

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -23,6 +23,8 @@
 #     both pty output and the ZRUSH_LOG file (including the ^Xb/^Xp/^Xh test-only
 #     dump widgets registered by rc/minimal.zshrc).
 #   - Always drain the pty in wait loops to prevent tcsetattr TCSADRAIN blocking.
+#     Draining never hides output from a later expect: EXPECT_BUF holds
+#     everything the host has emitted since the last input we sent it.
 #   - After executing a command, synchronize on the HP> prompt before sending more keys.
 emulate -L zsh
 setopt extended_glob
@@ -119,22 +121,30 @@ unset OVERFLOW_ITEM
 typeset -gi HOSTFD=-1
 typeset -g TRANSCRIPT= EXPECT_BUF= STDIO_BASELINE=
 
-send_line() { zpty -w  host $1 }
-send_keys() { zpty -wn host $1 }
+# EXPECT_BUF is the observation window: everything the host has emitted since
+# the last input we sent it. Sending input (and adopting a new host's fd) is
+# the only thing that opens a fresh window, so output that an intervening
+# drain happened to read is still there for a later expect to match.
+send_line() { EXPECT_BUF=; zpty -w  host $1 }
+send_keys() { EXPECT_BUF=; zpty -wn host $1 }
+
+buf_has() {  # $1=glob -> 0 when EXPECT_BUF already satisfies it
+  # Match the raw bytes, then again with SGR stripped: highlighting can split
+  # a word the pattern expects to be contiguous.
+  [[ $EXPECT_BUF == ${~1} || ${EXPECT_BUF//$'\e['[0-9;]#m/} == ${~1} ]]
+}
 
 expect() {  # $1=glob $2=timeout(s)
   local pat=$1
   local -F deadline=$(( SECONDS + ${2:-10} ))
-  EXPECT_BUF=
+  buf_has "$pat" && return 0
   local chunk
   while (( SECONDS < deadline )); do
     if zselect -t 20 -r $HOSTFD 2>/dev/null; then
       zpty -r host chunk 2>/dev/null || return 2
       EXPECT_BUF+=$chunk
       TRANSCRIPT+=$chunk
-      [[ $EXPECT_BUF == ${~pat} ]] && return 0
-      # Match again after stripping SGR that may split words for highlighting.
-      [[ ${EXPECT_BUF//$'\e['[0-9;]#m/} == ${~pat} ]] && return 0
+      buf_has "$pat" && return 0
     fi
   done
   return 1
@@ -237,7 +247,6 @@ dump_get() {
 assert_host_stdio() {  # $1=label; compare fd targets and stdout/stderr delivery
   local label=$1
   log_count 'TESTSTDIO='; local -i baseline=$REPLY
-  EXPECT_BUF=
   send_keys $'\C-xf'
   if ! wait_log 'TESTSTDIO=' $baseline 5; then
     ng "$label: stdio probe did not run"
@@ -279,6 +288,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   local REPLY=
   zpty -b host zsh -d -i || return 1
   HOSTFD=$REPLY
+  EXPECT_BUF=
   expect '*MARK-RC-DONE*' 20 || return 1
   drain 0.3
   return 0
@@ -290,6 +300,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   local REPLY=
   zpty -b host zsh -d -i || { ng "host failed to start"; exit 1 }
   HOSTFD=$REPLY
+  EXPECT_BUF=
   if expect '*MARK-RC-DONE*' 20; then
     ok "host started + compinit + zrush.zsh sourced (config loaded)"
   else
@@ -736,7 +747,6 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   fake_count 'die 1 '; local -i fake_die0=$REPLY
   local -i err_log_line0=0
   [[ -r $ZRUSH_LOG ]] && err_log_line0=$(wc -l < $ZRUSH_LOG)
-  EXPECT_BUF=
   send_keys 'ls fx/basic/al'
   local -i active_death_ok=1
   wait_fake 'die 1 ' $fake_die0 10 || active_death_ok=0
@@ -848,8 +858,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   else
     ng "(err-4) shell did not respond after worker failures"
   fi
-  # No sync_prompt here: the expect above already consumed this command's
-  # prompt, so another wait could only time out.
+  # No sync_prompt here: the expect above already covers this command's prompt.
   drain 0.2
 
   # ================================================================ (10) History menu (issue #9)
@@ -1293,8 +1302,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   print -r -- die > $ZRUSH_FAKE_CONTROL
   fake_count "die $hist_fake_session "; local -i hist_die0=$REPLY
   log_count 'worker: session failure:'; local -i hist_fail0=$REPLY
-  send_keys $'\e[A'   # raw send, not press: press's own drain would already
-                       # consume the one-shot warning before expect looks for it
+  send_keys $'\e[A'
   if wait_fake "die $hist_fake_session " $hist_die0 10 \
      && wait_log 'worker: session failure:' $hist_fail0 10; then
     ok "(h24a) active worker death is recorded on the synchronous history path"

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -273,8 +273,13 @@ assert_host_stdio() {  # $1=label; compare fd targets and stdout/stderr delivery
 # buffer, so those scenarios need a real line abandon + resync instead.
 # The generous bound matches the other send-break sites: a loaded host has
 # been observed to spend >5s inside pty-^C interrupt handling before the new
-# prompt appears (#47).
-reset_line() { send_keys $'\C-c'; drain 0.3; sync_prompt 15 }
+# prompt appears (#47). A resync that never happens leaves every following
+# case running against a desynced host, so it is reported rather than dropped.
+reset_line() {
+  send_keys $'\C-c'
+  drain 0.3
+  sync_prompt 15 || ng "reset_line: no prompt after send-break"
+}
 
 # Stop whatever is running as the "host" pty and start a fresh one under a
 # given ZDOTDIR/XDG_CONFIG_HOME/log file. Used by the history-menu section


### PR DESCRIPTION
Closes #63.

`expect()` cleared the shared `EXPECT_BUF` on entry, so it could only match bytes that arrived after it started waiting — but `drain()` reads from the same pty and appends to that buffer, so anything that arrived during a preceding `drain` was unobservable. `reset_line`'s `sync_prompt` was the casualty: its `drain 0.3` consumed the fresh prompt, so the wait always ran to its timeout and worked as a fixed sleep instead of a synchronization.

`EXPECT_BUF` now holds everything the host has emitted since the last input we sent it. `expect` matches the accumulated buffer once before waiting; sending input is the only thing that opens a fresh window; adopting a new host's fd (`use_host` in the coexistence driver) starts a new stream. `driver-coexist.zsh`'s `drain` did not append to `EXPECT_BUF` at all — it does now.

## What changed

- `expect()` no longer clears `EXPECT_BUF`; it checks the accumulated buffer before entering the wait loop. Both match forms (raw, and with SGR stripped) moved into a shared `buf_has` helper.
- `send_keys` / `send_line` clear `EXPECT_BUF` — the only window-boundary rule. Host-fd adoption also clears it, so a previous host's `MARK-RC-DONE` banner cannot satisfy the next host's startup check.
- The two ad-hoc `EXPECT_BUF=` resets in test bodies became redundant and were deleted; the immediately following `send_keys` performs the same reset.
- `reset_line` reports a failed resync instead of discarding it. The `sync_prompt 15` bound stays (see below).
- Three comments that justified working around the old behavior ("`press()` would consume output while draining") were removed, since that is no longer true.

## Deviation from the issue as originally written

The issue asked to revert `reset_line`'s bound from 15s back to 5s, on the grounds that the larger value changed nothing because no bytes ever arrived during the wait. That premise is consumed by this fix: the wait is now released by the prompt, so the bound stops being a duration and becomes the grace period before a host counts as broken. What that period should be is a property of the host — a loaded host has been measured spending >5s inside pty-`^C` interrupt handling before the new prompt appears (#47) — not of the call site, so it stays at 15 and is shared with the other four send-break resyncs.

Keeping a generous bound is only safe if a timeout is loud, and all three `reset_line` callers discard its status. That silence is the same shape of defect this PR fixes, so the failure is now reported where it happens. The issue body has been updated to record this.

## Verification

macOS 27.0 / Mac15,12 / 8 cores / zsh 5.9 / `cargo build --release`.

- `driver.zsh` ×2 and `driver-coexist.zsh` on the final code: `PASS=144 FAIL=0` and `PASS=37 FAIL=0 SKIP=0`.
- Mutation check: removing only the pre-loop match in `expect` brings back exactly three `sync_prompt` timeouts, all at `reset_line` — while the run still reports `PASS=144 FAIL=0`, confirming these dead waits were invisible in the results. With the fix, three instrumented runs recorded zero timeouts.
- Wall clock: `driver.zsh` 2:40 → 1:45, `driver-coexist.zsh` 31s → 27s. The coexistence driver's PS2 resync had the same dead wait and is released too.
- `cargo fmt --check` / `clippy --all-targets -D warnings` / `test` green (no Rust change).

## For the reviewer

A static sweep of every `expect`/`sync_prompt` call site found where the observation window actually widened — i.e. where a reader sits between the last keystroke and the `expect`. In `driver.zsh`: `reset_line` (the fix), `(cfm-2)` around line 590 (safe — the buffer at that point yields no candidates, so no stale listing text can exist), and three `sync_prompt` calls whose window starts at the `\r` or at host adoption, where the only `HP>` present is the fresh prompt. In `driver-coexist.zsh`: the four `sync_prompt` calls, same reasoning. Every other call site is byte-identical to before.

Known approximation, unchanged by this PR: the window is "output read after we sent X", not "output caused by X". Bytes emitted in response to an earlier stimulus but still unread are attributed to the new window. The old clear-on-entry behavior had the identical hole, and a pty offers nothing better.

Repeated runs surfaced `(h19a)` / `(h20b)` / `(h24a)` failing intermittently, including on `main`. Those are the specced 100ms history deadline being exceeded by a cold worker start, already tracked in #48; evidence from these runs (sequential single-instance reproduction, plus a host log showing the deadline consumed in 99.8ms) has been added there.

Not addressed here, both candidates for follow-ups: `driver-coexist.zsh`'s own `sync_prompt` calls still discard their status, and `driver.zsh`'s header still describes the harness as shared with `driver-latency.zsh`, whose `expect` now has different semantics (a function-local buffer — structurally immune to this bug, so it is deliberately untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
