### PR TITLE
test(zle): make the history-menu deadline overridable via a test seam

### DIFF
--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -257,6 +257,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 - 履歴 payload の合成が完了した直後から、対象 request_id の完全な終端応答を受け取るまでを
   **1 本の絶対 100ms deadline**で制限する。worker が未起動なら、その起動・`hello` / `ready` 握手・
   要求送信・完全な応答受信をすべて同じ 100ms に含める。deadline は固定方針であり設定項目にしない。
+  環境変数 `ZRUSH_HISTORY_DEADLINE_MS`(ミリ秒、未設定時は 100)で deadline を上書きできるが、これは `zsh/zrush.zsh` の `ZRUSH_BIN` と `ZRUSH_NO_INIT` に倣ったテストドライバ専用の seam である。
   payload 合成に費やす時間はこの deadline に含めない。
 - 同期待ちの間に先行する非同期要求の応答を受けた場合も通常どおり終端まで読み、stale なら破棄して
   対象 request_id を待ち続ける。先行要求の outbound queue 送信と直列処理に費やす時間も同じ deadline を消費する。

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -107,6 +107,8 @@ export ZRUSH_BIN=$WORK/bin/zrush
 export ZRUSH_REAL_BIN=$REPO/target/release/zrush
 export ZRUSH_FAKE_CONTROL=$WORK/fake-control
 export ZRUSH_FAKE_STATE=$WORK/fake-state
+# Test seam: 5000 ms matches the driver's other bounded waits.
+export ZRUSH_HISTORY_DEADLINE_MS=5000
 
 print "source $REPO/tests/zsh/rc/minimal.zshrc" > $ZDOTDIR/.zshrc
 

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -1561,7 +1561,7 @@ _zrush_history_payload() {  # -> REPLY = candidate payload bytes
 _zrush_request_plan_sync() {
   emulate -L zsh
   local payload=$1 producer=$2 query=$3 tspace=$4
-  local -F deadline=$(( EPOCHREALTIME + 0.100 )) remaining
+  local -F deadline=$(( EPOCHREALTIME + ${ZRUSH_HISTORY_DEADLINE_MS:-100} / 1000.0 )) remaining
   _zrush_request_plan "$payload" "$producer" "$query" "$tspace" || return 1
   local -i target=$REPLY cs
   _zrush_sync_target=$target _zrush_sync_done=0 _zrush_sync_ok=0


### PR DESCRIPTION
Closes #48.

The history-menu cases in `tests/zsh/driver.zsh` assume the synchronous plan exchange finishes inside the absolute 100ms deadline that `docs/internal/specs/behavior.md`「履歴メニュー」fixes for this path.
Under machine load — including single sequential runs on a busy machine (see the measurement in #48) — a cold worker spawn plus the `hello`/`ready` handshake legitimately overruns the window, the menu correctly does not open, and the cases fail although `zsh/zrush.zsh` behaves exactly as specced; a second consecutive session failure then disables zrush for the whole test host.

This change adds the test seam proposed in #48:

- `zsh/zrush.zsh`: the single deadline-arming site in `_zrush_request_plan_sync` becomes `${ZRUSH_HISTORY_DEADLINE_MS:-100}` scaled to seconds. Unset means 100; the arithmetic result is bit-identical to the previous `0.100` (verified empirically on zsh 5.9). The deadline is threaded as an absolute timestamp to every check site, so this one site governs the whole sync path.
- `tests/zsh/driver.zsh`: exports `ZRUSH_HISTORY_DEADLINE_MS=5000` once at startup; every zpty host, including the extra hosts from `start_hist_host`, inherits it.
- `docs/internal/specs/behavior.md`: the deadline paragraph records the seam as test-driver-only, following the `ZRUSH_BIN` / `ZRUSH_NO_INIT` precedent. The 100ms budget stays a fixed policy and is not a `config.toml` item.

`tests/zsh/driver-latency.zsh` and real usage leave the variable unset, so user-visible behavior is unchanged.
`tests/zsh/driver-coexist.zsh` never opens the history menu and is untouched.

## Verification

Apple Silicon Mac (Darwin 27.0.0), zsh 5.9, `cargo build --release` binary:

- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --release` / `cargo test` (227 tests): all pass.
- `tests/zsh/driver.zsh`: 10 sequential runs + one 12-way parallel run (22 runs total), all `PASS=144 FAIL=0 SKIP=0`; grepping every kept `$WORK` host log for `history deadline exceeded` finds zero occurrences, per the Tests section of #48.
- `tests/zsh/driver-coexist.zsh`: `PASS=37 FAIL=0 SKIP=0`.

## Reviewer notes

- The env var is spliced into math context unvalidated; a non-numeric value evaluates to 0 and makes every menu open fail. Accepted as-is for a documented test-only seam (the `ZRUSH_BIN` seam already executes an arbitrary binary, and the only setter is the driver's literal `5000`).
- behavior.md's earlier summary lines (「固定の絶対 100ms deadline」) intentionally stay unchanged: unset = 100ms remains the fixed production policy; the authoritative「履歴メニュー」paragraph records the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)