### PR TITLE
fix(history): build the payload from one bulk value expansion

### DIFF
--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -1545,25 +1545,27 @@ _zrush_apply_highlights() {
 _zrush_history_payload() {  # -> REPLY = candidate payload bytes
   emulate -L zsh
   local -i limit=$ZRUSH_CFG_HISTORY_LIMIT
-  local -a events=()
-  if (( limit > 0 )); then
-    events=( "${(@k)history}" )
-    (( $#events > limit )) && events=( "${(@)events[1,limit]}" )
-  fi
+  local -a kv=()
+  (( limit > 0 )) && kv=( "${(@kv)history}" )   # one bulk expansion: event/line pairs, newest first
   local -A seen=()
-  local event line
-  local -a recs=( b$'\1' )
-  for event in "${(@)events}"; do
-    line=$history[$event]
+  local event line block=b$'\1'
+  local -i pending=0
+  local -a blocks=()
+  for event line in "${(@)kv[1,2 * limit]}"; do   # two elements per entry
     # Within the raw scan window (nothing is pulled in from outside it to make
     # up for a drop), reject empty/framing-byte lines and retain only the
     # newest event number for each distinct line.
     [[ -n $line && $line != *$'\0'* && $line != *$'\1'* && $line != *$'\2'* ]] || continue
     (( ${+seen[$line]} )) && continue
     seen[$line]=1
-    recs+=( w$'\1'$line$'\2'n$'\1'$event )
+    block+=$'\0'w$'\1'$line$'\2'n$'\1'$event
+    # Appending to a zsh string or array copies everything it already holds, so
+    # growing either one record at a time is quadratic. Sealing the open block
+    # every 16 records bounds both copies and keeps the total linear.
+    (( ++pending < 16 )) || { blocks+=( "$block" ); block=; pending=0; }
   done
-  typeset -g REPLY=${(pj:\0:)recs}$'\0'
+  blocks+=( "$block" )
+  typeset -g REPLY=${(pj::)blocks}$'\0'
   return 0
 }
 


### PR DESCRIPTION
Closes #40.

`_zrush_history_payload` expanded only the history keys in bulk and then fetched each line individually with `line=$history[$event]` inside the scan loop. Those per-event lookups on the `history` special parameter are superlinear in the scan window, so opening the history menu cost about 90 ms at the default `[history].limit = 5000` — violating the synthesis-cost guarantees stated in `cli-protocol.md` ("history profile"), `config-schema.md` (`[history]`), and `configuration.md`.

This change makes the code meet the contract as written; no docs change.

- Replace the key-only expansion + per-event lookups with a single bulk expansion of event/line pairs (`${(@kv)history}`), scanned pairwise. A pre-check verified that `(@kv)` yields the same newest-first order as `(@k)` with keys and values correctly interleaved (machine-checked up to 10000 entries, zero mismatches).
- While fixing this, a second superlinear component surfaced: appending records one at a time (`recs+=( ... )`) copies everything the array already holds on every append, so record accumulation was quadratic on its own (isolated: 1.3 ms at 1000 records → 39 ms at 10000). Replaced with a two-stage accumulation that seals the open block every 16 records, which bounds both copies and keeps the total linear. Array `+=`, string `+=`, and indexed assignment were each measured quadratic in isolation, which is why blocking was chosen.

The payload is byte-identical to the previous implementation, machine-verified across 44 boundary cases in an isolated environment (empty history, various limits, block boundaries at multiples of 16, framing-byte lines, duplicate lines, multi-line entries).

## Measurements

macOS 27.0 (Darwin 27.0.0), Apple M3, zsh 5.9, isolated `zsh -f` environment with `HOME`/`XDG_CONFIG_HOME`/`HISTFILE` redirected to a temp dir; reproduction script from #40, `[history].limit = 5000`:

| entries scanned | before | after |
|---|---|---|
| 1000 | 6.6 ms | 5.8 ms |
| 5000 | 49.0 ms | 29.0 ms |

The 5000/1000 ratio drops from 7.3x to 5.0x, matching the entry ratio. Sweeping with `limit = 20000` shows a flat 5.6–6.0 ms per 1000 entries across the whole range (the old implementation grows monotonically from 6.6 to 21.6 ms per 1000, reaching 432 ms at 20000 entries vs. 115 ms after the fix).

## Verification

`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --release` / `cargo test` (231 passed), `tests/zsh/driver.zsh` (149 ok), `tests/zsh/driver-coexist.zsh` (37 ok), `tests/zsh/vectors.zsh` (74 ok), `tests/zsh/transport.zsh` (10 ok) — all green, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188nuvy2RuoqqWz8FBSzAMp