### PR TITLE
fix(zle): end the synchronous history exchange at the target response

### DIFF
--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -259,6 +259,8 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   要求送信・完全な応答受信をすべて同じ 100ms に含める。deadline は固定方針であり設定項目にしない。
   環境変数 `ZRUSH_HISTORY_DEADLINE_MS`(ミリ秒、未設定時は 100)で deadline を上書きできるが、これは `zsh/zrush.zsh` の `ZRUSH_BIN` と `ZRUSH_NO_INIT` に倣ったテストドライバ専用の seam である。
   payload 合成に費やす時間はこの deadline に含めない。
+- 対象 request_id の完全な終端応答を受信した時点で同期待ちは終了する。
+  受信済みで未処理の後続応答は同期待ちの中では処理せず、非同期経路が引き取る。
 - 同期待ちの間に先行する非同期要求の応答を受けた場合も通常どおり終端まで読み、stale なら破棄して
   対象 request_id を待ち続ける。先行要求の outbound queue 送信と直列処理に費やす時間も同じ deadline を消費する。
   deadline を要求ごと・write/read ごとに延長しない。超過時は worker プロセスを終了させて消滅を確認し、

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -1,7 +1,9 @@
 #!/bin/zsh -f
-# Non-pty unit tests for the zsh-side worker transport write path: the outbound
-# frame queue, the short-lived writer child that _zrush_worker_flush forks, and
-# the ack/EOF notification fd that _zrush_worker_consume_ack reads.
+# Non-pty unit tests for the zsh-side worker transport. The write path: the
+# outbound frame queue, the short-lived writer child that _zrush_worker_flush
+# forks, and the ack/EOF notification fd that _zrush_worker_consume_ack reads.
+# The read path: how _zrush_worker_read walks the receive buffer, in the
+# synchronous mode the history menu drives it in.
 #
 # Usage:
 #   zsh -f tests/zsh/transport.zsh
@@ -16,11 +18,14 @@
 # Scope: vectors.zsh covers the capture encoder and the plan decoder; this file
 # is the home for non-pty unit tests of the zsh-side worker transport instead.
 # The behavior under test is specified in docs/internal/specs/behavior.md,
-# section "worker ライフサイクル".
+# sections "worker ライフサイクル" and "履歴メニュー".
 #
 # Test seams used here, none of which touch zsh/zrush.zsh:
 #   - _zrush_warn is replaced by a recorder, so warnings are asserted instead of
 #     printed into the runner's output.
+#   - _zrush_worker_deadline_expired is replaced, for one case, by an oracle
+#     that reports expiry from the state of the exchange rather than from the
+#     clock, so the moment a deadline trips is fixed instead of measured.
 #   - The ZLE callback never runs headless, so the shared consume path
 #     (_zrush_worker_consume_ack) is called directly, exactly as the synchronous
 #     history loop calls it.
@@ -499,6 +504,100 @@ mkdir -p $HOME $XDG_CONFIG_HOME
   peek_close
   fifo_teardown
   verdict "teardown: a child already at EOF is never signalled"
+
+  # ------------------------------------------------------ read-path fixtures
+  # A read fd that never carries data: sysread -t 0 on it always reports EAGAIN,
+  # so _zrush_worker_read can only make progress from what the case put into
+  # _zrush_worker_rx, and no worker process is needed behind it.
+  typeset -g RFIFO=
+  sync_setup() {  # $1=case name; a session waiting synchronously for request 1
+    emulate -L zsh
+    transport_reset
+    RFIFO=$WORK/rx-$1.fifo
+    command mkfifo $RFIFO || { out "FATAL: mkfifo $RFIFO"; exit 1 }
+    sysopen -rw -o cloexec -u _zrush_worker_rfd $RFIFO || { out "FATAL: rx open"; exit 1 }
+    _zrush_worker_ready=1
+    typeset -gi _zrush_current_request=0
+    _zrush_worker_pending=( 1 history 2 compsys 3 compsys )
+    typeset -gi _zrush_sync_target=1 _zrush_sync_done=0 _zrush_sync_ok=0
+  }
+  sync_teardown() {
+    emulate -L zsh
+    (( _zrush_worker_rfd > 2 )) && { exec {_zrush_worker_rfd}>&- } 2>/dev/null
+    _zrush_worker_rfd=-1
+    [[ -n $RFIFO ]] && command rm -f $RFIFO
+    RFIFO=
+  }
+
+  # An outer frame carrying an `ok` response whose render plan is the smallest
+  # one _zrush_parse_plan accepts: no rows, no highlights, no positions.
+  msg_ok() {  # $1=request_id -> REPLY
+    emulate -L zsh
+    setopt localoptions nomultibyte
+    local LC_ALL=C
+    _zrush_encode_message ok "$1" $'\0'"0"$'\0'"0"$'\0'"0"$'\0'
+  }
+
+  # ============================================================ case 8
+  # The target's terminal response ends the synchronous exchange.
+  sync_setup lone
+  msg_ok 1; _zrush_worker_rx=$REPLY
+  typeset -gF DEADLINE=$(( EPOCHREALTIME + 5 ))
+  _zrush_worker_read sync $DEADLINE; st=$?
+  eq "read status" $st 0
+  eq "exchange finished" $_zrush_sync_done 1
+  eq "exchange succeeded" $_zrush_sync_ok 1
+  eq "target no longer pending" ${+_zrush_worker_pending[1]} 0
+  eq "receive buffer consumed" ${#_zrush_worker_rx} 0
+  eq "session failures" $_zrush_worker_failures 0
+  eq "warnings" $#WARNINGS 0
+  sync_teardown
+  verdict "sync read: the target's terminal response commits the exchange"
+
+  # ============================================================ case 9
+  # Same response, now followed by responses for other request_ids that arrived
+  # in the same read. The exchange ends at the target; the rest stays buffered
+  # for the asynchronous path instead of being processed inside the sync window.
+  sync_setup trailing
+  msg_ok 1; typeset -g TARGET=$REPLY
+  msg_ok 2; typeset -g TRAILING=$REPLY
+  msg_ok 3; TRAILING+=$REPLY
+  _zrush_worker_rx=$TARGET$TRAILING
+  DEADLINE=$(( EPOCHREALTIME + 5 ))
+  _zrush_worker_read sync $DEADLINE; st=$?
+  eq "read status" $st 0
+  eq "exchange finished" $_zrush_sync_done 1
+  eq "exchange succeeded" $_zrush_sync_ok 1
+  eq "trailing bytes left buffered" ${#_zrush_worker_rx} ${#TRAILING}
+  eq "trailing bytes left untouched" "$_zrush_worker_rx" "$TRAILING"
+  eq "trailing requests still pending" $#_zrush_worker_pending 2
+  eq "session failures" $_zrush_worker_failures 0
+  eq "warnings" $#WARNINGS 0
+  sync_teardown
+  verdict "sync read: trailing responses are left to the asynchronous path"
+
+  # ============================================================ case 10
+  # The same buffer under a deadline that trips the instant the target's
+  # response is committed -- the worst moment there is, and the one a clock
+  # cannot be aimed at. A success already committed is never withdrawn.
+  sync_setup expiring
+  msg_ok 1; TARGET=$REPLY
+  msg_ok 2; TRAILING=$REPLY
+  msg_ok 3; TRAILING+=$REPLY
+  _zrush_worker_rx=$TARGET$TRAILING
+  typeset -g DEADLINE_FN=$functions[_zrush_worker_deadline_expired]
+  _zrush_worker_deadline_expired() { [[ -n $1 ]] && (( _zrush_sync_done )) }
+  DEADLINE=$(( EPOCHREALTIME + 5 ))   # the oracle, not this value, decides expiry
+  _zrush_worker_read sync $DEADLINE; st=$?
+  functions[_zrush_worker_deadline_expired]=$DEADLINE_FN
+  eq "read status" $st 0
+  eq "exchange finished" $_zrush_sync_done 1
+  eq "exchange succeeded" $_zrush_sync_ok 1
+  eq "trailing bytes left buffered" ${#_zrush_worker_rx} ${#TRAILING}
+  eq "session failures" $_zrush_worker_failures 0
+  eq "warnings" $#WARNINGS 0
+  sync_teardown
+  verdict "sync read: a deadline expiring after the commit cannot undo it"
 
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"
 } always {

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -1271,6 +1271,10 @@ _zrush_worker_read() {  # async | sync [absolute-deadline]
       _zrush_worker_rx=$REPLY_REST
       (( ++frames ))
       _zrush_worker_handle_message "$message" "$deadline" || return 1
+      # Returning rather than continuing keeps the rest of the buffer off the
+      # keystroke path -- the deadline is sync mode's only bound -- and keeps
+      # the loop-top check from tripping on a result already committed.
+      [[ $mode == sync ]] && (( _zrush_sync_done )) && return 0
       continue
     fi
     if (( st == 2 )); then
@@ -1599,6 +1603,10 @@ _zrush_request_plan_sync() {
   done
   local -i ok=$_zrush_sync_ok
   _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
+  # Only once the synchronous state is cleared, and never propagating the
+  # status: arming fails by failing the session, which tears the transport down
+  # and would take this exchange's committed result with it.
+  [[ -n $_zrush_worker_rx ]] && _zrush_worker_arm_drain
   (( ok ))
 }
 


### PR DESCRIPTION
Closes #42.

The synchronous history exchange kept reading after the target request's terminal response had already been committed, and the deadline check at the top of the read loop applied to that drain.
Tripping it ran `_zrush_worker_session_fail`, whose transport teardown resets `_zrush_sync_done` and `_zrush_sync_ok`, withdrawing a success that had been committed on time: the history menu did not open, and the counted failure brought the shell one step closer to the permanent `_zrush_disabled=1`.

Suppressing the deadline once the target arrived would fix that symptom while leaving the drain unbounded, because synchronous mode has no other bound — the `frames >= 32` and `reads >= 4 || bytes >= 32768` caps in `_zrush_worker_read` are both gated on asynchronous mode.
The open latency of the history menu would then depend on the size of an unrelated, already-cancelled completion response.

This ends the exchange instead.
`_zrush_worker_read` returns the moment the target's terminal response is committed, and whatever else is buffered is left to the asynchronous path, which `_zrush_request_plan_sync` arms once its synchronous state has been reset.
No deadline check can run after the commit because there is no longer anything after it, and the keystroke path stays bounded.

The deadline checks themselves are unchanged: they still govern the period while the target is being waited for, as `behavior.md` requires.

`_zrush_worker_arm_drain` is called only after the synchronous state has been reset, and its status is not propagated.
It fails by failing the session, which tears the transport down and would take this exchange's committed result with it — the same defect being fixed here.

## Spec

`docs/internal/specs/behavior.md`, 履歴メニュー: the synchronous wait ends when the target request_id's complete terminal response is received, and already-received responses behind it are left to the asynchronous path.
The existing wording that scopes the deadline, and the wording that makes a prior asynchronous request's serial processing consume the same deadline, are both untouched — they describe the period while the target is being waited for.

## Tests

`tests/zsh/transport.zsh` gains three cases and its scope note now covers the read loop:

- the target's terminal response commits the exchange (control);
- trailing responses are left to the asynchronous path (the structural change);
- a deadline expiring after the commit cannot undo it (the reported symptom).

The third replaces `_zrush_worker_deadline_expired` with an oracle that reports expiry from the state of the exchange rather than from the clock, so the deadline trips exactly at the commit — the worst instant, and one a clock cannot be aimed at.
The seam is documented in the file header alongside the existing ones and the original function is restored immediately after the call.

With the fix reverted, cases 9 and 10 fail; case 10 reports `read status=1`, `sync_done=0`, `sync_ok=0`, `failures=1`, `warnings=1`, which is issue #42's symptom.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build --release`, `cargo test` (202 + 22 + 5) all pass.
`tests/zsh/transport.zsh` 10/10, `tests/zsh/vectors.zsh` 74/74, `tests/zsh/driver.zsh` 144 PASS / 0 FAIL (1 OBSV, the pre-existing `inflight-1c` timing observation), `tests/zsh/driver-coexist.zsh` 37 PASS / 0 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4fNKBkRZH5sKTjw1a8o4o
