### PR TITLE
fix(zle): start the persistent worker on zsh 5.8 (sysopen nonblock is 5.9+)

### DIFF
--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -569,7 +569,7 @@ start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
     ng "(sel-1a) selection did not start"
   fi
   if dump_get $'\C-xh' TESTRH; then
-    if [[ $REPLY == *'memo=zrush-sel'* || ( ! HAVE_MEMO && $REPLY == *standout* ) ]]; then
+    if [[ $REPLY == *'memo=zrush-sel'* ]] || { (( ! HAVE_MEMO )) && [[ $REPLY == *standout* ]] }; then
       ok "(sel-1b) pos=1's own decoration (standout/selected) replaces its match highlight"
     else
       ng "(sel-1b) selected-cell decoration not found: ${REPLY:-<none>}"

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -978,7 +978,7 @@ _zrush_worker_finish_start() {
   else
     # The substitution forks before sysopen runs, so record the pid whether or not
     # sysopen succeeded: a failure here still has a worker to terminate.
-    sysopen -r -o nonblock,cloexec -u _zrush_worker_rfd \
+    sysopen -r -o cloexec -u _zrush_worker_rfd \
       <( exec "$ZRUSH_BIN" worker <&$child_in 2>>| "${ZRUSH_LOG:-/dev/null}" ) || failed=1
     _zrush_worker_pid=${sysparams[procsubstpid]:--1}
   fi


### PR DESCRIPTION
Closes #73.

On zsh 5.8.x the persistent worker never started: `_zrush_worker_finish_start` opened the worker's stdout with `sysopen -r -o nonblock,cloexec`, and `-o nonblock` only exists since zsh 5.9, so every spawn failed and the circuit breaker disabled completion for the session. The flag was redundant — every read of that fd goes through `sysread -t 0` or a `zselect` wait, so the shell never blocks on it regardless of O_NONBLOCK — and is now dropped.

Also fixes the driver assertion that should have caught this class of problem: sel-1b's `! HAVE_MEMO` inside `[[ ]]` tested a literal word (always-false branch), so the zsh<5.9 fallback could never pass; it now uses `(( ! HAVE_MEMO ))` like apl-1c.

Verified green on zsh 5.8.1 (driver 98 FAIL → 144/144 PASS; two consecutive full container runs) and 5.9, plus the full macOS native suite including driver-coexist.zsh. Details and minimal reproduction in #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)