### PR TITLE
ci: run the Linux test suite in containers pinned to zsh 5.8 and 5.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust (stable)
@@ -25,11 +21,17 @@ jobs:
         run: cargo fmt --check
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (stable)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
       - name: cargo build (release)
         run: cargo build --release
-      - name: Install zsh (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y zsh
       - name: cargo test
         run: cargo test
       - name: zle driver
@@ -38,3 +40,14 @@ jobs:
         run: zsh -f tests/zsh/vectors.zsh
       - name: zsh worker transport
         run: zsh -f tests/zsh/transport.zsh
+
+  test-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        zsh-version: ["5.8.1", "5.9"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test suite in container (zsh ${{ matrix.zsh-version }})
+        run: tests/docker/run.sh ${{ matrix.zsh-version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ cargo test
 
 For changes touching `zsh/`, the zle-integration drivers `tests/zsh/driver.zsh` and `tests/zsh/driver-coexist.zsh` must also pass — run them locally.
 CI runs the headless `driver.zsh`, `tests/zsh/vectors.zsh` (capture-encoder and plan-decoder golden vectors), and `tests/zsh/transport.zsh` (worker transport write path); `driver-coexist.zsh` remains local-only.
+CI's Linux jobs run the whole suite in a container whose zsh is built from source, as a matrix over the supported versions; the same run reproduces locally (needs Docker) with
+
+```sh
+tests/docker/run.sh 5.8.1   # or 5.9
+```
 `zsh/verify.zsh` launches an isolated shell for manual verification, and `tests/zsh/driver-latency.zsh` measures first-paint latency; each file's header documents prerequisites and usage.
 
 ## Commits, issues, and pull requests

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,32 @@
+# Linux test image: Rust toolchain plus zsh built from source at ZSH_VERSION.
+# Built and run by tests/docker/run.sh; see AGENTS.md "Build and test".
+FROM rust:bookworm
+
+# - libncurses-dev: zsh build dependency.
+# - locales + locale-gen: tests/zsh/driver.zsh sets LC_ALL=en_US.UTF-8, which
+#   Debian does not ship pre-generated.
+# - python3: tests/zsh/fake-worker.py.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libncurses-dev locales python3 \
+    && sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && locale-gen \
+    && rm -rf /var/lib/apt/lists/*
+
+# zsh.org keeps only the latest release under pub/; every other version lives
+# under pub/old/, hence the fallback URL.
+# --with-tcsetpgrp: the configure check for tcsetpgrp needs a tty, which
+# docker build does not have.
+ARG ZSH_VERSION
+RUN set -eux; \
+    cd /tmp; \
+    curl -fsSLo zsh.tar.xz "https://www.zsh.org/pub/zsh-${ZSH_VERSION}.tar.xz" \
+      || curl -fsSLo zsh.tar.xz "https://www.zsh.org/pub/old/zsh-${ZSH_VERSION}.tar.xz"; \
+    tar -xf zsh.tar.xz; \
+    cd "zsh-${ZSH_VERSION}"; \
+    ./configure --prefix=/usr/local --enable-multibyte --with-tcsetpgrp; \
+    make -j"$(nproc)"; \
+    make install; \
+    cd /; \
+    rm -rf /tmp/zsh.tar.xz "/tmp/zsh-${ZSH_VERSION}"
+
+ENV LANG=en_US.UTF-8

--- a/tests/docker/run.sh
+++ b/tests/docker/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run the Linux test suite in a container pinned to a specific zsh version.
+#
+# Usage:
+#   tests/docker/run.sh <zsh-version>      # e.g. 5.8.1, 5.9
+#
+# Builds tests/docker/Dockerfile (cached by the Docker daemon) and runs
+# tests/docker/suite.zsh inside it: cargo build/test plus the headless zsh
+# suites (driver.zsh, vectors.zsh, transport.zsh). CI's Linux matrix calls
+# exactly this script, so a CI failure reproduces locally with one command.
+#
+# bash, not zsh: this is the one script that must run on hosts whose zsh is
+# the very thing under suspicion (or absent, as on GitHub's Linux runners).
+#
+# Mount layout:
+#   - repo bind-mounted rw at /zrush, with named volumes shadowing target/
+#     (per-arch) and the cargo registry, so container builds never touch the
+#     host's target/ and re-runs skip recompilation.
+#   - /tmp is a tmpfs with exec: driver.zsh copies its fake-worker launcher
+#     under $TMPDIR and must be able to execute it (the Docker default is
+#     noexec).
+#
+# ZRUSH_DOCKER_BUILD_ARGS adds extra arguments to docker build (e.g. a
+# --cache-from for CI, should image caching ever be needed).
+set -euo pipefail
+
+version=${1:?usage: tests/docker/run.sh <zsh-version>}
+repo=$(cd "$(dirname "$0")/../.." && pwd)
+image="zrush-test:zsh-$version"
+arch=$(docker version --format '{{.Server.Arch}}')
+
+# shellcheck disable=SC2086  # ZRUSH_DOCKER_BUILD_ARGS is intentionally word-split
+docker build \
+    ${ZRUSH_DOCKER_BUILD_ARGS:-} \
+    --build-arg "ZSH_VERSION=$version" \
+    -t "$image" \
+    "$repo/tests/docker"
+
+docker run --rm \
+    -v "$repo:/zrush" \
+    -v "zrush-target-linux-$arch:/zrush/target" \
+    -v "zrush-cargo-registry:/usr/local/cargo/registry" \
+    --tmpfs /tmp:exec,mode=1777 \
+    -w /zrush \
+    "$image" \
+    zsh -f tests/docker/suite.zsh

--- a/tests/docker/suite.zsh
+++ b/tests/docker/suite.zsh
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+# The in-container half of tests/docker/run.sh: the full Linux test suite,
+# in the same order as CI's macOS job. Not meant to run on a host.
+emulate -L zsh
+set -e
+
+print -r -- "== $(zsh --version) =="
+cargo build --release
+cargo test
+zsh -f tests/zsh/driver.zsh "$(mktemp -d)"
+zsh -f tests/zsh/vectors.zsh
+zsh -f tests/zsh/transport.zsh


### PR DESCRIPTION
Closes #71.

- `tests/docker/Dockerfile` (`ARG ZSH_VERSION`): rust:bookworm base, zsh built from source (zsh.org keeps only the latest release under `pub/`, so there is an `old/` fallback URL); `--with-tcsetpgrp` because docker build has no tty; en_US.UTF-8 generated for the driver; python3 for the fake worker.
- `tests/docker/run.sh <version>`: builds the image (daemon layer cache) and runs the whole Linux suite inside it — cargo build/test plus driver/vectors/transport via `tests/docker/suite.zsh`. The repo is bind-mounted with named volumes shadowing `target/` (per-arch) and the cargo registry, and `/tmp` is an exec tmpfs. CI's Linux matrix calls exactly this script, so any CI failure reproduces locally with one command.
- CI: `lint` (fmt+clippy, native), `test-macos` (native, as before), `test-linux` matrix {5.8.1, 5.9} running `tests/docker/run.sh`. No image caching for now (stability first — no extra actions, tokens, or cache eviction modes); `ZRUSH_DOCKER_BUILD_ARGS` is the injection point if caching is ever wanted.
- AGENTS.md documents the local reproduction command.

Verification on this branch (rebased on main with #74/#79 in): `tests/docker/run.sh 5.8.1` and `5.9` both green end to end (cargo test 201; driver `PASS=144 FAIL=0 SKIP=0`; vectors 74; transport 7). The 5.8-only code paths and the previously flaky over-capacity listing path are exercised and stable thanks to #74 and #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)