### PR TITLE
fix(zle): keep the persistent worker out of the interactive shell's job table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ name = "zrush"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "libc",
  "nucleo-matcher",
  "proptest",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 rust-version = "1.88"
 
 [dependencies]
+# Unix fd validation and the watchdog's process-wide immediate exit. The
+# standard library exposes OwnedFd but not fcntl(2) or _exit(2).
+libc = "0.2"
 # CLI argument parsing (derive). Declarative parsing keeps subcommand,
 # --help, and usage-error behavior robust at the process boundary.
 clap = { version = "4.6", features = ["derive"] }

--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -18,7 +18,7 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 > 検証: 版番号のコピーの一致 — `src/config.rs` のテスト `protocol_version_matches_docs_and_zsh`。
 
-- **PROTOCOL_VERSION = 6**
+- **PROTOCOL_VERSION = 7**
 - `zrush config` の出力に `ZRUSH_PROTOCOL_VERSION` が含まれる。
   zrush.zsh は自身が期待する版番号と照合し、不一致なら警告を 1 回表示して zrush を無効化する。
   zrush.zsh はバイナリに埋め込まれて配布される(「zrush init」節)ため、
@@ -27,7 +27,8 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
   かつ古い版の常駐 worker を保持している状況である。
 - 照合の機会を保証するため、zrush.zsh は **source 時に無条件で `zrush config` を 1 回実行**する
   (config.toml の mtime 変化だけをトリガにすると、バイナリのみ更新された場合に照合されない)。
-- 互換性が壊れる変更(フィールドの追加・削除・意味変更、キー記法の変更)で版番号を上げる。
+- 互換性が壊れる変更(フィールドの追加・削除・意味変更、worker の必須 CLI/control 契約、キー記法の変更)で
+  版番号を上げる。
 - 未知の引数を渡された `zrush` は exit 2 で拒否する(前方互換より誤用の早期検出を優先する意図的選択。
   版不整合は上記の警告で検知される)。
 
@@ -90,7 +91,7 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 | コード | 意味 |
 |---|---|
 | 0 | 成功。worker は frame 境界での stdin EOF、`zrush config` は設定ファイルの問題があっても既定値と警告を出力して成功する。`zrush init` は自身の絶対パス解決とスクリプト出力に成功する |
-| 1 | worker の session-fatal framing/I/O/内部エラー、`zrush config` の内部エラー、または `zrush init` の自身のパス解決失敗を含む内部エラー |
+| 1 | worker の session-fatal framing/I/O/内部エラー、control-fd の setup failure、watchdog による abort、`zrush config` の内部エラー、または `zrush init` の自身のパス解決失敗を含む内部エラー |
 | 2 | usage エラー(未知・不足・不正な引数、未知または未指定のサブコマンド) |
 
 `--help` / `-h`、および `help` サブコマンドは使用方法を表示して exit 0 する。
@@ -106,10 +107,15 @@ zsh がそのまま適用できる描画プランを返す。
 ### 起動と責務
 
 ```
-zrush worker
+zrush worker --control-fd N
 ```
 
-引数は取らない。未知の引数は起動前に exit 2 で拒否する。起動後は stdin から要求を読み、
+`--control-fd N` は必須で、`N > 2` の open 済み readable Unix fd を指定する。
+worker は検証後にこの fd の sole ownership を引き取り、watchdog 以外からは使用しない。
+option の欠落、数字でない/2 以下の値、未知または余分な引数は起動前に exit 2 で拒否する。
+fd が closed / write-only である場合、または watchdog setup に失敗した場合は、`hello` / `ready` や
+request 処理を始める前に startup 診断を stderr へ 1 行書いて exit 1 する。
+起動後は stdin から要求を読み、
 要求ごとにマッチング・ランキング・グループ分割・グリッドレイアウト・ハイライト計算・
 ナビゲーション表構築・挿入テキスト構築を行って stdout へ応答する。
 one-shot の `zrush plan` サブコマンドは存在しない。
@@ -117,6 +123,24 @@ one-shot の `zrush plan` サブコマンドは存在しない。
 ワーカーは **config.toml を読まない**。設定スナップショットは要求フィールドで受け取る
 (設定の取得・mtime 監視は zsh 側の責務)。`HISTFILE` も読まず、候補 payload 全体を要求ごとに受け取る。
 ただしファイルシステムに対しては純粋でない: `f = 1` 候補の `/` 合成判定だけは要求の `cwd` を基準に stat する。
+
+### abort control と worker 終了
+
+`--control-fd` は request/response protocol と独立した private control byte stream で、message framing を持たない。
+worker は通常の request 処理を始める前に watchdog thread を起動し、control fd を blocking read する。
+
+- 1 byte 以上を受信した場合は値によらず abort。zsh は byte 1 個だけを書けばよい。
+- EOF は control writer の喪失を表し、同じく abort。
+- `EINTR` は read を retry し、それ以外の read error は fatal abort。
+- abort は小さな Unix 専用 wrapper から process 全体へ `_exit(1)` を実行する。
+  main worker thread が request 処理で停止していても watchdog 単独で終了させる。
+- watchdog は detached であり、frame 境界の stdin EOF による main thread の正常 exit 0 を妨げない。
+  zsh は正常 shutdown の response EOF まで control write fd を open に保ち、先に閉じて abort と競合させない。
+
+stdout(fd 1)は response stream 専用で、worker は起動時に cloexec を付ける。
+worker が起動する descendant は fd 1 を継承しないため、zsh は buffered response bytes を raw drain した後の
+stdout EOF を worker completion の唯一の oracle にできる。control channel は supervisor process でも
+request/response の shutdown message でもなく、request/response の netstring fields は変更しない。
 
 ### セッションフレーミングと握手
 
@@ -143,8 +167,8 @@ message   = netstring(netstring(field-1) ... netstring(field-N))
 zsh は kind・フィールド数・版番号が完全一致する `ready` を受けたときだけセッションを利用する。
 
 ```
-hello:        ["hello", "6"]
-ready:        ["ready", "6"]
+hello:        ["hello", "7"]
+ready:        ["ready", "7"]
 incompatible: ["incompatible", worker_version]
 ```
 
@@ -609,7 +633,8 @@ zsh は一覧を消す。
   stale 応答も正常に形成されていれば終端応答として扱い、失敗回数を戻す。
 - worker の stderr は端末に流さない(zle 表示を壊さないため)。`ZRUSH_LOG` が設定されていれば
   診断をそこへ追記し、未設定なら `/dev/null` へ送る。
-  worker はセッション失敗で終了するとき、その理由を 1 行の診断として stderr に書いてから終了する。
+  main request 処理がセッション失敗で終了するときは、その理由を 1 行の診断として stderr に書いてから終了する。
+  control byte / EOF / fatal read error の watchdog abort は `_exit(1)` を使うため、この診断を要求しない。
   この行の内容は契約の対象外であり、zsh が解析してはならない。
 - セッション失敗時の破棄・再起動・無効化・警告は behavior.md「worker ライフサイクル」が定める。
 
@@ -637,7 +662,7 @@ zrush config
 ### stdout(zsh source 形式)
 
 ```zsh
-typeset -g  ZRUSH_PROTOCOL_VERSION='6'
+typeset -g  ZRUSH_PROTOCOL_VERSION='7'
 typeset -g  ZRUSH_CFG_MAX_LINES='10'
 typeset -g  ZRUSH_CFG_DELAY_MS='30'
 typeset -g  ZRUSH_CFG_MIN_INPUT='0'
@@ -734,10 +759,14 @@ typeset -g ZRUSH_BIN=${ZRUSH_BIN:-'<自身の絶対パス>'}
 ## 想定シーケンス(参考・規範ではない)
 
 1. source 時: `.zshrc` の `source <(zrush init zsh)` が `$ZRUSH_BIN` prelude と埋め込みスクリプトを読み込む。
-   埋め込みスクリプト自身の source 時処理として `zrush config` を実行し、版番号を照合してキーバインドを適用する。
+   埋め込みスクリプト自身の source 時処理として `zrush config` を実行し、版番号を照合し、private runtime directory と
+   request/response/abort-control FIFO を同期的・transactional に作成してからキーバインドを適用する。
 2. プロンプト表示ごと: config.toml の mtime を確認し、変化していれば
    `zrush config` を再実行して source、キーバインドを再適用、警告があれば表示。
-3. 最初の実要求時: `zrush worker` を起動して `hello` / `ready` を交換する。
+3. 最初の実要求時: source 時に作成済みの FIFO endpoint だけを開き、abort-control FIFO の read fd を渡して
+   `zrush worker --control-fd N` を起動し、watchdog setup 後に `hello` / `ready` を交換する。
+   遅延起動時に runtime directory/FIFO を作成してはならない。spawn 後の parent endpoint/watcher failure と
+   writer notification/watcher failure の fail-closed quarantine・runtime taint は behavior.md が定める。
 4. 入力変化 → デバウンス → zpty 収集完了後: zsh が pid レコードを取り除いた
    捕獲 payload を `producer = compsys` の plan 要求で worker に送る。
    対応する `ok` の描画プランを POSTDISPLAY / region_highlight に適用する。

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -26,82 +26,132 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   (規範は `../contracts/cli-protocol.md`「適用」節)。
 - **入力は決してブロックしない**: 候補収集は非同期で行う。
   収集が遅い場合も「一覧が遅れて出る」だけで、打鍵は常に即応する。
-  ただし履歴メニュー(後述)はユーザーの明示操作であり、同期実行を許す:
-  走査する履歴エントリ数は `[history].limit` 件までに限り、worker 交換には固定の絶対 100ms deadline を置く。
+  この原則に対する同期的な例外は、ユーザーが明示した履歴メニュー(後述)と、
+  process の重複・frame 途中の EOF・fd の取り違えを防ぐための worker lifecycle 停止だけである。
+  履歴メニューで走査する履歴エントリ数は `[history].limit` 件までに限り、worker 交換には
+  固定の絶対 100ms deadline を置く。lifecycle 停止も後述の 1 本の絶対 100ms deadline 内だけ
+  同期待機を許し、正常 shutdown から異常 abort へ移っても更新しない。超過後は入力へ戻して
+  readiness-driven cleanup を続けるため、入力を無期限に止めない。
 - **確定は挿入のみ**: コマンドは実行しない(実行はもう一度 Enter)。
 - zrush は compinit を実行しない。compsys 未初期化を検知したら警告のみ表示する。
 
 ## worker ライフサイクル
 
-- 対話シェルごとに `zrush worker` を最大 1 プロセス持つ。source 時には `zrush config` だけを one-shot で実行し、
-  worker は最初の plan 要求が生じた時点で遅延起動する。worker は config.toml と `HISTFILE` を読まず、
-  候補キャッシュ・履歴 payload 合成・デバウンス/収集キャンセルの状態も持たない。
-- worker の stdin/stdout は pty ではなく専用 pipe へ接続する。zsh は stdout の read fd を `zle -F` で監視し、
-  通常の補完 plan 応答を非同期に読む。セッションの nested-netstring 形式と `hello` / `ready` 握手は
-  `../contracts/cli-protocol.md` が定める。
-- worker は対話シェルの job table に登録せず、動作中でもシェルの `exit` を妨げない。
-- 通常の補完経路では、worker の cold start と握手を待たない。起動処理は ZLE へ直ちに制御を返し、
-  `hello` も outbound queue の先頭フレームとして、他の plan 要求と同じく後述の writer child 経由で送る。
-  `ready` の受信は worker stdout の既存の `zle -F` callback で進める。
-  握手中に生じた plan 要求は `hello` より後ろの outbound queue に置く。
-  同期的に worker を待ってよいのは履歴メニューだけであり、その待機も後述の 1 本の絶対 100ms deadline 内に限る。
-- worker stdin への送信はフレーム単位で行う。
-  フレームは不可分な送信単位であり、outbound queue は完成済みフレームのリストを持つだけで、
-  対話シェル側に送信オフセットは存在しない。
-  対話シェルは worker stdin(request FIFO)への blocking な write fd を worker 起動時に確保し、
-  FIFO パスの unlink 前に開いた上で cloexec を付けて worker には継承させない
-  (fork した子は cloexec の性質上、exec するまで fd を引き継ぐ)。
-  1 フレームの送信は、この blocking fd を渡して fork した短命な writer child に委譲する。
-  writer child は 1 回の `syswrite` でフレーム全体を書き切り、書き終えたら通知用パイプへ
-  ack バイトを 1 個書く。
-  writer child は worker と同じく対話シェルの job table に登録しない。
-  対話シェルは通知 fd を `zle -F` で監視し、blocking write を一切行わず
-  ZLE callback 内で書き込み完了を待たない。
-  ack の消費は通知 fd の readiness を確認したうえで行い、通知 fd の `zle -F` callback・
-  worker 応答の受信時・同期履歴ループのいずれから行ってもよい。
-  in-flight の writer child は常に高々 1 個であり、次のフレームは直前の child が
-  ack バイトを書いた時点で送る。
-  worker は受信した plan を直列に処理するため、この直列送信によって queue も request_id 順を保つ。
-  busy loop は行わない。
-- queue に入った通常の補完要求は、新しい要求で coalesce・置換・除去しない。
-  送信時点ですでに stale でも同じ session 上で順に送り、worker の終端応答まで読み取って UI への適用だけを捨てる。
-  request FIFO の backpressure が及ぶのは writer child の `syswrite` だけであり、ZLE を止める理由にはならない。
-  queue の残りは、writer child からの ack を受けてから次のフレームとして送る。
-- `request_id` は zsh が所有し、実 plan 要求ごとに増やす。同じシェルセッションでは worker の再起動後も
-  リセット・再利用しない。新しい実要求を開始した後に古い request_id の正常応答が届いても stale として捨て、
-  表示には適用しない。worker は受け取った各要求へ `ok` / `error` を 1 個返し、zsh 側の stale 判定を理由に
-  応答を省略させない。
-- 外側/nested framing の破損、stdout の EOF/read error、writer child の通知 fd が ack バイトなしで
-  EOF に達すること(stdin の write 失敗)、予期しない終了、要求と対応しない応答、
-  仕様を満たさない `ok` の描画プラン、履歴交換の deadline 超過は **worker セッション失敗**である。
-  stdin の write 失敗は通知 fd の EOF/ack のみで判定し、writer child の終了ステータスからは
-  一切推測しない。
-  その session に割り当て済みで終端応答のない要求を、writer child に渡して送信中のフレーム・
-  outbound queue 内のフレーム・送信済みの要求の区別なくすべて破棄し、既存一覧も消す。
-  いずれも自動 replay しない。
-  in-flight の writer child がいれば、未送信のフレームを queue から破棄したうえで
-  その child の終了を有界時間だけ待ち、なお終了しなければ TERM してから KILL する。
-  フレーム送信の途中で kill された child は request FIFO に不完全なフレームを残すが、
-  これは worker がフレーミングエラーとして検出する想定内の abort 挙動であり、正常な EOF とは区別できる。
-  worker プロセスが残っていれば終了させて消滅を確認し、`zle -F` watcher を解除して
-  stdin/stdout pipe fd と通知 fd を閉じ、head-of-line blocking を残さない。
-  この cleanup が完了するまで代替 worker を起動せず、worker を重複させない。
-- 連続 worker セッション失敗回数は、正常に形成された終端 `ok` / `error` を受けたときだけ 0 に戻す。
-  握手成功だけでは戻さない。1 回目の失敗後は worker 不在のままにし、**次の実要求**で 1 個だけ代替 worker を
-  遅延起動する。終端応答を 1 個も受けないまま 2 回目のセッション失敗が起きたら、そのシェルでは zrush を無効化する。
-  無限 respawn や one-shot plan への fallback は行わない。
-- `hello` / `ready` の版不一致または worker の `incompatible` 応答は、失敗回数による再起動を介さず
-  即座に zrush を無効化する。source 時の `zrush config` 版照合も同じく不一致なら無効化する。
-- worker 障害のユーザー向け警告は、種類や再発回数によらず同じシェルセッションで高々 1 回表示する。
-  `ZRUSH_LOG` が設定されている場合、ユーザー向け警告を抑止した後も各障害の診断を追記する。
-- worker の起動・通常終了・異常終了・再起動・re-source・無効化を含む全 lifecycle で、zsh が所有する
-  内部 fd の操作は対話シェル自身の fd 0 / 1 / 2 の open / closed 状態と接続先を変更しない。
-  内部 fd の close error を抑止するときも、その抑止を対話シェルの標準エラーへ恒久適用しない。
-- 同じシェルで zrush.zsh を re-source するときは、既存 worker プロセスを終了させて消滅を確認し、`zle -F` watcher を解除して
-  stdin/stdout pipe fd を閉じてからフックとキーバインドを再構築する。cleanup 中に新旧 worker を重複させない。
-  re-source は同じシェルセッションの request_id 単調性・警告済み状態・連続失敗回数・無効化状態を巻き戻さない。
-  `zshexit` でも worker プロセスを終了させて消滅を確認し、watcher を解除して pipe fd を閉じる。
-  worker が既に終了していることはエラーにしない。
+- zsh script の source generation ごとに、mode 0700 の private runtime directory を 1 個同期的に作り、
+  その中に mode 0600 の request / response / abort-control FIFO を 1 個ずつ持つ。
+  request は worker stdin、response は worker stdout、abort-control は watchdog の入力に使う。
+  runtime directory と FIFO の path はその generation だけが所有し、設定項目にはしない。
+  runtime の作成は source 時だけに行い、遅延 worker 起動は既存の path を開くだけで同期的な directory/FIFO 作成を
+  行わない。通常の worker session 交換では taint されていない同じ directory を再利用し、re-source の handoff
+  完了時または shell exit 時に所有する正確な path だけを unlink して directory を破棄する。
+- runtime directory/FIFO の作成、worker spawn 前の各 endpoint fd 取得、cloexec の設定、active state の公開は
+  transaction として行う。spawn 前の失敗は local な fd/path を rollback し、部分的な session を公開しない。
+  未設定/割り当て失敗の fd を 0 と解釈せず、fd 0 / 1 / 2 を internal state へ格納したり stdin を監視したり、
+  worker 起動/交換を部分的に active にしたりしない。source 時の同期 setup に失敗した generation は
+  hook/keybind/worker transport を有効化しない。
+- worker を spawn した後の parent endpoint allocation・cloexec・active-state 公開の失敗は、spawn 前の rollback には
+  戻せない。local response/request/control fd を rollback 専用 state として公開して stopping gate を立て、control
+  byte/EOF と request close で fail-closed abort を開始する。worker が ownership を持つ response stream の read fd は
+  completion oracle として保持して raw drain し、response EOF と存在する writer gate の解決までは新しい worker を
+  許可しないため、部分公開や worker overlap を起こさない。
+- spawn 後の response watcher 登録に失敗した runtime は taint し、所有する 3 つの FIFO 名を直ちに unlink して
+  既に開いた inode へ old worker/parent を閉じ込める。runtime directory/path の ownership ledger は source cleanup
+  まで保持し、response EOF まで上記の rollback quarantine を続ける。readiness cleanup を保証できない場合は
+  fail-closed のまま direct な明示 cleanup または shell exit に委ねてよい。EOF finalization 後も taint は残り、
+  同じ source generation で worker を交換しない。
+- worker は最初の実 plan 要求で遅延起動し、対話シェルごとに高々 1 個とする。
+  stdin/stdout は request/response FIFO に接続し、abort-control FIFO の read fd を
+  `zrush worker --control-fd N` で渡す(詳細は `../contracts/cli-protocol.md`)。
+  worker と短命な writer child は対話シェルの job table に登録せず、zsh は両者の numeric PID を
+  lifecycle state に記録せず、signal / `wait` / exit status で終了を判定しない。supervisor process も設けない。
+- worker は通常の request 処理より先に watchdog thread を起動する。zsh は正常 session 中、
+  abort-control FIFO の write fd を open のまま保持する。watchdog は control byte を 1 個でも受けた場合、
+  control EOF、または retry 不能な read error の場合に process 全体を `_exit(1)` させる。
+  正常な frame 境界の request EOF だけは worker の通常 exit 0 を生じさせる。
+  worker は response FIFO に接続した fd 1 を自身の lifetime 全体で所有し、起動時に cloexec を付けて
+  descendant へ継承させない。したがって raw drain 後の response EOF だけを worker completion の oracle とし、
+  control channel や request FIFO の EOF、job/exit status から完了を推測しない。
+- request/response の nested-netstring と `hello` / `ready` は
+  `../contracts/cli-protocol.md` が定める。通常の補完経路は cold start・握手・応答を同期的に待たず、
+  response fd の `zle -F` callback で進める。同期的に起動/plan 応答を待てるのは履歴メニューだけで、
+  その 1 本の絶対 100ms deadline に起動・握手・先行 request・対象応答をすべて含める。
+- worker stdin への送信単位は完成済み frame 1 個で、outbound queue に send offset を持たない。
+  対話シェル自身は request FIFO へ blocking write せず、cloexec 付き request write fd を fork した
+  短命な writer child に渡す。fork した child は request と通知以外の transport fd copy を直ちに閉じ、
+  control/response EOF を保持しない。writer は 1 回の `syswrite` で frame 全体を書き、直後に自身の request fd を
+  閉じてから通知 pipe へ ack byte 1 個を書く。ack は full-frame delivery を証明し、その時点で writer の
+  通知 watcher/fd、transport ownership、sole writer slot を解放するため、通常送信では writer process の
+  通知 EOF を待たず次 frame を渡してよい。ack 前の通知 EOF は write failure であり、通常 session を失敗にする。
+  停止中の unacked writer は ack または通知 EOF のどちらかを観測するまで replacement gate として残るが、
+  numeric PID や writer process の消滅確認は必要としない。
+- writer を spawn した後に notification fd の取得、watcher 登録、または slot 公開が失敗した場合は、frame が
+  request FIFO へ部分的に届いた可能性を否定できないため、その 3-FIFO runtime generation 全体を taint する。
+  所有する 3 つの FIFO 名を直ちに unlink して open 済み inode へ old writer/worker を閉じ込め、worker を異常 abort
+  する。取得済みの notification fd があれば ack/EOF まで gate として保持し、response EOF まで raw drain する。
+  runtime directory/path の ledger は source cleanup まで保持するが、taint された FIFO inode/runtime は replacement に
+  再利用しない。cleanup 後も同じ source generation では worker を再開せず、新しい source generation の同期 runtime
+  setup が成功した後だけ transport を再び有効化する。notification watcher 登録に失敗した場合は direct な明示
+  cleanup まで fail-closed でよい。
+- 通常の queue は coalesce・置換・除去せず request_id 順に直列送信する。送信時に stale でも worker の
+  終端応答まで読み、UI 適用だけを捨てる。backpressure を受けるのは writer の `syswrite` だけで、
+  ZLE callback は ack を同期的に待たず busy loop もしない。
+- response / writer-ack / drain の callback 登録ごとに同じ shell session 内で単調増加する compact generation を
+  割り当て、callback は fd と generation が現在の登録に一致するときだけ state を変更する。response と ack の
+  watcher は停止開始時にも登録を保ち、callback 自身が stopping gate を見て通常の parse/send ではなく raw drain /
+  stop-progress へ分岐する。停止専用の別 callback kind へ登録し直さない。finalization・rollback は watcher より先に
+  registration generation を無効化するため、snapshot 済み callback や numeric fd 再利用後の stale callback は
+  何もしない。fd/watcher/generation/active state の公開と rollback も transaction とする。
+- transport の停止には、健全な session を手放す **正常 shutdown** と、session を信用できない
+  **異常 abort** がある。どちらも最初に stopping gate を立て、normal callback と新しい enqueue/send/start を止め、
+  unhanded frame と session の未完了 request をすべて破棄し、一覧を消して replay しない。
+  zrush の disable policy は stop mode と別に決める。
+- 正常 shutdown は unhanded frame を破棄し、unacked writer があれば full-frame ack を待つ。
+  ack を受けると writer が既に自身の request fd を閉じているため、対話シェルの request write fd を閉じて
+  frame 境界の EOF を作る。その後も abort-control write fd は閉じず、response FIFO を bytes のまま EOF まで
+  raw drain する。drain 中の `ready` / `ok` / `error` は parse も UI 適用もしない。
+  response EOF と、writer slot が ack または通知 EOF で解決して通知 watcher/fd も解放済みであることの
+  両方で停止完了とする。
+- 異常 abort は abort-control FIFO へ byte 1 個(値は任意)の送信を 1 回だけ試み、その write fd と
+  対話シェルの request write fd を閉じる。byte を送れなくても control EOF が watchdog を停止させる。
+  response FIFO は正常 shutdown と同じく raw drain し、response EOF を worker completion とする。
+  unacked writer は ack または通知 EOF まで replacement gate に残す。abort は request を replay せず、
+  response を通常応答として parse/apply しない。
+- 1 回の lifecycle stop が入力を同期的に止めてよいのは、開始時に定めた **1 本の絶対 100ms deadline** 内だけである。
+  正常 shutdown 中の ack failure や session failure は同じ deadline のまま abort へ遷移し、
+  deadline を更新しない。deadline までに停止 predicates が揃わなければ control byte/EOF による abort を確実に開始して
+  入力へ制御を戻し、runtime directory・endpoint・stopping gate を quarantine として保持する。
+  以後は generation 検証付きの既存 ack/response callback が stopping branch で readiness-driven に writer gate の解決と
+  raw response drain を続け、新しい deadline や同期 loop を開始しない。response EOF と writer gate 解決後にだけ
+  finalization が fd/session state を解放し、代替 worker を許可する。
+- 外側/nested framing の破損、通常処理中の response EOF/read error、ack なしの writer 通知 EOF、
+  予期しない終了、要求と対応しない応答、仕様を満たさない `ok`、履歴交換の deadline 超過は
+  **worker session failure** であり、異常 abort を開始する。その session の未完了 request は
+  queue/送信中/送信済みを区別せず破棄して replay しない。
+- 連続 worker session failure 回数は、正常に形成された終端 `ok` / `error` を受けたときだけ 0 に戻す。
+  握手成功だけでは戻さない。1 回目の失敗を finalization した後は worker 不在のままとし、次の実要求で
+  代替 worker を 1 個だけ遅延起動する。終端応答なしの 2 回目でその shell の zrush を無効化し、
+  無限 respawn や one-shot fallback は行わない。ただし taint された runtime generation はこの通常の 1 回交換の
+  対象外であり、cleanup 後も fresh re-source まで代替 worker を起動しない。
+- `hello` / `ready` の版不一致、worker の `incompatible`、source/config の protocol 版不一致は
+  失敗回数を介さず zrush を無効化する。認識済み `incompatible` や local request_id 枯渇のように
+  transport が健全なら正常 shutdown、壊れた handshake/session なら異常 abort を使う。
+  stopping/quarantine 中の re-source・config reload・protocol 照合は fail fast し、新しい deadline や stop を
+  自動開始せず、既存 generation の functions/hooks/runtime directory/endpoints/stopping gate を保持する。
+- 同じ shell で re-source するときは、旧 generation の hook/keybind を外す前に正常 shutdown を開始する。
+  同じ invocation の deadline 内に predicates が揃った場合だけ旧 fd/path/hook を finalization し、
+  private runtime directory を破棄してから新 generation の同期 setup と hook/keybind 導入へ進む。
+  deadline 超過時は re-source 自体を失敗させ、非同期 cleanup は旧 worker session の finalization だけを行う。
+  新 generation の導入は cleanup 完了後の次の re-source invocation に任せる。
+  旧 generation が quarantine 中の re-source は fail fast し、新旧 transport を重複させない。
+  request_id と callback generation の単調性・警告済み状態・連続失敗回数・無効化状態は巻き戻さない。
+- `zshexit` も同じ停止を開始し、同期待ちは 100ms を超えない。deadline で未完了でも shell exit を妨げず、
+  control/request/response を含む所有 fd を閉じ、所有する正確な FIFO path と runtime directory を unlink する。
+  control EOF により worker watchdog は abort し、この経路も numeric PID・`wait`・exit status を使わない。
+- worker 障害の user warning は同じ shell session で高々 1 回表示する。`ZRUSH_LOG` が設定されていれば
+  warning 抑止後も診断を追記する。worker stderr は端末へ流さない。
+- worker の起動・正常 shutdown・異常 abort・交換・quarantine・re-source・disable・exit の全経路で、
+  internal fd 操作は対話シェル自身の fd 0 / 1 / 2 の open/closed 状態と接続先を変えない。
+  internal close error の抑止を shell stderr へ恒久適用しない。
 
 ## 候補収集
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use crate::keybind;
 use crate::matching::Mode;
 
 /// Protocol version emitted as ZRUSH_PROTOCOL_VERSION (cli-protocol.md).
-pub const PROTOCOL_VERSION: &str = "6";
+pub const PROTOCOL_VERSION: &str = "7";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabBehavior {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod wire;
 
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::RawFd;
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -49,7 +50,11 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Serve render-plan requests over a persistent byte-stream session.
-    Worker,
+    Worker {
+        /// Read end of the worker abort control channel.
+        #[arg(long, value_parser = parse_control_fd)]
+        control_fd: RawFd,
+    },
     /// Emit zsh-sourceable settings (cli-protocol.md "zrush config").
     Config,
     /// Emit the zsh integration script for `.zshrc` to source
@@ -60,6 +65,19 @@ enum Command {
     },
 }
 
+fn parse_control_fd(value: &str) -> Result<RawFd, String> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("control fd must be an unsigned decimal integer".into());
+    }
+    let fd = value
+        .parse::<RawFd>()
+        .map_err(|_| "control fd is out of range".to_string())?;
+    if fd <= libc::STDERR_FILENO {
+        return Err("control fd must be greater than 2".into());
+    }
+    Ok(fd)
+}
+
 #[derive(Clone, Copy, ValueEnum)]
 enum Shell {
     Zsh,
@@ -68,13 +86,18 @@ enum Shell {
 /// Run the command-line interface and return its process exit code.
 pub fn run() -> ExitCode {
     match Cli::parse().command {
-        Command::Worker => cmd_worker(),
+        Command::Worker { control_fd } => cmd_worker(control_fd),
         Command::Config => cmd_config(),
         Command::Init { shell: Shell::Zsh } => cmd_init_zsh(),
     }
 }
 
-fn cmd_worker() -> ExitCode {
+fn cmd_worker(control_fd: RawFd) -> ExitCode {
+    if let Err(error) = worker::start_watchdog(control_fd) {
+        let _ = writeln!(std::io::stderr().lock(), "zrush worker: {error}");
+        return ExitCode::from(EXIT_INTERNAL);
+    }
+
     match worker::run(std::io::stdin().lock(), std::io::stdout().lock()) {
         Ok(worker::End::Eof | worker::End::Incompatible) => ExitCode::SUCCESS,
         Err(error) => {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2,8 +2,10 @@
 
 use std::ffi::OsStr;
 use std::fmt;
+use std::fs::File;
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
 
 use crate::config::PROTOCOL_VERSION;
@@ -13,6 +15,89 @@ use crate::plan::{self, Producer};
 
 const READ_BUFFER_SIZE: usize = 8192;
 const REQUEST_FIELD_COUNT: usize = 11;
+const FIRST_APPLICATION_FD: RawFd = 3;
+
+pub(crate) fn start_watchdog(control_fd: RawFd) -> std::io::Result<()> {
+    let control = acquire_control_fd(control_fd)?;
+    set_close_on_exec(control.as_raw_fd())?;
+    set_close_on_exec(libc::STDOUT_FILENO)?;
+
+    std::thread::Builder::new()
+        .name("zrush-control-watchdog".into())
+        .spawn(move || watch_control(control))?;
+    Ok(())
+}
+
+fn acquire_control_fd(raw_fd: RawFd) -> std::io::Result<OwnedFd> {
+    if raw_fd < FIRST_APPLICATION_FD {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--control-fd must be greater than 2",
+        ));
+    }
+
+    let status = fcntl_get(raw_fd, libc::F_GETFL)?;
+    if status & libc::O_ACCMODE == libc::O_WRONLY {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "--control-fd must be readable",
+        ));
+    }
+
+    // No threads exist yet, so the successful fcntl validation above and this
+    // ownership transfer cannot race with a close or descriptor replacement.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw_fd) })
+}
+
+fn set_close_on_exec(raw_fd: RawFd) -> std::io::Result<()> {
+    let flags = fcntl_get(raw_fd, libc::F_GETFD)?;
+    fcntl_set(raw_fd, libc::F_SETFD, flags | libc::FD_CLOEXEC)
+}
+
+fn fcntl_get(raw_fd: RawFd, command: libc::c_int) -> std::io::Result<libc::c_int> {
+    loop {
+        // fcntl is called with a command that takes no third argument.
+        let result = unsafe { libc::fcntl(raw_fd, command) };
+        if result >= 0 {
+            return Ok(result);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn fcntl_set(raw_fd: RawFd, command: libc::c_int, value: libc::c_int) -> std::io::Result<()> {
+    loop {
+        // fcntl is called with the integer argument required by F_SETFD.
+        let result = unsafe { libc::fcntl(raw_fd, command, value) };
+        if result >= 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn watch_control(control: OwnedFd) -> ! {
+    let mut control = File::from(control);
+    let mut byte = [0_u8; 1];
+    loop {
+        match control.read(&mut byte) {
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Ok(_) | Err(_) => immediate_failure_exit(),
+        }
+    }
+}
+
+fn immediate_failure_exit() -> ! {
+    // This deliberately bypasses destructors and stdio flushing from the
+    // watchdog thread; no Rust references cross the process exit.
+    unsafe { libc::_exit(1) }
+}
 
 #[derive(Debug)]
 pub(crate) enum Error {
@@ -336,7 +421,7 @@ mod tests {
 
     #[test]
     fn handshake_and_multiple_requests_share_one_session() {
-        let hello = message(&[b"hello", b"6"]);
+        let hello = message(&[b"hello", b"7"]);
         let first = request(b"1", b"/", b"");
         let second = request(b"2", b"/", b"");
         let input = [hello, message(&first), message(&second)].concat();
@@ -344,7 +429,7 @@ mod tests {
 
         assert_eq!(run(Cursor::new(input), &mut output).unwrap(), End::Eof);
         let decoded = messages(&output);
-        assert_eq!(decoded[0], [b"ready".to_vec(), b"6".to_vec()]);
+        assert_eq!(decoded[0], [b"ready".to_vec(), b"7".to_vec()]);
         assert_eq!(&decoded[1][..2], [b"ok".as_slice(), b"1".as_slice()]);
         assert_eq!(&decoded[2][..2], [b"ok".as_slice(), b"2".as_slice()]);
         assert_eq!(decoded[1][2], b"\0\x30\0\x30\0\x30\0");
@@ -359,13 +444,13 @@ mod tests {
         );
         assert_eq!(
             messages(&output),
-            [vec![b"incompatible".to_vec(), b"6".to_vec()]]
+            [vec![b"incompatible".to_vec(), b"7".to_vec()]]
         );
     }
 
     #[test]
     fn correlatable_shape_and_payload_errors_are_in_band() {
-        let hello = message(&[b"hello", b"6"]);
+        let hello = message(&[b"hello", b"7"]);
         let bad_shape = message(&[b"other", b"7"]);
         let bad_payload = message(&request(b"8", b"/", b"unterminated"));
         let mut output = Vec::new();
@@ -378,7 +463,7 @@ mod tests {
         assert_eq!(
             messages(&output),
             [
-                vec![b"ready".to_vec(), b"6".to_vec()],
+                vec![b"ready".to_vec(), b"7".to_vec()],
                 vec![
                     b"error".to_vec(),
                     b"7".to_vec(),
@@ -400,7 +485,7 @@ mod tests {
             vec![b"plan".as_slice(), b"01".as_slice()],
             vec![b"plan".as_slice(), b"9223372036854775808".as_slice()],
         ] {
-            let input = [message(&[b"hello", b"6"]), message(&fields)].concat();
+            let input = [message(&[b"hello", b"7"]), message(&fields)].concat();
             let mut output = Vec::new();
             assert!(matches!(
                 run(Cursor::new(input), &mut output),
@@ -413,7 +498,7 @@ mod tests {
     #[test]
     fn completed_prefix_is_written_before_later_outer_corruption() {
         let input = [
-            message(&[b"hello", b"6"]),
+            message(&[b"hello", b"7"]),
             message(&request(b"1", b"/", b"")),
             b"1:x!".to_vec(),
         ]
@@ -429,7 +514,7 @@ mod tests {
     #[test]
     fn nested_framing_corruption_is_fatal() {
         let malformed_nested = framing::encode(b"4:plan,1:1");
-        let input = [message(&[b"hello", b"6"]), malformed_nested].concat();
+        let input = [message(&[b"hello", b"7"]), malformed_nested].concat();
         let mut output = Vec::new();
         let Err(Error::Framing(error)) = run(Cursor::new(input), &mut output) else {
             panic!("expected a framing error");
@@ -445,7 +530,7 @@ mod tests {
         };
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
 
-        let Err(Error::Io(error)) = run(Cursor::new(message(&[b"hello", b"6"])), FailingWriter)
+        let Err(Error::Io(error)) = run(Cursor::new(message(&[b"hello", b"7"])), FailingWriter)
         else {
             panic!("expected an I/O error");
         };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,9 @@
 
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -10,6 +13,28 @@ use zrush::wire;
 
 fn zrush() -> Command {
     Command::new(env!("CARGO_BIN_EXE_zrush"))
+}
+
+fn worker_command() -> (Command, UnixStream, UnixStream) {
+    let (read, write) = UnixStream::pair().expect("create control channel");
+    let control_fd = read.as_raw_fd();
+    let mut command = zrush();
+    command
+        .arg("worker")
+        .arg("--control-fd")
+        .arg(control_fd.to_string());
+    // UnixStream descriptors are CLOEXEC. Only the intended control read end
+    // is made inheritable in the forked child, without exposing unrelated
+    // parallel-test descriptors across exec.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fcntl(control_fd, libc::F_SETFD, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    (command, read, write)
 }
 
 // ---- zrush worker ----
@@ -70,18 +95,19 @@ fn run_plan(extra: &[&str], stdin: &[u8]) -> (i32, Vec<u8>) {
         value("--trailing-space").as_bytes(),
         stdin,
     ]);
-    let mut child = zrush()
-        .arg("worker")
+    let (mut command, control_read, _control_write) = worker_command();
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn zrush worker");
+    drop(control_read);
     child
         .stdin
         .take()
         .expect("stdin")
-        .write_all(&[msg(&[b"hello", b"6"]), req].concat())
+        .write_all(&[msg(&[b"hello", b"7"]), req].concat())
         .expect("write stdin");
     let out = child.wait_with_output().expect("wait");
     let frames = decode_frames(&out.stdout);
@@ -355,14 +381,15 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
             &payload,
         ])
     };
-    let mut child = zrush()
-        .arg("worker")
+    let (mut command, control_read, _control_write) = worker_command();
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+    drop(control_read);
     let mut input = Vec::new();
-    input.extend(msg(&[b"hello", b"6"]));
+    input.extend(msg(&[b"hello", b"7"]));
     input.extend(request(b"1"));
     input.extend(request(b"2"));
     let mut stdin = child.stdin.take().unwrap();
@@ -373,18 +400,19 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
     let out = child.wait_with_output().unwrap();
     let frames = decode_frames(&out.stdout);
     assert_eq!(frames.len(), 3, "ready plus two terminal responses");
-    assert_eq!(fields(&frames[0]), vec![b"ready".to_vec(), b"6".to_vec()]);
+    assert_eq!(fields(&frames[0]), vec![b"ready".to_vec(), b"7".to_vec()]);
     assert!(fields(&frames[1])[0] == b"ok" && fields(&frames[2])[0] == b"ok");
 }
 
 #[test]
 fn worker_protocol_mismatch_exits_after_incompatible_response() {
-    let mut child = zrush()
-        .arg("worker")
+    let (mut command, control_read, _control_write) = worker_command();
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
         .unwrap();
+    drop(control_read);
     child
         .stdin
         .take()
@@ -395,7 +423,7 @@ fn worker_protocol_mismatch_exits_after_incompatible_response() {
     assert_eq!(out.status.code(), Some(0));
     assert_eq!(
         fields(&decode_frames(&out.stdout)[0]),
-        vec![b"incompatible".to_vec(), b"6".to_vec()]
+        vec![b"incompatible".to_vec(), b"7".to_vec()]
     );
 }
 
@@ -403,14 +431,15 @@ fn worker_protocol_mismatch_exits_after_incompatible_response() {
 /// existence and single-line shape are pinned here.
 #[test]
 fn worker_session_fatal_failure_emits_one_diagnostic_line_on_stderr() {
-    let mut child = zrush()
-        .arg("worker")
+    let (mut command, control_read, _control_write) = worker_command();
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .unwrap();
-    let mut input = msg(&[b"hello", b"6"]);
+    drop(control_read);
+    let mut input = msg(&[b"hello", b"7"]);
     input.extend_from_slice(b"1:x!");
     child.stdin.take().unwrap().write_all(&input).unwrap();
 
@@ -477,7 +506,7 @@ fn config_without_file_prints_contract_default_output() {
     let (code, out) = run_config(&dir);
     assert_eq!(code, 0);
     let expected = "\
-typeset -g  ZRUSH_PROTOCOL_VERSION='6'
+typeset -g  ZRUSH_PROTOCOL_VERSION='7'
 typeset -g  ZRUSH_CFG_MAX_LINES='10'
 typeset -g  ZRUSH_CFG_DELAY_MS='30'
 typeset -g  ZRUSH_CFG_MIN_INPUT='0'

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -1,6 +1,9 @@
 use std::ffi::OsString;
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -163,18 +166,33 @@ fn run_vector_raw(path: &Path) -> std::process::Output {
         value("--trailing-space").as_bytes(),
         &payload,
     ]);
-    let mut child = Command::new(env!("CARGO_BIN_EXE_zrush"))
+    let (control_read, _control_write) = UnixStream::pair().expect("create control channel");
+    let control_fd = control_read.as_raw_fd();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_zrush"));
+    command
         .arg("worker")
+        .arg("--control-fd")
+        .arg(control_fd.to_string());
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fcntl(control_fd, libc::F_SETFD, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .unwrap_or_else(|error| panic!("{}: spawn zrush: {error}", path.display()));
+    drop(control_read);
     let write_result = child
         .stdin
         .take()
         .expect("vector child stdin")
-        .write_all(&[msg(&[b"hello", b"6"]), request].concat());
+        .write_all(&[msg(&[b"hello", b"7"]), request].concat());
     if let Err(error) = write_result {
         assert_eq!(
             error.kind(),
@@ -372,7 +390,7 @@ fn reject_vectors_match_expected_in_band_errors() {
         };
         let valid = output.status.code() == Some(0)
             && frames.len() == 2
-            && decode_fields_strict(&frames[0]) == vec![b"ready".to_vec(), b"6".to_vec()]
+            && decode_fields_strict(&frames[0]) == vec![b"ready".to_vec(), b"7".to_vec()]
             && decode_fields_strict(&frames[1])
                 == vec![b"error".to_vec(), b"1".to_vec(), expected.to_vec()];
         if !valid {

--- a/tests/vectors/README.md
+++ b/tests/vectors/README.md
@@ -70,7 +70,7 @@ A generated `expected` is a proposal, not an answer -- read it against cli-proto
 
 ## Who checks what
 
-`cargo test` checks `plan/`, `reject/`, and `reject-plan/` against the Rust worker and the `wire` reference parser. Reject vectors structurally validate exactly `[ready,6]` plus one terminal in-band `error`; no process exit 2/3 compatibility is tested.
+`cargo test` checks `plan/`, `reject/`, and `reject-plan/` against the Rust worker and the `wire` reference parser. Reject vectors structurally validate exactly `[ready,7]` plus one terminal in-band `error`; no process exit 2/3 compatibility is tested.
 Both runners independently implement the file format above, check every corpus file for canonical spelling, and hold their own codec to a round trip over arbitrary byte strings.
 `zsh -f tests/zsh/vectors.zsh` checks `encode/` against the zsh encoder `_zrush_encode_batch`,
 the history sender's line/event-number pairing and filtering against `_zrush_history_payload`,

--- a/tests/worker_control.rs
+++ b/tests/worker_control.rs
@@ -1,0 +1,170 @@
+use std::io::{Read, Write};
+use std::os::unix::io::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+fn zrush() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_zrush"))
+}
+
+fn spawn_worker() -> (Child, UnixStream) {
+    let (control_read, control_write) = UnixStream::pair().expect("create control channel");
+    let control_fd = control_read.as_raw_fd();
+    let mut command = zrush();
+    command
+        .arg("worker")
+        .arg("--control-fd")
+        .arg(control_fd.to_string())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    // The socket starts CLOEXEC. Clear that flag only in this forked child so
+    // concurrent test subprocesses cannot retain each other's control ends.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fcntl(control_fd, libc::F_SETFD, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let child = command.spawn().expect("spawn worker");
+    drop(control_read);
+    (child, control_write)
+}
+
+fn complete_handshake(child: &mut Child) {
+    child
+        .stdin
+        .as_mut()
+        .expect("request stdin")
+        .write_all(b"12:5:hello,1:7,,")
+        .expect("write hello");
+    let mut ready = [0_u8; 16];
+    child
+        .stdout
+        .as_mut()
+        .expect("response stdout")
+        .read_exact(&mut ready)
+        .expect("read ready");
+    assert_eq!(&ready, b"12:5:ready,1:7,,");
+}
+
+fn wait_bounded(child: &mut Child) -> ExitStatus {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(status) = child.try_wait().expect("poll worker") {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("worker did not exit before timeout");
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn abort_byte_exits_while_request_stdin_is_blocked() {
+    let (mut child, mut control) = spawn_worker();
+    complete_handshake(&mut child);
+
+    control.write_all(&[0]).expect("send abort byte");
+
+    assert_eq!(wait_bounded(&mut child).code(), Some(1));
+}
+
+#[test]
+fn control_eof_exits_while_request_stdin_is_blocked() {
+    let (mut child, control) = spawn_worker();
+    complete_handshake(&mut child);
+
+    drop(control);
+
+    assert_eq!(wait_bounded(&mut child).code(), Some(1));
+}
+
+#[test]
+fn normal_request_stdin_eof_exits_cleanly_without_joining_watchdog() {
+    let (mut child, control) = spawn_worker();
+    drop(child.stdin.take());
+
+    assert_eq!(wait_bounded(&mut child).code(), Some(0));
+    drop(control);
+}
+
+#[test]
+fn invalid_control_fd_fails_before_request_processing() {
+    let output = zrush()
+        .args(["worker", "--control-fd", "2147483647"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run worker with invalid control fd");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty(), "worker never emits ready");
+    assert!(output.stderr.ends_with(b"\n"));
+}
+
+#[test]
+fn write_only_control_fd_fails_before_request_processing() {
+    let control = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/null")
+        .expect("open write-only descriptor");
+    let control_fd = control.as_raw_fd();
+    let mut command = zrush();
+    command
+        .args(["worker", "--control-fd", &control_fd.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fcntl(control_fd, libc::F_SETFD, 0) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let output = command.output().expect("run worker with write-only fd");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty(), "worker never emits ready");
+}
+
+#[test]
+fn missing_control_fd_is_a_usage_error() {
+    let output = zrush()
+        .arg("worker")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .expect("run worker without control fd");
+
+    assert_eq!(output.status.code(), Some(2));
+}
+
+#[test]
+fn standard_or_malformed_control_fd_is_a_usage_error() {
+    for value in ["2", "-1", "+3", "not-a-fd"] {
+        let output = zrush()
+            .args(["worker", "--control-fd", value])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .expect("run worker with invalid control fd argument");
+
+        assert_eq!(output.status.code(), Some(2), "value {value:?}");
+    }
+}

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -90,7 +90,15 @@ export TERM=vt100
 # keys this driver sends (^U, ^P, ^V, ...) are emacs-keymap bindings, so the
 # invoking environment must not decide which keymap the host gets.
 unset EDITOR VISUAL
-export LC_ALL=en_US.UTF-8   # match POSTDISPLAY printability checks to real UTF-8 use
+# Match POSTDISPLAY printability checks to real UTF-8 use. Minimal Linux
+# images commonly provide only C.UTF-8/C.utf8, while macOS provides
+# en_US.UTF-8; select the first locale this host actually accepts.
+typeset -g DRIVER_UTF8_LOCALE=
+for DRIVER_UTF8_LOCALE in en_US.UTF-8 C.UTF-8 C.utf8; do
+  LC_ALL=$DRIVER_UTF8_LOCALE command locale charmap >/dev/null 2>&1 && break
+done
+LC_ALL=$DRIVER_UTF8_LOCALE command locale charmap >/dev/null 2>&1 || DRIVER_UTF8_LOCALE=C
+export LC_ALL=$DRIVER_UTF8_LOCALE
 export HOME=$PLAYGROUND     # isolated; never the real home
 export ZRUSH_TEST_TMP=$WORK
 export ZDOTDIR=$WORK/zdot
@@ -107,6 +115,7 @@ export ZRUSH_BIN=$WORK/bin/zrush
 export ZRUSH_REAL_BIN=$REPO/target/release/zrush
 export ZRUSH_FAKE_CONTROL=$WORK/fake-control
 export ZRUSH_FAKE_STATE=$WORK/fake-state
+typeset -gi FAKE_DRAIN_TAIL_BYTES=8388608
 # Test seam: 5000 ms matches the driver's other bounded waits.
 export ZRUSH_HISTORY_DEADLINE_MS=5000
 
@@ -269,6 +278,41 @@ fake_count() {  # $1=fixed state line -> REPLY=count
   return 0
 }
 
+fake_session_count() {  # -> REPLY=number of fake worker sessions created
+  typeset -g REPLY=0
+  [[ -r $ZRUSH_FAKE_STATE.count ]] &&
+    REPLY=$(command cat $ZRUSH_FAKE_STATE.count 2>/dev/null)
+  [[ $REPLY == <-> ]] || REPLY=0
+}
+
+worker_state_has() {  # $1=TESTWORKER value, remaining args=exact fields
+  local state=$1 field
+  shift
+  for field in "$@"; do
+    [[ " $state " == *" $field "* ]] || return 1
+  done
+  return 0
+}
+
+# Wait until asynchronous worker-stop cleanup reaches an exact observable
+# state. Session failure is logged before the fixed 100 ms lifecycle budget has
+# necessarily reached response EOF, so a following request must not use that
+# log line alone as evidence that replacement is allowed.
+wait_worker_state() {  # $1=timeout(s), remaining args=exact TESTWORKER fields
+  local -F dl=$(( SECONDS + $1 ))
+  shift
+  local state=
+  while (( SECONDS < dl )); do
+    if dump_get $'\C-xw' TESTWORKER; then
+      state=$REPLY
+      worker_state_has "$state" "$@" && return 0
+    fi
+    drain 0.1
+  done
+  typeset -g REPLY=$state
+  return 1
+}
+
 wait_fake() {  # $1=fixed state line $2=baseline $3=timeout
   local -F dl=$(( SECONDS + ${3:-5} ))
   while (( SECONDS < dl )); do
@@ -281,7 +325,7 @@ wait_fake() {  # $1=fixed state line $2=baseline $3=timeout
 
 # Compare an exact ^Xb BUFFER dump against an expected string.
 assert_buffer() {  # $1=expected buffer $2=label
-  local want=${(qqqq)1}
+  local expected=$1 want=${(qqqq)1}
   send_keys $'\C-xb'
   local -F dl=$(( SECONDS + 5 ))
   local last=
@@ -290,7 +334,7 @@ assert_buffer() {  # $1=expected buffer $2=label
     drain 0.15
     tl=( ${(f)"$(grep -F 'TESTBUF=' $ZRUSH_LOG 2>/dev/null)"} )
     (( $#tl )) && last=${tl[-1]#*TESTBUF=}
-    [[ $last == "$want" ]] && { ok "$2"; return 0 }
+    [[ ${(Q)last} == "$expected" ]] && { ok "$2"; return 0 }
   done
   ng "$2: buffer=${last:-?} want=$want"
   return 1
@@ -393,7 +437,8 @@ sec_boot() {
   sync_prompt
 
   # The Rust worker is lazy: sourcing/config validation alone must not start it.
-  if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == 'pid=-1 ready=0 seq=0 '* ]]; then
+  if dump_get $'\C-xw' TESTWORKER \
+     && worker_state_has "$REPLY" ready=0 seq=0 stopping=0 tainted=0 rfd=-1 wfd=-1 control=-1 ack=-1; then
     ok "(worker-1a) source/config leaves the persistent worker stopped"
   else
     ng "(worker-1a) worker was not lazy: ${REPLY:-<none>}"
@@ -407,6 +452,27 @@ sec_boot() {
     ng "(fd-1b) auxiliary fd teardown mismatch: ${REPLY:-<none>}"
   fi
   assert_host_stdio "(fd-1c) timer/ack/drain teardown preserves host fd 0/1/2"
+
+  # Register a production-generated drain wrapper from a widget, then return
+  # to the real ZLE event loop. Only readiness dispatch through zle -F can
+  # reach the temporary read seam and emit TESTGENERATED=dispatched.
+  log_count 'TESTGENERATED=dispatched'; local -i generated0=$REPLY
+  send_keys $'\C-xg'
+  local -i generated_ok=1
+  wait_log 'TESTGENERATED=dispatched' $generated0 5 || generated_ok=0
+  local generated_line=$(grep -F 'TESTGENERATED=dispatched' $ZRUSH_LOG 2>/dev/null | tail -1)
+  local generated_value=${${generated_line#*generation=}%% *}
+  if (( generated_ok )) && [[ $generated_value == <-> ]] \
+     && worker_state_has "$generated_line" kind=drain current=0 drain=-1 handler_live=0 widget_live=0 \
+     && dump_get $'\C-xw' TESTWORKER \
+     && worker_state_has "$REPLY" ready=0 stopping=0 tainted=0 rfd=-1 wfd=-1 control=-1 ack=-1; then
+    ok "(worker-callback) generated zle -F handler dispatches readiness and self-invalidates"
+  else
+    ng "(worker-callback) generated handler did not progress/clean up: line=${generated_line:-<none>} state=${REPLY:-<none>}"
+    send_keys $'\C-xG'
+    drain 0.2
+  fi
+  assert_host_stdio "(fd-1d) generated callback dispatch preserves host fd 0/1/2"
 }
 
 sec_capture() {
@@ -421,8 +487,11 @@ sec_capture() {
   fi
   dump_get $'\C-xw' TESTWORKER
   local worker_after_first=$REPLY
-  local -i first_worker_pid=${${worker_after_first#pid=}%% *}
-  if (( first_worker_pid > 1 )) && [[ $worker_after_first == *'ready=1'*'seq=1'* ]]; then
+  local -i first_worker_rfd=${${worker_after_first#*rfd=}%% *}
+  local first_runtime=${${worker_after_first#*runtime=}%% *}
+  if (( first_worker_rfd > 2 )) \
+     && worker_state_has "$worker_after_first" ready=1 seq=1 stopping=0 tainted=0 \
+     && [[ $first_runtime != '<none>' ]]; then
     ok "(worker-1b) first real request starts and handshakes one worker"
   else
     ng "(worker-1b) unexpected first-request state: $worker_after_first"
@@ -458,28 +527,96 @@ sec_capture() {
 
   dump_get $'\C-xw' TESTWORKER
   local worker_after_successive=$REPLY
-  if [[ $worker_after_successive == "pid=$first_worker_pid "* ]] && (( ${${worker_after_successive#*seq=}%% *} > 1 )); then
+  local -i successive_rfd=${${worker_after_successive#*rfd=}%% *}
+  local successive_runtime=${${worker_after_successive#*runtime=}%% *}
+  if (( successive_rfd == first_worker_rfd \
+        && ${${worker_after_successive#*seq=}%% *} > 1 )) \
+     && [[ $successive_runtime == $first_runtime ]]; then
     ok "(worker-1c) successive completion requests reuse the same Rust worker"
   else
     ng "(worker-1c) worker was not reused: first=$worker_after_first now=$worker_after_successive"
   fi
 
   local -i seq_before_resource=${${worker_after_successive#*seq=}%% *}
+  log_count 'worker: transport stopped'; local -i resource_stopped0=$REPLY
+  # This case tests the completed handoff, not the separately-covered 100 ms
+  # expiry/quarantine branch. Give the old definition an extended test-only
+  # budget so scheduler variance cannot turn this source invocation into the
+  # specified fail-fast result whose cleanup completes just after the prompt.
+  send_line '_ZRUSH_WORKER_SHUTDOWN_MS=5000'
+  sync_prompt
   send_line "source <($ZRUSH_REAL_BIN init zsh)"
   sync_prompt
-  if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == "pid=-1 ready=0 seq=$seq_before_resource "* && $REPLY == *'rfd=-1 wfd=-1 ack=-1 pending=0' ]]; then
+  local post_resource_state= post_resource_runtime=
+  dump_get $'\C-xw' TESTWORKER && post_resource_state=$REPLY
+  post_resource_runtime=${${post_resource_state#*runtime=}%% *}
+  if worker_state_has "$post_resource_state" ready=0 seq=$seq_before_resource stopping=0 tainted=0 \
+       rfd=-1 wfd=-1 control=-1 ack=-1 pending=0 \
+     && [[ $post_resource_runtime != '<none>' && $post_resource_runtime != $first_runtime ]]; then
     ok "(worker-1d) re-source tears down transport while preserving the request counter"
   else
-    ng "(worker-1d) bad post-resource state: ${REPLY:-<none>}"
+    ng "(worker-1d) bad post-resource state: ${post_resource_state:-<none>}"
   fi
-  local terminated_resource=$(grep -F "worker: terminated pid=$first_worker_pid gone=1" $ZRUSH_LOG 2>/dev/null | tail -1)
-  if [[ -n $terminated_resource ]] \
-     && ! kill -0 $first_worker_pid 2>/dev/null; then
-    ok "(worker-1e) re-source terminates old worker pid=$first_worker_pid and confirms it is gone"
+  if wait_log 'worker: transport stopped' $resource_stopped0 5 \
+     && [[ ! -e $first_runtime ]]; then
+    ok "(worker-1e) re-source observes response EOF before replacing the old runtime generation"
   else
-    ng "(worker-1e) old worker did not disappear: line=${terminated_resource:-<none>}"
+    ng "(worker-1e) old completion/runtime cleanup missing: runtime=$first_runtime"
   fi
   assert_host_stdio "(fd-3) re-source teardown preserves host fd 0/1/2"
+
+  # Re-source a healthy fake session whose final stdout bytes are deliberately
+  # not a protocol frame. The fake records stdin EOF, a successful raw tail
+  # write, and clean return in that order. This makes the shutdown observation
+  # deterministic without depending on whether a real worker happened to have
+  # an outstanding response when the source command ran.
+  fake_session_count; local -i drain_session=$(( REPLY + 1 ))
+  print -r -- drain > $ZRUSH_FAKE_CONTROL
+  fake_count "drain $drain_session "; local -i drain_request0=$REPLY
+  log_count 'worker: error request_id='; local -i drain_error0=$REPLY
+  send_keys 'ls fx/basic/al'
+  if wait_fake "drain $drain_session " $drain_request0 10 \
+     && wait_log 'worker: error request_id=' $drain_error0 10 \
+     && dump_get $'\C-xw' TESTWORKER \
+     && worker_state_has "$REPLY" ready=1 stopping=0 tainted=0; then
+    local -i drain_seq=${${REPLY#*seq=}%% *}
+    fake_count "eof $drain_session"; local -i drain_eof0=$REPLY
+    fake_count "tail $drain_session $FAKE_DRAIN_TAIL_BYTES"; local -i drain_tail0=$REPLY
+    fake_count "exit $drain_session"; local -i drain_exit0=$REPLY
+    clear_line
+    drain 0.2
+    # The 8 MiB tail deliberately exceeds pipe capacity. Extend only this
+    # successful-shutdown fixture; the bounded deadline and quarantine path are
+    # asserted independently by transport.zsh.
+    send_line '_ZRUSH_WORKER_SHUTDOWN_MS=5000'
+    sync_prompt
+    send_line "source <($ZRUSH_REAL_BIN init zsh)"
+    local -i drain_resource_ok=1
+    sync_prompt || drain_resource_ok=0
+    wait_fake "eof $drain_session" $drain_eof0 5 || drain_resource_ok=0
+    wait_fake "tail $drain_session $FAKE_DRAIN_TAIL_BYTES" $drain_tail0 5 || drain_resource_ok=0
+    wait_fake "exit $drain_session" $drain_exit0 5 || drain_resource_ok=0
+    local drain_resource_output=${EXPECT_BUF//$'\e['[0-9;]#m/}
+    if (( drain_resource_ok )) \
+       && [[ $drain_resource_output != *'Terminated'* \
+             && $drain_resource_output != *'Done'* \
+             && $drain_resource_output != *'zsh: you have running jobs.'* ]]; then
+      ok "(worker-1f) healthy re-source closes stdin at EOF, drains raw stdout, and confirms clean worker disappearance"
+    else
+      ng "(worker-1f) healthy fake shutdown incomplete: output=${(qqqq)drain_resource_output}"
+    fi
+    if dump_get $'\C-xw' TESTWORKER \
+       && worker_state_has "$REPLY" ready=0 seq=$drain_seq stopping=0 tainted=0 \
+            rfd=-1 wfd=-1 control=-1 ack=-1 pending=0; then
+      ok "(worker-1g) healthy re-source leaves no transport state and does not start a replacement"
+    else
+      ng "(worker-1g) bad post-resource fake-worker state: ${REPLY:-<none>}"
+    fi
+    assert_host_stdio "(fd-3b) healthy raw-drain re-source preserves host fd 0/1/2"
+  else
+    ng "(worker-1f/g) healthy fake session did not become ready: ${REPLY:-<none>}"
+  fi
+  print -r -- proxy > $ZRUSH_FAKE_CONTROL
 
   # (cap-1c) w vs m: a candidate whose quoted form differs from its raw text.
   # The listing must show the raw text (m, cli-protocol.md "候補レコード"), and
@@ -881,28 +1018,30 @@ sec_death() {
 
   # Switch only future sessions to the fake. It handshakes ready, records the
   # assigned request id, then exits without a terminal response.
-  dump_get $'\C-xw' TESTWORKER
-  local -i explicit_teardown_pid=${${REPLY#pid=}%% *}
+  log_count 'worker: transport stopped'; local -i explicit_stop0=$REPLY
   send_keys $'\C-xq'
   drain 0.3
   dump_get $'\C-xw' TESTWORKER
-  [[ $REPLY == 'pid=-1 ready=0 '* ]] || ng "(err-setup) worker teardown failed: $REPLY"
-  local explicit_termination=$(grep -F "worker: terminated pid=$explicit_teardown_pid gone=1" $ZRUSH_LOG 2>/dev/null | tail -1)
-  if (( explicit_teardown_pid > 1 )) && [[ -n $explicit_termination ]] \
-     && ! kill -0 $explicit_teardown_pid 2>/dev/null; then
-    ok "(err-setup) explicit teardown terminates pid=$explicit_teardown_pid and confirms it is gone"
+  if worker_state_has "$REPLY" ready=0 stopping=0 rfd=-1 wfd=-1 control=-1 ack=-1 pending=0 \
+     && wait_log 'worker: transport stopped' $explicit_stop0 5; then
+    ok "(err-setup) explicit healthy teardown reaches response EOF and clears transport state"
   else
-    ng "(err-setup) explicit teardown did not confirm old worker disappeared: ${explicit_termination:-<none>}"
+    ng "(err-setup) explicit teardown did not finalize: ${REPLY:-<none>}"
   fi
   assert_host_stdio "(fd-4) explicit worker teardown preserves host fd 0/1/2"
+  fake_session_count; local -i death_session0=$REPLY
+  local -i death_first_session=$(( death_session0 + 1 ))
+  local -i death_second_session=$(( death_session0 + 2 ))
+  local -i death_third_session=$(( death_session0 + 3 ))
+  local -i death_starts0=$(grep -c '^start ' $ZRUSH_FAKE_STATE 2>/dev/null)
   print -r -- die > $ZRUSH_FAKE_CONTROL
   log_count 'worker: session failure:'; local -i err_fail0=$REPLY
-  fake_count 'die 1 '; local -i fake_die0=$REPLY
+  fake_count "die $death_first_session "; local -i fake_die0=$REPLY
   local -i err_log_line0=0
   [[ -r $ZRUSH_LOG ]] && err_log_line0=$(wc -l < $ZRUSH_LOG)
   send_keys 'ls fx/basic/al'
   local -i active_death_ok=1
-  wait_fake 'die 1 ' $fake_die0 10 || active_death_ok=0
+  wait_fake "die $death_first_session " $fake_die0 10 || active_death_ok=0
   wait_log 'worker: session failure:' $err_fail0 10 || active_death_ok=0
   local worker_warning_output=${EXPECT_BUF//$'\e['[0-9;]#m/}
   if [[ $worker_warning_output == *'zrush: worker transport failed; suppressing further warnings this session'* ]]; then
@@ -911,27 +1050,15 @@ sec_death() {
     ng "(fd-5a) worker warning missing from pty output: ${(qqqq)worker_warning_output}"
   fi
   local err_log_delta=$(sed -n "$(( err_log_line0 + 1 )),\$p" $ZRUSH_LOG 2>/dev/null)
-  local fake_started=$(print -r -- "$err_log_delta" | grep -F 'worker: started pid=' 2>/dev/null)
-  local -i fake_started_count=$(print -r -- "$fake_started" | grep -cF 'worker: started pid=' 2>/dev/null)
-  local -i fake_worker_pid=-1
-  if (( fake_started_count == 1 )); then
-    local fake_worker_tail=${fake_started#*'worker: started pid='}
-    fake_worker_pid=${fake_worker_tail%% *}
-  fi
-  local exact_fake_termination=
-  if (( fake_worker_pid > 1 )); then
-    exact_fake_termination=$(print -r -- "$err_log_delta" \
-      | grep -E "\\] worker: terminated pid=$fake_worker_pid gone=1\$" 2>/dev/null)
-  fi
-  if (( active_death_ok && fake_started_count == 1 && fake_worker_pid > 1 )) \
-     && [[ -n $exact_fake_termination ]] \
+  local -i fake_started_count=$(print -r -- "$err_log_delta" | grep -cF 'worker: started rfd=' 2>/dev/null)
+  if (( active_death_ok && fake_started_count == 1 )) \
      && dump_get $'\C-xw' TESTWORKER \
-     && [[ $REPLY == *'failures=1 disabled=0'*'warned=1'*'pending=0' ]]; then
+     && worker_state_has "$REPLY" failures=1 disabled=0 warned=1 pending=0; then
     ok "(err-1a) ready worker dies with an assigned request; pending is discarded and failure is retryable"
   else
-    ng "(err-1a) active-death state missing: state=${REPLY:-<none>} pid=$fake_worker_pid termination=${exact_fake_termination:-<none>}"
+    ng "(err-1a) active-death state missing: state=${REPLY:-<none>} starts=$fake_started_count"
   fi
-  local first_die=$(grep -F 'die 1 ' $ZRUSH_FAKE_STATE 2>/dev/null | tail -1)
+  local first_die=$(grep -F "die $death_first_session " $ZRUSH_FAKE_STATE 2>/dev/null | tail -1)
   local first_dead_id=${first_die##* }
   drain 0.5
   if dump_get $'\C-xp' TESTPOST; then
@@ -948,13 +1075,17 @@ sec_death() {
   # and assignment so state can be inspected before its terminal response.
   clear_line; drain 0.3
   assert_host_stdio "(fd-5b) session failure teardown preserves host fd 0/1/2"
+  local -i first_death_clean=0
+  wait_worker_state 10 ready=0 stopping=0 rfd=-1 wfd=-1 control=-1 ack=-1 pending=0 \
+    && first_death_clean=1
   print -r -- hold > $ZRUSH_FAKE_CONTROL
-  fake_count 'hold 2 '; local -i fake_hold0=$REPLY
+  fake_count "hold $death_second_session "; local -i fake_hold0=$REPLY
   send_keys 'ls fx/basic/'
-  if wait_fake 'hold 2 ' $fake_hold0 10 \
+  if (( first_death_clean )) \
+     && wait_fake "hold $death_second_session " $fake_hold0 10 \
      && dump_get $'\C-xw' TESTWORKER \
-     && [[ $REPLY == *'ready=1'*'failures=1 disabled=0'*'pending=1' ]] \
-     && (( $(grep -c '^start ' $ZRUSH_FAKE_STATE) == 2 )); then
+     && worker_state_has "$REPLY" ready=1 failures=1 disabled=0 pending=1 \
+     && (( $(grep -c '^start ' $ZRUSH_FAKE_STATE) == death_starts0 + 2 )); then
     ok "(err-1c) next request starts exactly one replacement; ready handshake does not reset failure streak"
   else
     ng "(err-1c) held replacement state missing: ${REPLY:-<none>}"
@@ -969,7 +1100,7 @@ sec_death() {
   print -r -- error > $ZRUSH_FAKE_CONTROL
   if wait_log 'worker: error request_id=' $err_terminal0 10 \
      && dump_get $'\C-xw' TESTWORKER \
-     && [[ $REPLY == *'failures=0 disabled=0'*'pending=0' ]]; then
+     && worker_state_has "$REPLY" failures=0 disabled=0 pending=0; then
     ok "(err-1e) well-formed terminal error resets the session-failure streak"
   else
     ng "(err-1e) terminal response did not reset streak: ${REPLY:-<none>}"
@@ -980,25 +1111,32 @@ sec_death() {
   # must not resolve against a failed plan.
   print -r -- die > $ZRUSH_FAKE_CONTROL
   clear_line; drain 0.3
-  fake_count 'die 2 '; local -i fake_die1=$REPLY
+  fake_count "die $death_second_session "; local -i fake_die1=$REPLY
   log_count 'worker: session failure:'; local -i active_fail1=$REPLY
   send_keys 'ls fx/basic/al'
-  wait_fake 'die 2 ' $fake_die1 10 \
+  wait_fake "die $death_second_session " $fake_die1 10 \
     && wait_log 'worker: session failure:' $active_fail1 10
+  local -i second_death_clean=0
+  wait_worker_state 10 ready=0 stopping=0 rfd=-1 wfd=-1 control=-1 ack=-1 pending=0 \
+    && second_death_clean=1
   clear_line; drain 0.3
-  fake_count 'die 3 '; local -i fake_die2=$REPLY
+  fake_count "die $death_third_session "; local -i fake_die2=$REPLY
   log_count 'worker: session failure:'; local -i active_fail2=$REPLY
   send_keys 'ls fx/basic/al'$'\t'
-  wait_fake 'die 3 ' $fake_die2 10 \
+  wait_fake "die $death_third_session " $fake_die2 10 \
     && wait_log 'worker: session failure:' $active_fail2 10
+  local -i third_death_clean=0
+  wait_worker_state 10 ready=0 stopping=0 rfd=-1 wfd=-1 control=-1 ack=-1 pending=0 \
+    && third_death_clean=1
   drain 0.5
   assert_buffer 'ls fx/basic/al' "(err-2) pending Tab resolved against an actively-dead worker inserts nothing"
   if dump_get $'\C-xw' TESTWORKER \
-     && [[ $REPLY == *'failures=2 disabled=1'*'warned=1'*'pending=0' ]] \
-     && (( $(grep -c '^start ' $ZRUSH_FAKE_STATE) == 3 )); then
+     && (( second_death_clean && third_death_clean )) \
+     && worker_state_has "$REPLY" failures=2 disabled=1 warned=1 pending=0 \
+     && (( $(grep -c '^start ' $ZRUSH_FAKE_STATE) == death_starts0 + 3 )); then
     ok "(err-3) two consecutive active-session deaths open the breaker after one lazy replacement"
   else
-    ng "(err-3) active-death breaker state missing: ${REPLY:-<none>}"
+    ng "(err-3) active-death breaker state missing: second-clean=$second_death_clean third-clean=$third_death_clean state=${REPLY:-<none>}"
   fi
 
   clear_line
@@ -1457,10 +1595,12 @@ sec_hist() {
   # start an unrelated async request before the history-menu attempt.
   send_keys $'\C-xq'
   drain 0.3
-  local -i hist_fake_session=$(( ${$(<$ZRUSH_FAKE_STATE.count):-0} + 1 ))
+  fake_session_count
+  local -i hist_fake_session=$(( REPLY + 1 ))
   print -r -- die > $ZRUSH_FAKE_CONTROL
   fake_count "die $hist_fake_session "; local -i hist_die0=$REPLY
   log_count 'worker: session failure:'; local -i hist_fail0=$REPLY
+  log_count 'worker: transport stopped'; local -i hist_stopped0=$REPLY
   send_keys $'\e[A'
   if wait_fake "die $hist_fake_session " $hist_die0 10 \
      && wait_log 'worker: session failure:' $hist_fail0 10; then
@@ -1483,6 +1623,11 @@ sec_hist() {
     ng "(h24d) shell did not respond after the failed history-menu plan"
   fi
   sync_prompt
+  # The session-failure log can precede response EOF when abort exhausts its
+  # synchronous budget. Do not make the next history request race the retained
+  # stopping gate.
+  local -i h26_worker_clean=0
+  wait_log 'worker: transport stopped' $hist_stopped0 10 && h26_worker_clean=1
 
   # ---- (h26a/h26b) audit A2: send-break while the history menu is open must
   # not leak kind/listing state into the next line. The existing (sb-1)
@@ -1498,7 +1643,8 @@ sec_hist() {
   drain 0.5
   press $'\e[A'
   dump_get $'\C-xk' TESTKIND
-  [[ $REPLY == 'kind=history'* ]] || ng "(h26-setup) history menu did not open: $REPLY"
+  [[ $REPLY == 'kind=history'* && $h26_worker_clean == 1 ]] ||
+    ng "(h26-setup) history menu did not open after worker cleanup=$h26_worker_clean: $REPLY"
   send_keys $'\C-c'   # send-break: abandon the line, bypassing confirm/dismiss/line-finish
   if sync_prompt 15; then
     ok "(h26a) a new prompt appears after send-break with the history menu open"
@@ -1735,8 +1881,18 @@ sec_jobtable() {
   if start_hist_host $WORK/zdot-exit $WORK/xdg-exit $WORK/host-exit.log; then
     send_line '[[ -o checkjobs && -o checkrunningjobs ]] && print CHECK-JOBS-ENABLED'
     if expect '*CHECK-JOBS-ENABLED*HP>*' 5; then
-      send_keys_wait_plan nonempty 'ls fx/basic/al'
-      if dump_get $'\C-xw' TESTWORKER && [[ $REPLY == 'pid='<->' ready=1 '* ]]; then
+      fake_session_count; local -i exit_session=$(( REPLY + 1 ))
+      # Job-table behavior does not require the separate 8 MiB raw-drain
+      # stressor. A small terminal response keeps this case focused on one
+      # `exit`, while zshexit remains free to stop waiting at its fixed deadline.
+      print -r -- error > $ZRUSH_FAKE_CONTROL
+      fake_count "error $exit_session "; local -i exit_request0=$REPLY
+      log_count 'worker: error request_id='; local -i exit_error0=$REPLY
+      send_keys 'ls fx/basic/al'
+      if wait_fake "error $exit_session " $exit_request0 10 \
+         && wait_log 'worker: error request_id=' $exit_error0 10 \
+         && dump_get $'\C-xw' TESTWORKER \
+         && worker_state_has "$REPLY" ready=1 stopping=0; then
         clear_line
         drain 0.3
         local -F exit_deadline=$(( SECONDS + 5 ))
@@ -1755,8 +1911,11 @@ sec_jobtable() {
           fi
         done
         local visible_exit_output=${exit_output//$'\e['[0-9;]#m/}
-        if (( exit_eof )) && [[ $visible_exit_output != *'zsh: you have running jobs.'* ]]; then
-          ok "(worker-job-table) one exit terminates a worker-owning shell without a running-jobs refusal"
+        if (( exit_eof )) \
+           && [[ $visible_exit_output != *'zsh: you have running jobs.'* \
+                 && $visible_exit_output != *'Terminated'* \
+                 && $visible_exit_output != *'Done'* ]]; then
+          ok "(worker-job-table) one exit terminates without job-control output"
         else
           ng "(worker-job-table) exit did not terminate cleanly: eof=$exit_eof output=${(qqqq)visible_exit_output}"
         fi
@@ -1769,6 +1928,7 @@ sec_jobtable() {
   else
     ng "(worker-job-table) dedicated exit host failed to start"
   fi
+  print -r -- proxy > $ZRUSH_FAKE_CONTROL
 }
 
 sec_inflight() {
@@ -1790,6 +1950,7 @@ sec_inflight() {
   # Reaping it here first, without redirecting stderr, avoids the crash;
   # start_hist_host's own redundant delete of the now-already-gone session
   # is then a harmless no-op.
+  print -r -- proxy > $ZRUSH_FAKE_CONTROL
   zpty -d host
   mkdir -p $WORK/zdot-inflight $WORK/xdg-inflight/zrush
   print "source $REPO/tests/zsh/rc/minimal.zshrc" > $WORK/zdot-inflight/.zshrc
@@ -1806,7 +1967,7 @@ sec_inflight() {
       send_keys 'ls fx/overflow/'
       if wait_log 'worker: sending frame' $inflight_sending_before 15; then
         local inflight_sending_line=$(grep -F 'worker: sending frame' $ZRUSH_LOG 2>/dev/null | tail -1)
-        local -i inflight_writer_pid=${${inflight_sending_line##*writer_pid=}%% *}
+        local -i inflight_ack_fd=${${inflight_sending_line##*ackfd=}%% *}
         log_count 'worker: frame sent'; local -i inflight_sent_at_dispatch=$REPLY
         # No drain here: the whole point is to tear down as close as possible
         # to the writer-child spawn, before its ack can land. ^U
@@ -1814,8 +1975,8 @@ sec_inflight() {
         # 'ls fx/overflow/' buffer text so that `exit` runs on an empty line;
         # the capture already finished -- that's how the frame got queued --
         # and an empty buffer collects nothing (behavior.md 候補収集), so no
-        # new request races the exit. The transport is untouched (only
-        # _zrush_worker_transport_teardown touches it).
+        # new request races the exit. The transport is untouched until the
+        # zshexit hook begins healthy shutdown.
         #
         # ^C would clear the buffer just as well but must not be used here:
         # zsh 5.9 defers a SIGINT that arrives while a `zle -F` watcher
@@ -1847,23 +2008,10 @@ sec_inflight() {
         else
           ng "(inflight-1a) job-control output leaked during in-flight teardown: eof=$inflight_exit_eof output=${(qqqq)inflight_visible_output}"
         fi
-        if (( inflight_writer_pid > 1 )); then
-          local -F inflight_gone_deadline=$(( SECONDS + 2 ))
-          local -i inflight_writer_gone=0
-          while (( SECONDS < inflight_gone_deadline )); do
-            if ! kill -0 $inflight_writer_pid 2>/dev/null; then
-              inflight_writer_gone=1
-              break
-            fi
-            zselect -t 5 2>/dev/null
-          done
-          if (( inflight_writer_gone )); then
-            ok "(inflight-1b) the delegated writer child (pid=$inflight_writer_pid) is gone after teardown"
-          else
-            ng "(inflight-1b) writer child pid=$inflight_writer_pid still alive after teardown"
-          fi
+        if (( inflight_ack_fd > 2 )) && [[ $inflight_sending_line != *'writer_pid='* ]]; then
+          ok "(inflight-1b) delegated writer is tracked only by its ack transport slot"
         else
-          ng "(inflight-1b) could not parse a writer_pid from: ${inflight_sending_line:-<none>}"
+          ng "(inflight-1b) missing PID-free ack slot in: ${inflight_sending_line:-<none>}"
         fi
         if (( inflight_sent_at_dispatch == inflight_sent_before )); then
           obsv "(inflight-1c) teardown was dispatched before this frame's ack was consumed (writer child genuinely still delegated)"

--- a/tests/zsh/fake-worker.py
+++ b/tests/zsh/fake-worker.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -11,6 +12,7 @@ REAL = os.environ["ZRUSH_REAL_BIN"]
 CONTROL = Path(os.environ["ZRUSH_FAKE_CONTROL"])
 STATE = Path(os.environ["ZRUSH_FAKE_STATE"])
 COUNT = STATE.with_suffix(".count")
+DRAIN_TAIL_BYTES = 8 * 1024 * 1024
 
 
 def mode() -> str:
@@ -80,13 +82,27 @@ def fail(reason: str):
     raise SystemExit(18)
 
 
-def worker() -> None:
+def watchdog(control_fd: int) -> None:
+    while True:
+        try:
+            os.read(control_fd, 1)
+        except InterruptedError:
+            continue
+        except OSError:
+            os._exit(1)
+        os._exit(1)
+
+
+def worker(control_fd: int) -> None:
+    os.set_inheritable(1, False)
+    thread = threading.Thread(target=watchdog, args=(control_fd,), daemon=True)
+    thread.start()
     session = next_session()
     note(f"start {session}")
     hello = read_netstring(sys.stdin.buffer)
-    if hello is None or fields(hello) != [b"hello", b"6"]:
+    if hello is None or fields(hello) != [b"hello", b"7"]:
         fail("bad hello")
-    sys.stdout.buffer.write(message(b"ready", b"6"))
+    sys.stdout.buffer.write(message(b"ready", b"7"))
     sys.stdout.buffer.flush()
     note(f"ready {session}")
 
@@ -94,6 +110,18 @@ def worker() -> None:
         payload = read_netstring(sys.stdin.buffer)
         if payload is None:
             note(f"eof {session}")
+            if mode() == "drain":
+                # Deliberately not a protocol frame. Healthy transport shutdown
+                # must keep stdout open and drain bytes without parsing them.
+                # Eight MiB is well above the largest default pipe capacity in
+                # the supported macOS/Linux matrix, including Linux systems
+                # with 64 KiB pages. Flush therefore cannot finish unless the
+                # parent actively drains stdout.
+                tail = b"x" * DRAIN_TAIL_BYTES
+                sys.stdout.buffer.write(tail)
+                sys.stdout.buffer.flush()
+                note(f"tail {session} {len(tail)}")
+            note(f"exit {session}")
             return
         request = fields(payload)
         request_id = request[1].decode("ascii") if len(request) > 1 else "missing"
@@ -107,12 +135,12 @@ def worker() -> None:
         if action == "die":
             note(f"die {session} {request_id}")
             os._exit(19)
-        if action == "error":
+        if action in ("error", "drain"):
             sys.stdout.buffer.write(
                 message(b"error", request_id.encode(), b"invalid-request")
             )
             sys.stdout.buffer.flush()
-            note(f"error {session} {request_id}")
+            note(f"{action} {session} {request_id}")
             continue
         fail("unknown control " + action)
 
@@ -121,4 +149,12 @@ if len(sys.argv) < 2:
     os.execv(REAL, [REAL, *sys.argv[1:]])
 if sys.argv[1] != "worker" or mode() == "proxy":
     os.execv(REAL, [REAL, *sys.argv[1:]])
-worker()
+if len(sys.argv) != 4 or sys.argv[2] != "--control-fd":
+    fail("bad worker argv")
+try:
+    control = int(sys.argv[3])
+except ValueError:
+    fail("bad control fd")
+if control <= 2:
+    fail("bad control fd")
+worker(control)

--- a/tests/zsh/rc/history.zshrc
+++ b/tests/zsh/rc/history.zshrc
@@ -58,7 +58,7 @@ bindkey '^Xt' _zrt-dump-fds
 
 # ^Xq: deterministic test-only transport teardown before replacing the private
 # binary. Unlike typing an internal function call, this does not pollute history.
-_zrt_teardown_worker() { _zrush_worker_transport_teardown test }
+_zrt_teardown_worker() { _zrush_worker_shutdown }
 zle -N _zrt-teardown-worker _zrt_teardown_worker
 bindkey '^Xq' _zrt-teardown-worker
 

--- a/tests/zsh/rc/minimal.zshrc
+++ b/tests/zsh/rc/minimal.zshrc
@@ -25,12 +25,12 @@ bindkey '^Xh' _zrt-dump-rh
 # ^Xw: persistent-worker lifecycle state. This exposes only stable invariants
 # needed by driver.zsh (lazy start, reuse, monotonic ids, and clean teardown).
 _zrt_dump_worker() {
-  _zlog "TESTWORKER=pid=$_zrush_worker_pid ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled warned=$_zrush_worker_warned rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending"
+  _zlog "TESTWORKER=ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled warned=$_zrush_worker_warned stopping=$_zrush_worker_stopping tainted=$_zrush_worker_runtime_tainted rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd control=$_zrush_worker_control_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending runtime=${_zrush_worker_runtime_dir:-<none>}"
 }
 zle -N _zrt-dump-worker _zrt_dump_worker
 bindkey '^Xw' _zrt-dump-worker
 
-_zrt_teardown_worker() { _zrush_worker_transport_teardown test }
+_zrt_teardown_worker() { _zrush_worker_shutdown }
 zle -N _zrt-teardown-worker _zrt_teardown_worker
 bindkey '^Xq' _zrt-teardown-worker
 
@@ -82,6 +82,44 @@ _zrt_close_aux_fds() {
 }
 zle -N _zrt-close-aux-fds _zrt_close_aux_fds
 bindkey '^Xj' _zrt-close-aux-fds
+
+# ^Xg: arm the production generated drain handler. The readiness event occurs
+# only after this widget returns to the real ZLE loop; the generated handler
+# invalidates itself, closes its fd, then reaches this temporary read seam.
+typeset -g _zrt_generated_handler= _zrt_generated_generation=
+_zrt_generated_callback_cleanup() {
+  _zrush_worker_disarm_drain
+  if (( $+functions[_zrt_generated_read_saved] )); then
+    functions[_zrush_worker_read]=$functions[_zrt_generated_read_saved]
+    unfunction _zrt_generated_read_saved
+  fi
+}
+_zrt_generated_callback_probe() {
+  emulate -L zsh
+  setopt localoptions no_monitor no_notify no_bg_nice
+  _zrt_generated_callback_cleanup
+  functions[_zrt_generated_read_saved]=$functions[_zrush_worker_read]
+  _zrush_worker_read() {
+    emulate -L zsh
+    local handler=$_zrt_generated_handler generation=$_zrt_generated_generation
+    functions[_zrush_worker_read]=$functions[_zrt_generated_read_saved]
+    unfunction _zrt_generated_read_saved
+    _zlog "TESTGENERATED=dispatched kind=drain generation=$generation current=${_zrush_worker_callback_generation[drain]:-0} drain=$_zrush_worker_drain_fd handler_live=${+functions[$handler]} widget_live=${+widgets[$handler]}"
+    return 0
+  }
+  if _zrush_worker_arm_drain; then
+    _zrt_generated_handler=$_zrush_worker_callback_handler[drain]
+    _zrt_generated_generation=$_zrush_worker_callback_generation[drain]
+    _zlog "TESTGENERATED=armed kind=drain generation=$_zrt_generated_generation fd=$_zrush_worker_drain_fd handler=$_zrt_generated_handler"
+  else
+    _zrt_generated_callback_cleanup
+    _zlog "TESTGENERATED=arm-failed kind=drain"
+  fi
+}
+zle -N _zrt-generated-callback-probe _zrt_generated_callback_probe
+bindkey '^Xg' _zrt-generated-callback-probe
+zle -N _zrt-generated-callback-cleanup _zrt_generated_callback_cleanup
+bindkey '^XG' _zrt-generated-callback-cleanup
 
 _zrt_cursor_left_three() { (( CURSOR >= 3 )) && (( CURSOR -= 3 )) }
 zle -N _zrt-cursor-left-three _zrt_cursor_left_three

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -1,607 +1,646 @@
 #!/bin/zsh -f
-# Non-pty unit tests for the zsh-side worker transport. The write path: the
-# outbound frame queue, the short-lived writer child that _zrush_worker_flush
-# forks, and the ack/EOF notification fd that _zrush_worker_consume_ack reads.
-# The read path: how _zrush_worker_read walks the receive buffer, in the
-# synchronous mode the history menu drives it in.
-#
-# Usage:
-#   zsh -f tests/zsh/transport.zsh
-#     No arguments, no pty, no terminal. The zrush binary is NOT needed and no
-#     worker process is started: this runner only sources zsh/zrush.zsh with
-#     ZRUSH_NO_INIT=1 (the test seam at the end of that file) and drives the
-#     transport functions directly against a FIFO it owns, standing in for the
-#     worker's request FIFO.
-#     $HOME and $XDG_CONFIG_HOME are redirected to a fresh mktemp directory,
-#     so the real ~/.zshrc, shell history and ~/.config/zrush are untouched.
-#
-# Scope: vectors.zsh covers the capture encoder and the plan decoder; this file
-# is the home for non-pty unit tests of the zsh-side worker transport instead.
-# The behavior under test is specified in docs/internal/specs/behavior.md,
-# sections "worker ライフサイクル" and "履歴メニュー".
-#
-# Test seams used here, none of which touch zsh/zrush.zsh:
-#   - _zrush_warn is replaced by a recorder, so warnings are asserted instead of
-#     printed into the runner's output.
-#   - _zrush_worker_deadline_expired is replaced, for one case, by an oracle
-#     that reports expiry from the state of the exchange rather than from the
-#     clock, so the moment a deadline trips is fixed instead of measured.
-#   - The ZLE callback never runs headless, so the shared consume path
-#     (_zrush_worker_consume_ack) is called directly, exactly as the synchronous
-#     history loop calls it.
-#   - ZRUSH_LOG points at a file under the temp directory, so that teardown's
-#     classification of the writer child (signal it, or leave its pid alone)
-#     can be read back.
-#   - The notification fd is duplicated before consuming, so that "exactly one
-#     ack byte" and "EOF without an ack byte" can be observed independently of
-#     the code under test. The writer child is never `wait`ed on and its exit
-#     status is never used as an oracle.
+# Headless regression tests for the PID-free zsh worker transport.
+# The real Rust worker is used for control-byte/EOF and healthy lifecycle
+# checks; deterministic FIFO seams cover writer backpressure and quarantine.
 emulate -L zsh
 setopt extended_glob nomultibyte
 export LC_ALL=C
-zmodload zsh/system || { print -u2 FATAL: system; exit 1 }
-zmodload zsh/zselect || { print -u2 FATAL: zselect; exit 1 }
+zmodload zsh/system zsh/zselect zsh/datetime zsh/stat || {
+  print -u2 FATAL: required zsh modules
+  exit 1
+}
 
 typeset -g HERE=${${(%):-%N}:A:h}
 typeset -g REPO=${HERE:h:h}
+typeset -g REAL_BIN=$REPO/target/release/zrush
+[[ -x $REAL_BIN ]] || { print -u2 "FATAL: build first: cargo build --release"; exit 1 }
 
-typeset -gi PASS=0 FAIL=0
+typeset -gi PASS=0 FAIL=0 WAIT_CS=500 IDLE_CS=10
 out() { print -r -u2 -- "$@" }
-ok()  { out "PASS: $1"; (( ++PASS )) }
-ng()  { out "FAIL: $1"; (( ++FAIL )) }
-
-# Bounded waits: WAIT_CS for "this must happen", IDLE_CS for "this must not
-# happen". Both are centiseconds (zselect's unit); no sleep is ever used for
-# synchronization.
-typeset -gi WAIT_CS=300 IDLE_CS=20
+ok() { out "PASS: $1"; (( ++PASS )) }
+ng() { out "FAIL: $1"; (( ++FAIL )) }
+typeset -ga WHY=()
+eq() { [[ $2 == "$3" ]] || WHY+=( "$1: got ${(qqq)2}, want ${(qqq)3}" ) }
+note() { WHY+=( "$1" ) }
+verdict() {
+  if (( $#WHY == 0 )); then
+    ok "$1"
+  else
+    ng "$1"
+    local why
+    for why in "${(@)WHY}"; do out "      - $why"; done
+  fi
+  WHY=()
+}
 
 typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-transport.XXXXXX)
-export HOME=$WORK/home             # isolated; never the real home
-export XDG_CONFIG_HOME=$WORK/xdg   # isolated; never the real ~/.config/zrush
-export HISTFILE=$WORK/histfile     # nothing writes history, but never the real one either
-unset ZDOTDIR
+export HOME=$WORK/home XDG_CONFIG_HOME=$WORK/xdg HISTFILE=$WORK/history
 mkdir -p $HOME $XDG_CONFIG_HOME
+unset ZDOTDIR
 
 {
-  typeset -g ZRUSH_NO_INIT=1
+  typeset -g ZRUSH_BIN=$REAL_BIN ZRUSH_NO_INIT=1
   source $REPO/zsh/zrush.zsh || { out "FATAL: cannot source zrush.zsh"; exit 1 }
   unset ZRUSH_NO_INIT
-  for fn in _zrush_worker_flush _zrush_worker_consume_ack _zrush_worker_release_writer \
-            _zrush_worker_transport_teardown _zrush_encode_message; do
-    (( $+functions[$fn] )) || { out "FATAL: $fn undefined after source"; exit 1 }
-  done
-  (( _zrush_enabled )) && { out "FATAL: ZRUSH_NO_INIT did not suppress initialization"; exit 1 }
-
-  typeset -ga WARNINGS=()
-  _zrush_warn() { WARNINGS+=( "$1" ) }   # test seam: record instead of printing
-
-  # _zlog appends only when ZRUSH_LOG is set (zsh/zrush.zsh); point it at the
-  # temp directory so teardown's writer classification is observable.
-  typeset -g LOGFILE=$WORK/zrush.log
-  typeset -g ZRUSH_LOG=$LOGFILE
+  typeset -g LOGFILE=$WORK/zrush.log ZRUSH_LOG=$WORK/zrush.log
   : >| $LOGFILE
-  log_reset() { : >| $LOGFILE }
-  log_has() { command grep -qF -- "$1" $LOGFILE }
-  log_lines() {  # append the whole log to the failure reasons, for diagnosis
-    local l
-    for l in ${(f)"$(command cat $LOGFILE 2>/dev/null)"}; do WHY+=( "log| $l" ); done
-  }
+  typeset -ga WARNINGS=()
+  _zrush_warn() { WARNINGS+=( "$1" ) }
 
-  # ------------------------------------------------------------- assertions
-  typeset -ga WHY=()
-  eq() {  # $1=what $2=actual $3=expected
-    [[ $2 == "$3" ]] || WHY+=( "$1: got ${(qqq)2}, want ${(qqq)3}" )
-  }
-  note() { WHY+=( "$1" ) }
-  verdict() {  # $1=case label
-    if (( $#WHY == 0 )); then
-      ok "$1"
-    else
-      ng "$1"
-      local w
-      for w in "${(@)WHY}"; do out "      - $w"; done
-    fi
-    WHY=()
-  }
-
-  # ------------------------------------------------------------- fixtures
-  typeset -gi RFD=-1 ANCHOR=-1
-  typeset -g FIFO=
-
-  # A writer child forked by _zrush_worker_flush inherits this runner's reader
-  # fds on the FIFO, so a child left blocked inside syswrite by a failing
-  # implementation would never see EPIPE and would outlive the run holding the
-  # runner's stdout. Remember the pids and reap the survivors at exit; never an
-  # oracle, only a safety net for failing runs.
-  typeset -ga SPAWNED=()
-  remember_writer() { (( _zrush_worker_writer_pid > 1 )) && SPAWNED+=( $_zrush_worker_writer_pid ); return 0 }
-  flush_now() {
-    _zrush_worker_flush
-    local -i s=$?
-    remember_writer
-    return $s
-  }
-  reap_spawned() {
-    local -i p
-    local pp
-    for p in ${(@)SPAWNED}; do
-      kill -0 $p 2>/dev/null || continue
-      # Only ever signal a pid that is still one of this runner's own children,
-      # so a recycled pid cannot be hit.
-      pp=${${(f)"$(command ps -o ppid= -p $p 2>/dev/null)"}//[[:space:]]/}
-      [[ $pp == $$ ]] && kill -KILL $p 2>/dev/null
+  readable() { zselect -t ${2:-$WAIT_CS} -r $1 >/dev/null 2>&1 }
+  fd_open() { [[ $1 == <-> && $1 -gt 2 && -e /dev/fd/$1 ]] }
+  watcher_for_fd() {
+    emulate -L zsh
+    local listing=$(builtin zle -F 2>/dev/null) line
+    local -a lines=( ${(f)listing} ) words
+    for line in "${(@)lines}"; do
+      words=( ${(z)line} )
+      (( $#words >= 2 )) && [[ $words[-2] == $1 ]] && return 0
     done
-    SPAWNED=()
+    return 1
+  }
+  mode_of() {
+    local value
+    value=$(command stat -f %Lp "$1" 2>/dev/null) ||
+      value=$(command stat -c %a "$1" 2>/dev/null) || return 1
+    typeset -g REPLY=$value
   }
 
-  # Reset every transport global the write path reads, so each case starts from
-  # a clean session with no worker process behind it.
-  transport_reset() {
-    typeset -g  _zrush_worker_txq=() _zrush_worker_rx= _zrush_worker_setup_req=
-    typeset -gi _zrush_worker_ack_fd=-1 _zrush_worker_writer_pid=-1
-    typeset -gi _zrush_worker_rfd=-1 _zrush_worker_wfd=-1
-    typeset -gi _zrush_worker_drain_fd=-1 _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
-    typeset -gi _zrush_worker_pid=-1 _zrush_worker_ready=0
-    typeset -gi _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0
-    typeset -gA _zrush_worker_pending=()
+  reset_transport() {
+    emulate -L zsh
+    local kind fd
+    for kind in data ack drain; do
+      case $kind in
+        data) fd=${_zrush_worker_rfd:--1} ;;
+        ack) fd=${_zrush_worker_ack_fd:--1} ;;
+        drain) fd=${_zrush_worker_drain_fd:--1} ;;
+      esac
+      (( $+functions[_zrush_worker_invalidate_callback] )) &&
+        _zrush_worker_invalidate_callback $kind $fd
+    done
+    for fd in ${_zrush_worker_ack_fd:--1} ${_zrush_worker_drain_fd:--1} \
+              ${_zrush_worker_rfd:--1} ${_zrush_worker_wfd:--1} \
+              ${_zrush_worker_control_wfd:--1}; do
+      (( fd > 2 )) && _zrush_close_internal_fd $fd
+    done
+    _zrush_worker_runtime_destroy
+    _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_control_wfd=-1
+    _zrush_worker_ack_fd=-1 _zrush_worker_drain_fd=-1
+    _zrush_worker_ready=0
+    _zrush_worker_stopping=0 _zrush_worker_rx=
+    _zrush_worker_runtime_tainted=0
+    _zrush_worker_txq=() _zrush_worker_pending=()
+    _zrush_current_request=0 _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
+    _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_enabled=0
+    _zrush_worker_callback_generation=( data 0 ack 0 drain 0 )
+    _zrush_worker_callback_handler=()
     WARNINGS=()
   }
 
-  # A FIFO standing in for the worker's request FIFO. The anchor is opened
-  # read-write so neither the reader nor the writer open blocks, and the write
-  # fd is blocking + cloexec exactly as _zrush_worker_finish_start opens it: the
-  # forked writer child keeps it because cloexec acts at exec, not at fork.
-  fifo_setup() {  # $1=case name
+  drain_exact() {  # fd path byte-count
     emulate -L zsh
-    FIFO=$WORK/$1.fifo
-    command mkfifo $FIFO || { out "FATAL: mkfifo $FIFO"; exit 1 }
-    sysopen -rw -o cloexec -u ANCHOR $FIFO || { out "FATAL: anchor open"; exit 1 }
-    sysopen -r -u RFD $FIFO || { out "FATAL: read open"; exit 1 }
-    transport_reset
-    sysopen -w -o cloexec -u _zrush_worker_wfd $FIFO || { out "FATAL: write open"; exit 1 }
-  }
-
-  fifo_teardown() {
-    emulate -L zsh
-    local -i fd
-    for fd in $_zrush_worker_wfd $RFD $ANCHOR; do
-      (( fd > 2 )) && { exec {fd}>&- } 2>/dev/null
-    done
-    _zrush_worker_wfd=-1 RFD=-1 ANCHOR=-1
-    [[ -n $FIFO ]] && command rm -f $FIFO
-    FIFO=
-  }
-
-  # Padding that leaves the writer child blocked inside its single syswrite.
-  # A FIFO's buffer is 8192 bytes on macOS but 65536 on Linux, so a frame only
-  # blocks on both platforms if it exceeds the larger figure with margin; the
-  # cases below never hard-code a capacity, they pad by this amount.
-  typeset -gi BLOCK_PAD=131072
-
-  # A representative encoded plan request. Fields carry the bytes the transport
-  # must ship verbatim: option-like values ("-f", "-cvar"), and NUL / SOH / STX,
-  # which cli-protocol.md allows anywhere in a payload. $1 pads the frame; pass
-  # $BLOCK_PAD when the case needs a writer child blocked inside syswrite.
-  build_frame() {  # $1=pad bytes (default 0) -> REPLY
-    emulate -L zsh
-    setopt localoptions nomultibyte
-    local LC_ALL=C
-    local -i pad=${1:-0}
-    local -a fields=(
-      plan 1 /some/path compsys somequery fuzzy 0 1 24 80
-      "w"$'\1'"-f"
-      "w"$'\1'"-cvar"
-      "w"$'\2'"README.md"$'\0'"after-nul"
-    )
-    (( pad > 0 )) && fields+=( "w"$'\1'"${(l:pad::x:)}" )
-    _zrush_encode_message "${(@)fields}"
-  }
-
-  # ------------------------------------------------------------- fd helpers
-  readable() {  # $1=fd $2=centiseconds -> 0 if readable within the budget
-    emulate -L zsh
-    zselect -t $2 -r $1 >/dev/null 2>&1
-  }
-
-  # Copy exactly $3 bytes off $1 into the file $2, never blocking unbounded.
-  drain_bytes() {  # $1=fd $2=outfile $3=byte count
-    emulate -L zsh
-    setopt localoptions nomultibyte
-    local LC_ALL=C
-    local -i fd=$1 want=$3 got=0 cnt=0 st=0 outfd=-1
+    local -i fd=$1 want=$3 total=0 count st outfd=-1
     exec {outfd}>| $2 || return 1
-    while (( got < want )); do
-      if ! readable $fd $WAIT_CS; then
-        { exec {outfd}>&- } 2>/dev/null
-        return 1
-      fi
-      cnt=0
-      sysread -c cnt -i $fd -o $outfd -s 65536; st=$?
-      (( st == 0 )) || { { exec {outfd}>&- } 2>/dev/null; return 1 }
-      (( got += cnt ))
+    while (( total < want )); do
+      readable $fd || { exec {outfd}>&-; return 1 }
+      count=0
+      sysread -c count -i $fd -o $outfd -s 65536; st=$?
+      (( st == 0 )) || { exec {outfd}>&-; return 1 }
+      (( total += count ))
     done
-    { exec {outfd}>&- } 2>/dev/null
-    return 0
+    exec {outfd}>&-
   }
 
-  # Duplicate the notification fd so the ack byte / EOF can be observed without
-  # racing the code under test for it.
-  peek_open() {  # -> PEEK
-    typeset -gi PEEK=-1
-    (( _zrush_worker_ack_fd >= 0 )) || return 1
-    exec {PEEK}<&$_zrush_worker_ack_fd
-  }
-  peek_close() {
-    (( PEEK > 2 )) && { exec {PEEK}>&- } 2>/dev/null
-    PEEK=-1
-  }
-  # Reads whatever the notification pipe still holds. status 4 = nothing yet,
-  # 0 = bytes available (in PEEK_BYTES), 5 = EOF.
-  peek_read() {  # -> PEEK_ST / PEEK_BYTES
-    typeset -g PEEK_BYTES=
-    sysread -t 0 -i $PEEK PEEK_BYTES
-    typeset -gi PEEK_ST=$?
+  start_ready() {
+    emulate -L zsh
+    local -F deadline=$(( EPOCHREALTIME + 5.0 ))
+    _zrush_worker_runtime_prepare || return 1
+    _zrush_worker_start || return 1
+    while (( _zrush_worker_ack_fd >= 0 && EPOCHREALTIME < deadline )); do
+      readable $_zrush_worker_ack_fd 20 && _zrush_worker_consume_ack
+    done
+    (( _zrush_worker_ack_fd < 0 )) || return 1
+    while (( !_zrush_worker_ready && EPOCHREALTIME < deadline )); do
+      readable $_zrush_worker_rfd 20 && _zrush_worker_read async
+    done
+    (( _zrush_worker_ready ))
   }
 
-  # ============================================================ case 1
-  # One frame: the child ships it whole and acks exactly once.
-  fifo_setup one
-  build_frame; typeset -g FRAME=$REPLY
-  print -rn -- "$FRAME" >| $WORK/one.expected
-  _zrush_worker_txq=( "$FRAME" )
-  flush_now; typeset -gi st=$?
-  eq "flush status" $st 0
-  eq "queue drained into the child" $#_zrush_worker_txq 0
-  (( _zrush_worker_ack_fd >= 0 )) || note "no notification fd after flush"
-  (( _zrush_worker_writer_pid > 1 )) || note "no writer child pid after flush"
-  if peek_open; then
-    if drain_bytes $RFD $WORK/one.actual ${#FRAME}; then
-      cmp -s $WORK/one.expected $WORK/one.actual || note "frame bytes differ from what was queued"
-    else
-      note "reader did not observe ${#FRAME} bytes within ${WAIT_CS}cs"
+  stop_until_done() {
+    emulate -L zsh
+    local -F deadline=$(( EPOCHREALTIME + ${1:-5.0} ))
+    while (( _zrush_worker_stopping && EPOCHREALTIME < deadline )); do
+      _zrush_worker_stop_progress async
+      (( _zrush_worker_stopping )) || break
+      _zrush_worker_wait $(( EPOCHREALTIME + 0.05 )) \
+        $_zrush_worker_ack_fd $_zrush_worker_rfd
+    done
+    (( !_zrush_worker_stopping ))
+  }
+
+  # ------------------------------------------------ secure runtime topology
+  reset_transport
+  typeset -gi saved0 saved1 saved2
+  exec {saved0}<&0 {saved1}>&1 {saved2}>&2
+  _zrush_worker_runtime_prepare || note "runtime preparation failed"
+  typeset -g runtime=$_zrush_worker_runtime_dir req=$_zrush_worker_request_path
+  typeset -g resp=$_zrush_worker_response_path ctl=$_zrush_worker_control_path
+  [[ -d $runtime && -p $req && -p $resp && -p $ctl ]] || note "runtime topology is incomplete"
+  mode_of $runtime && eq "runtime mode" $REPLY 700
+  local endpoint
+  for endpoint in $req $resp $ctl; do
+    mode_of $endpoint && eq "FIFO mode $endpoint" $REPLY 600
+  done
+  [[ /dev/fd/0 -ef /dev/fd/$saved0 && /dev/fd/1 -ef /dev/fd/$saved1 \
+     && /dev/fd/2 -ef /dev/fd/$saved2 ]] || note "runtime setup changed shell stdio"
+  _zrush_worker_runtime_destroy
+  [[ ! -e $runtime && -z $_zrush_worker_runtime_dir ]] || note "exact runtime paths survived destroy"
+  exec {saved0}>&- {saved1}>&- {saved2}>&-
+  verdict "runtime: private 0700 directory and three 0600 FIFOs are exact-owned"
+
+  # Lazy worker start consumes only a source-prepared runtime. It cannot hide
+  # a synchronous mkfifo/mkdir operation behind the first input event.
+  reset_transport
+  _zrush_worker_start >/dev/null 2>&1
+  typeset -gi no_runtime_st=$?
+  (( no_runtime_st != 0 )) || note "start without source-prepared runtime succeeded"
+  [[ -z $_zrush_worker_runtime_dir && -z $_zrush_worker_request_path \
+     && -z $_zrush_worker_response_path && -z $_zrush_worker_control_path ]] ||
+    note "lazy start created a runtime"
+  eq "lazy start response fd" $_zrush_worker_rfd -1
+  eq "lazy start request fd" $_zrush_worker_wfd -1
+  eq "lazy start control fd" $_zrush_worker_control_wfd -1
+  verdict "startup: lazy start never creates the source-generation runtime"
+
+  # -------------------------------- transactional descriptor acquisition
+  reset_transport
+  _zrush_worker_runtime_prepare || note "transaction fixture runtime failed"
+  runtime=$_zrush_worker_runtime_dir
+  typeset -gi txn0 txn1 txn2
+  exec {txn0}<&0 {txn1}>&1 {txn2}>&2
+  typeset -gi SYSOPEN_CALLS=0
+  sysopen() {
+    (( ++SYSOPEN_CALLS == 4 )) && return 1
+    builtin sysopen "$@"
+  }
+  _zrush_worker_start >/dev/null 2>&1
+  typeset -gi transaction_st=$?
+  unfunction sysopen
+  (( transaction_st != 0 )) || note "injected endpoint failure reported success"
+  eq "unpublished response fd" $_zrush_worker_rfd -1
+  eq "unpublished request fd" $_zrush_worker_wfd -1
+  eq "unpublished control fd" $_zrush_worker_control_wfd -1
+  eq "unpublished ack fd" $_zrush_worker_ack_fd -1
+  eq "stopping gate finalized" $_zrush_worker_stopping 0
+  [[ -d $runtime ]] || note "generation runtime was incorrectly destroyed by session start rollback"
+  [[ /dev/fd/0 -ef /dev/fd/$txn0 && /dev/fd/1 -ef /dev/fd/$txn1 \
+     && /dev/fd/2 -ef /dev/fd/$txn2 ]] || note "failed endpoint acquisition changed shell stdio"
+  exec {txn0}>&- {txn1}>&- {txn2}>&-
+  verdict "startup: endpoint allocation failure publishes no partial fd or active session"
+
+  # A watcher failure reported after the worker has spawned cannot use the
+  # pre-spawn rollback path. Keep the response fd as the sole completion
+  # oracle, unlink the generation's names, and refuse overlap even after EOF.
+  reset_transport
+  ZRUSH_BIN=$REAL_BIN
+  _zrush_worker_runtime_prepare || note "post-spawn worker fixture runtime failed"
+  typeset -g worker_failed_runtime=$_zrush_worker_runtime_dir
+  typeset -g worker_failed_req=$_zrush_worker_request_path
+  typeset -g worker_failed_resp=$_zrush_worker_response_path
+  typeset -g worker_failed_ctl=$_zrush_worker_control_path
+  typeset -gi worker0 worker1 worker2
+  exec {worker0}<&0 {worker1}>&1 {worker2}>&2
+  functions[_zrt_poll_eof]=$functions[_zrush_worker_poll_eof]
+  functions[_zrt_wait]=$functions[_zrush_worker_wait]
+  typeset -g worker_failed_handler=_zrush-worker-data-$(( _zrush_worker_callback_seq + 1 ))
+  zle() {
+    if [[ $1 == -F && $2 == -w && $4 == $worker_failed_handler ]]; then
+      return 1
     fi
-    readable $RFD $IDLE_CS && note "extra bytes followed the frame"
-    if readable $_zrush_worker_ack_fd $WAIT_CS; then
-      _zrush_worker_consume_ack; typeset -gi cst=$?
-      eq "consume_ack status" $cst 0
-      # consume_ack read the whole ack byte string: any second byte would have
-      # made it "11" and failed the session. The dup then shows EOF, so exactly
-      # one ack byte was ever written.
-      peek_read
-      eq "notification fd after the ack" $PEEK_ST 5
-      eq "bytes after the ack" ${#PEEK_BYTES} 0
-      eq "in-flight notification fd released" $_zrush_worker_ack_fd -1
-      eq "in-flight writer pid released" $_zrush_worker_writer_pid -1
-      eq "session failures" $_zrush_worker_failures 0
-      eq "warnings" $#WARNINGS 0
-    else
-      note "no ack within ${WAIT_CS}cs"
-    fi
-  else
-    note "cannot duplicate the notification fd"
-  fi
-  peek_close
-  fifo_teardown
-  verdict "frame: shipped byte-for-byte and acked exactly once"
+    builtin zle "$@"
+  }
+  _zrush_worker_poll_eof() { return 1 }
+  _zrush_worker_wait() { return 1 }
+  _zrush_worker_start >/dev/null 2>&1
+  typeset -gi post_worker_st=$?
+  unfunction zle
+  functions[_zrush_worker_poll_eof]=$functions[_zrt_poll_eof]
+  functions[_zrush_worker_wait]=$functions[_zrt_wait]
+  unfunction _zrt_poll_eof _zrt_wait
+  (( post_worker_st != 0 )) || note "post-spawn worker watcher failure reported success"
+  eq "post-spawn worker quarantine" $_zrush_worker_stopping 1
+  eq "post-spawn worker taint" $_zrush_worker_runtime_tainted 1
+  fd_open $_zrush_worker_rfd || note "post-spawn worker response oracle was discarded"
+  eq "failed response callback generation cleared" ${_zrush_worker_callback_generation[data]} 0
+  [[ -z ${_zrush_worker_callback_handler[data]} ]] || note "failed response callback handler remained published"
+  (( !$+functions[$worker_failed_handler] && !$+widgets[$worker_failed_handler] )) ||
+    note "failed response callback left a generated function/widget"
+  watcher_for_fd $_zrush_worker_rfd && note "failed response callback left a live fd watcher"
+  [[ ! -e $worker_failed_req && ! -e $worker_failed_resp && ! -e $worker_failed_ctl ]] ||
+    note "tainted worker FIFO names remained published"
+  [[ -d $worker_failed_runtime ]] || note "tainted worker ownership ledger directory was lost"
+  _zrush_worker_start; eq "post-spawn worker overlap rejected" $? 1
+  [[ /dev/fd/0 -ef /dev/fd/$worker0 && /dev/fd/1 -ef /dev/fd/$worker1 \
+     && /dev/fd/2 -ef /dev/fd/$worker2 ]] || note "post-spawn worker rollback changed shell stdio"
+  stop_until_done || note "explicit worker rollback cleanup did not observe response EOF"
+  eq "worker rollback finalized" $_zrush_worker_stopping 0
+  eq "worker taint survives EOF" $_zrush_worker_runtime_tainted 1
+  _zrush_worker_start; eq "tainted worker runtime remains unavailable" $? 1
+  _zrush_worker_runtime_destroy
+  _zrush_worker_runtime_tainted=0
+  _zrush_worker_runtime_prepare || note "fresh worker source-generation setup failed"
+  [[ $_zrush_worker_runtime_dir != $worker_failed_runtime ]] || note "fresh source reused the tainted runtime directory"
+  [[ -p $_zrush_worker_request_path && -p $_zrush_worker_response_path \
+     && -p $_zrush_worker_control_path ]] || note "fresh source did not publish new FIFO inodes"
+  exec {worker0}>&- {worker1}>&- {worker2}>&-
+  verdict "startup: post-spawn response-watcher failure quarantines the worker and taints the runtime"
 
-  # ============================================================ case 2
-  # Two frames: the second waits for the first frame's ack, and the reader sees
-  # the first frame complete before any byte of the second.
-  fifo_setup order
-  build_frame $BLOCK_PAD; typeset -g FRAME_A=$REPLY
-  build_frame;       typeset -g FRAME_B=$REPLY
-  print -rn -- "$FRAME_A" >| $WORK/order.a.expected
-  print -rn -- "$FRAME_B" >| $WORK/order.b.expected
+  # macOS readiness may report a response EOF only once. The normal parser
+  # must record that already-observed EOF as worker completion before entering
+  # abort; correctness cannot depend on polling the same EOF a second time.
+  reset_transport
+  exec {_zrush_worker_rfd}< /dev/null
+  exec {_zrush_worker_wfd}> /dev/null
+  exec {_zrush_worker_control_wfd}> /dev/null
+  _zrush_worker_ready=1
+  typeset -gi EOF_REPOLLS=0
+  functions[_zrt_poll_eof]=$functions[_zrush_worker_poll_eof]
+  _zrush_worker_poll_eof() { (( ++EOF_REPOLLS )); return 1 }
+  _zrush_worker_read async >/dev/null 2>&1
+  typeset -gi unexpected_eof_st=$?
+  functions[_zrush_worker_poll_eof]=$functions[_zrt_poll_eof]
+  unfunction _zrt_poll_eof
+  eq "unexpected EOF read status" $unexpected_eof_st 1
+  eq "unexpected EOF is not re-polled" $EOF_REPOLLS 0
+  eq "observed EOF closes response gate" $_zrush_worker_rfd -1
+  eq "observed EOF closes request" $_zrush_worker_wfd -1
+  eq "observed EOF closes control" $_zrush_worker_control_wfd -1
+  eq "observed EOF finalizes stop" $_zrush_worker_stopping 0
+  eq "unexpected EOF records one failure" $_zrush_worker_failures 1
+  verdict "response EOF: one normal-read observation completes the gate before abort"
+
+  # ------------------------------------------------ real watchdog control byte
+  reset_transport
+  ZRUSH_BIN=$REAL_BIN
+  start_ready || note "real worker did not reach protocol-7 ready"
+  typeset -gi byte_rfd=$_zrush_worker_rfd
+  _zrush_worker_abort $(( EPOCHREALTIME + 2.0 )); typeset -gi byte_st=$?
+  eq "abort byte status" $byte_st 0
+  eq "abort byte response EOF" $_zrush_worker_rfd -1
+  eq "abort byte control closed" $_zrush_worker_control_wfd -1
+  eq "abort byte gate finalized" $_zrush_worker_stopping 0
+  [[ ! -e /dev/fd/$byte_rfd ]] || note "response fd remained after watchdog byte"
+  verdict "control: real worker exits on abort byte and response EOF finalizes"
+
+  # ------------------------------------------------ real watchdog control EOF
+  reset_transport
+  start_ready || note "real worker did not reach ready for EOF case"
+  functions[_zrt_signal_abort]=$functions[_zrush_worker_signal_abort]
+  _zrush_worker_signal_abort() { return 0 }
+  _zrush_worker_abort $(( EPOCHREALTIME + 2.0 )); typeset -gi eof_st=$?
+  functions[_zrush_worker_signal_abort]=$functions[_zrt_signal_abort]
+  unfunction _zrt_signal_abort
+  eq "control EOF abort status" $eof_st 0
+  eq "control EOF response finalized" $_zrush_worker_rfd -1
+  eq "control EOF gate finalized" $_zrush_worker_stopping 0
+  verdict "control: real worker exits when the sole control writer closes"
+
+  # ------------------------------------------ normal writer ordering + ack slot
+  reset_transport
+  typeset -g REQ_FIFO=$WORK/request.fifo HOLD_FIFO=$WORK/hold.fifo
+  command mkfifo $REQ_FIFO $HOLD_FIFO
+  typeset -gi REQ_ANCHOR REQ_R HOLD_ANCHOR HOLD_R HOLD_W
+  sysopen -rw -o cloexec -u REQ_ANCHOR $REQ_FIFO
+  sysopen -r -o cloexec -u REQ_R $REQ_FIFO
+  sysopen -w -o cloexec -u _zrush_worker_wfd $REQ_FIFO
+  sysopen -rw -o cloexec -u HOLD_ANCHOR $HOLD_FIFO
+  sysopen -r -o cloexec -u HOLD_R $HOLD_FIFO
+  sysopen -w -o cloexec -u HOLD_W $HOLD_FIFO
+  _zrush_encode_message hello 7; typeset -g FRAME_A=$REPLY
+  _zrush_encode_message plan 1 / compsys q prefix false 1 1 false ''; typeset -g FRAME_B=$REPLY
+  print -rn -- "$FRAME_A" >| $WORK/a.expected
+  print -rn -- "$FRAME_B" >| $WORK/b.expected
+  print() {
+    if (( $# == 3 )) && [[ $1 == -rn && $2 == -- && $3 == 1 ]]; then
+      builtin print "$@"
+      exec {HOLD_W}>&- {HOLD_ANCHOR}>&-
+      local release
+      sysread -i $HOLD_R release
+      return 0
+    fi
+    builtin print "$@"
+  }
   _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
-  flush_now; st=$?
-  typeset -gi ACK_A=$_zrush_worker_ack_fd PID_A=$_zrush_worker_writer_pid
-  eq "flush status" $st 0
-  eq "second frame still queued" $#_zrush_worker_txq 1
-  eq "queued frame is B" "$_zrush_worker_txq[1]" "$FRAME_B"
-  (( PID_A > 1 )) || note "no writer child for frame A"
-  # A outgrows the FIFO's buffer on either platform and nothing drains yet, so
-  # A is still in flight here. A second flush must not hand B to another child.
-  flush_now; st=$?
-  eq "flush while a child is in flight" $st 0
-  eq "notification fd unchanged" $_zrush_worker_ack_fd $ACK_A
-  eq "writer pid unchanged" $_zrush_worker_writer_pid $PID_A
-  eq "B still queued while A is in flight" $#_zrush_worker_txq 1
-  if drain_bytes $RFD $WORK/order.a.actual ${#FRAME_A}; then
-    cmp -s $WORK/order.a.expected $WORK/order.a.actual || note "frame A bytes differ"
-  else
-    note "reader did not observe frame A within ${WAIT_CS}cs"
-  fi
-  # Nothing of B may be in the FIFO before A is acked.
-  readable $RFD $IDLE_CS && note "bytes of B reached the FIFO before A was acked"
-  eq "B still queued before A's ack" $#_zrush_worker_txq 1
-  if readable $_zrush_worker_ack_fd $WAIT_CS; then
-    _zrush_worker_consume_ack; cst=$?
-    remember_writer   # consume_ack flushed B itself
-    eq "consume_ack status for A" $cst 0
-    eq "B handed to a child on A's ack" $#_zrush_worker_txq 0
-    (( _zrush_worker_ack_fd >= 0 )) || note "no notification fd for frame B"
-    (( _zrush_worker_writer_pid > 1 && _zrush_worker_writer_pid != PID_A )) ||
-      note "frame B did not get its own writer child"
-    if drain_bytes $RFD $WORK/order.b.actual ${#FRAME_B}; then
-      cmp -s $WORK/order.b.expected $WORK/order.b.actual || note "frame B bytes differ"
-    else
-      note "reader did not observe frame B within ${WAIT_CS}cs"
-    fi
-    if readable $_zrush_worker_ack_fd $WAIT_CS; then
-      _zrush_worker_consume_ack; cst=$?
-      eq "consume_ack status for B" $cst 0
-      eq "notification fd released after B" $_zrush_worker_ack_fd -1
-      eq "writer pid released after B" $_zrush_worker_writer_pid -1
-      eq "session failures" $_zrush_worker_failures 0
-      eq "warnings" $#WARNINGS 0
-    else
-      note "no ack for frame B within ${WAIT_CS}cs"
-    fi
-  else
-    note "no ack for frame A within ${WAIT_CS}cs"
-  fi
-  fifo_teardown
-  verdict "queue: the next frame is sent only on the previous frame's ack, in order"
+  _zrush_worker_flush; typeset -gi order_st=$?
+  unfunction print
+  exec {HOLD_R}>&- {HOLD_ANCHOR}>&-
+  eq "first flush status" $order_st 0
+  eq "B remains queued under sole slot" $#_zrush_worker_txq 1
+  drain_exact $REQ_R $WORK/a.actual ${#FRAME_A} || note "frame A did not arrive"
+  command cmp -s $WORK/a.expected $WORK/a.actual || note "frame A bytes differ"
+  readable $_zrush_worker_ack_fd || note "frame A ack did not arrive"
+  typeset -gi ACK_A=$_zrush_worker_ack_fd
+  _zrush_worker_consume_ack
+  eq "A ack releases and delegates B" $#_zrush_worker_txq 0
+  (( _zrush_worker_ack_fd > 2 && _zrush_worker_ack_fd != ACK_A )) || note "B did not acquire a new sole slot"
+  drain_exact $REQ_R $WORK/b.actual ${#FRAME_B} || note "frame B did not arrive"
+  command cmp -s $WORK/b.expected $WORK/b.actual || note "frame B bytes differ"
+  readable $_zrush_worker_ack_fd || note "frame B ack did not arrive"
+  _zrush_worker_consume_ack
+  eq "B slot released" $_zrush_worker_ack_fd -1
+  syswrite -o $HOLD_W -- x 2>/dev/null
+  exec {HOLD_W}>&- {REQ_R}>&- {REQ_ANCHOR}>&-
+  _zrush_worker_close_request
+  command rm -f $REQ_FIFO $HOLD_FIFO
+  verdict "writer: ack releases the slot and preserves serial ordering without process EOF"
 
-  # ============================================================ case 3
-  # A child killed mid-frame: EOF without an ack byte is a worker session
-  # failure, never a silently truncated success.
-  fifo_setup killed
-  build_frame $BLOCK_PAD; typeset -g FRAME_BIG=$REPLY
-  _zrush_worker_txq=( "$FRAME_BIG" )
-  flush_now; st=$?
-  eq "flush status" $st 0
-  typeset -gi VICTIM=$_zrush_worker_writer_pid
-  if (( VICTIM > 1 )) && kill -0 $VICTIM 2>/dev/null && peek_open; then
-    # Nothing drains the FIFO, so the child is blocked inside its single
-    # syswrite with the frame only partly written.
-    readable $_zrush_worker_ack_fd $IDLE_CS && note "acked before the frame could have been written"
-    kill -KILL $VICTIM 2>/dev/null || note "cannot kill the writer child"
-    if readable $PEEK $WAIT_CS; then
-      peek_read
-      eq "notification fd reached EOF" $PEEK_ST 5
-      eq "ack bytes before EOF" ${#PEEK_BYTES} 0
-      typeset -gi BEFORE=$_zrush_worker_failures
-      _zrush_worker_consume_ack; cst=$?
-      eq "consume_ack reports failure" $cst 1
-      eq "session failure counted" $_zrush_worker_failures $(( BEFORE + 1 ))
-      eq "warned once" $#WARNINGS 1
-      eq "no in-flight notification fd left" $_zrush_worker_ack_fd -1
-      eq "no in-flight writer pid left" $_zrush_worker_writer_pid -1
-      eq "queue discarded" $#_zrush_worker_txq 0
-      eq "request fd closed by the teardown" $_zrush_worker_wfd -1
-    else
-      note "notification fd did not reach EOF within ${WAIT_CS}cs after the kill"
+  # Report an ack watcher failure only after its watcher was installed. The
+  # already-spawned writer may have touched its frame, so its notification fd
+  # remains the writer gate and the entire FIFO generation becomes unusable.
+  reset_transport
+  ZRUSH_BIN=$REAL_BIN
+  start_ready || note "post-spawn writer fixture did not reach ready"
+  typeset -g writer_failed_runtime=$_zrush_worker_runtime_dir
+  typeset -g writer_failed_req=$_zrush_worker_request_path
+  typeset -g writer_failed_resp=$_zrush_worker_response_path
+  typeset -g writer_failed_ctl=$_zrush_worker_control_path
+  typeset -gi writer0 writer1 writer2
+  exec {writer0}<&0 {writer1}>&1 {writer2}>&2
+  _zrush_encode_message plan 77 / compsys q prefix false 1 1 false ''
+  _zrush_worker_txq=( "$REPLY" never-replayed )
+  functions[_zrt_poll_writer]=$functions[_zrush_worker_poll_writer]
+  functions[_zrt_poll_eof]=$functions[_zrush_worker_poll_eof]
+  functions[_zrt_wait]=$functions[_zrush_worker_wait]
+  typeset -g writer_failed_handler=_zrush-worker-ack-$(( _zrush_worker_callback_seq + 1 ))
+  zle() {
+    if [[ $1 == -F && $2 == -w && $4 == $writer_failed_handler ]]; then
+      return 1
     fi
-  else
-    note "no live writer child to kill"
-  fi
-  peek_close
-  fifo_teardown
-  verdict "kill: a child killed mid-frame fails the session instead of truncating silently"
-
-  # ============================================================ case 4
-  # Frames are opaque byte units: whatever leading bytes a frame has, syswrite
-  # never parses them as its own options.
-  fifo_setup opaque
-  typeset -g ODD=$'-cvar\1-f\0--\2 -s 1'
-  print -rn -- "$ODD" >| $WORK/opaque.expected
-  _zrush_worker_txq=( "$ODD" )
-  flush_now; st=$?
-  eq "flush status" $st 0
-  if drain_bytes $RFD $WORK/opaque.actual ${#ODD}; then
-    cmp -s $WORK/opaque.expected $WORK/opaque.actual || note "option-like frame bytes differ"
-  else
-    note "reader did not observe the frame within ${WAIT_CS}cs"
-  fi
-  if readable $_zrush_worker_ack_fd $WAIT_CS; then
-    _zrush_worker_consume_ack; cst=$?
-    eq "consume_ack status" $cst 0
-    eq "session failures" $_zrush_worker_failures 0
-  else
-    note "no ack within ${WAIT_CS}cs"
-  fi
-  fifo_teardown
-  verdict "frame: option-like leading bytes are written verbatim, not parsed by syswrite"
-
-  # ============================================================ case 5
-  # Teardown drops the unsent queue and signals the child that is still inside
-  # its blocking syswrite: nothing readable on the notification fd is the only
-  # state in which the recorded pid is still the writer child's.
-  fifo_setup drop
-  build_frame $BLOCK_PAD; FRAME_A=$REPLY
-  build_frame;       FRAME_B=$REPLY
-  _zrush_worker_txq=( "$FRAME_A" "$FRAME_B" )
-  flush_now; st=$?
-  eq "flush status" $st 0
-  typeset -gi PID_BLOCKED=$_zrush_worker_writer_pid
-  if peek_open; then
-    log_reset
-    _zrush_worker_transport_teardown failure
-    eq "queued frames dropped" $#_zrush_worker_txq 0
-    eq "notification fd released" $_zrush_worker_ack_fd -1
-    eq "writer pid released" $_zrush_worker_writer_pid -1
-    eq "request fd closed" $_zrush_worker_wfd -1
-    if ! log_has "worker: teardown terminating writer pid=$PID_BLOCKED"; then
-      note "teardown did not signal the child blocked in syswrite"
-      log_lines
-    fi
-    log_has "teardown writer done" && note "teardown classified a blocked child as done"
-    if readable $PEEK $WAIT_CS; then
-      peek_read
-      eq "in-flight child gone without an ack" $PEEK_ST 5
-      eq "ack bytes" ${#PEEK_BYTES} 0
-    else
-      note "in-flight child outlived the teardown"
-    fi
-  else
-    note "cannot duplicate the notification fd"
-  fi
-  peek_close
-  fifo_teardown
-  verdict "teardown: unsent frames are dropped and the blocked child is signalled"
-
-  # ============================================================ case 6
-  # A child that already acked owns nothing any more, even when the ack byte has
-  # not been consumed yet: teardown must not signal that pid, which by then may
-  # belong to an unrelated process.
-  fifo_setup acked
-  build_frame; FRAME=$REPLY
-  _zrush_worker_txq=( "$FRAME" )
-  flush_now; st=$?
-  eq "flush status" $st 0
-  typeset -gi PID_DONE=$_zrush_worker_writer_pid
-  if drain_bytes $RFD $WORK/acked.actual ${#FRAME}; then
-    if readable $_zrush_worker_ack_fd $WAIT_CS; then
-      # The ack byte is deliberately left unconsumed: teardown, not
-      # _zrush_worker_consume_ack, has to classify it.
-      log_reset
-      _zrush_worker_transport_teardown failure
-      if ! log_has "worker: teardown writer done pid=$PID_DONE status=0"; then
-        note "teardown did not classify the acked child as done"
-        log_lines
-      fi
-      log_has "teardown terminating writer" && note "teardown signalled a child that had already acked"
-      eq "notification fd released" $_zrush_worker_ack_fd -1
-      eq "writer pid released" $_zrush_worker_writer_pid -1
-      eq "queue emptied" $#_zrush_worker_txq 0
-    else
-      note "no ack within ${WAIT_CS}cs"
-    fi
-  else
-    note "reader did not observe the frame within ${WAIT_CS}cs"
-  fi
-  fifo_teardown
-  verdict "teardown: a child that already acked is never signalled"
-
-  # ============================================================ case 7
-  # Same classification at the other end: a child that died mid-frame leaves the
-  # notification fd at EOF, and a dead pid must not be signalled either.
-  fifo_setup gone
-  build_frame $BLOCK_PAD; FRAME_BIG=$REPLY
-  _zrush_worker_txq=( "$FRAME_BIG" )
-  flush_now; st=$?
-  eq "flush status" $st 0
-  VICTIM=$_zrush_worker_writer_pid
-  if (( VICTIM > 1 )) && kill -0 $VICTIM 2>/dev/null && peek_open; then
-    kill -KILL $VICTIM 2>/dev/null || note "cannot kill the writer child"
-    if readable $PEEK $WAIT_CS; then
-      log_reset
-      _zrush_worker_transport_teardown failure
-      if ! log_has "worker: teardown writer done pid=$VICTIM status=5"; then
-        note "teardown did not classify the EOF as a finished child"
-        log_lines
-      fi
-      log_has "teardown terminating writer" && note "teardown signalled a child that had already died"
-      eq "notification fd released" $_zrush_worker_ack_fd -1
-      eq "writer pid released" $_zrush_worker_writer_pid -1
-    else
-      note "notification fd did not reach EOF within ${WAIT_CS}cs after the kill"
-    fi
-  else
-    note "no live writer child to kill"
-  fi
-  peek_close
-  fifo_teardown
-  verdict "teardown: a child already at EOF is never signalled"
-
-  # ------------------------------------------------------ read-path fixtures
-  # A read fd that never carries data: sysread -t 0 on it always reports EAGAIN,
-  # so _zrush_worker_read can only make progress from what the case put into
-  # _zrush_worker_rx, and no worker process is needed behind it.
-  typeset -g RFIFO=
-  sync_setup() {  # $1=case name; a session waiting synchronously for request 1
-    emulate -L zsh
-    transport_reset
-    RFIFO=$WORK/rx-$1.fifo
-    command mkfifo $RFIFO || { out "FATAL: mkfifo $RFIFO"; exit 1 }
-    sysopen -rw -o cloexec -u _zrush_worker_rfd $RFIFO || { out "FATAL: rx open"; exit 1 }
-    _zrush_worker_ready=1
-    typeset -gi _zrush_current_request=0
-    _zrush_worker_pending=( 1 history 2 compsys 3 compsys )
-    typeset -gi _zrush_sync_target=1 _zrush_sync_done=0 _zrush_sync_ok=0
+    builtin zle "$@"
   }
-  sync_teardown() {
-    emulate -L zsh
-    (( _zrush_worker_rfd > 2 )) && { exec {_zrush_worker_rfd}>&- } 2>/dev/null
-    _zrush_worker_rfd=-1
-    [[ -n $RFIFO ]] && command rm -f $RFIFO
-    RFIFO=
+  _zrush_worker_poll_writer() { return 1 }
+  _zrush_worker_poll_eof() { return 1 }
+  _zrush_worker_wait() { return 1 }
+  _zrush_worker_flush >/dev/null 2>&1
+  typeset -gi post_writer_st=$?
+  unfunction zle
+  functions[_zrush_worker_poll_writer]=$functions[_zrt_poll_writer]
+  functions[_zrush_worker_poll_eof]=$functions[_zrt_poll_eof]
+  functions[_zrush_worker_wait]=$functions[_zrt_wait]
+  unfunction _zrt_poll_writer _zrt_poll_eof _zrt_wait
+  (( post_writer_st != 0 )) || note "post-spawn writer watcher failure reported success"
+  eq "post-spawn writer quarantine" $_zrush_worker_stopping 1
+  eq "post-spawn writer taint" $_zrush_worker_runtime_tainted 1
+  fd_open $_zrush_worker_ack_fd || note "post-spawn writer notification gate was discarded"
+  fd_open $_zrush_worker_rfd || note "post-spawn writer response oracle was discarded"
+  eq "failed ack callback generation cleared" ${_zrush_worker_callback_generation[ack]} 0
+  [[ -z ${_zrush_worker_callback_handler[ack]} ]] || note "failed ack callback handler remained published"
+  (( !$+functions[$writer_failed_handler] && !$+widgets[$writer_failed_handler] )) ||
+    note "failed ack callback left a generated function/widget"
+  watcher_for_fd $_zrush_worker_ack_fd && note "failed ack callback left a live fd watcher"
+  eq "post-spawn writer drops unsent frames" $#_zrush_worker_txq 0
+  [[ ! -e $writer_failed_req && ! -e $writer_failed_resp && ! -e $writer_failed_ctl ]] ||
+    note "tainted writer FIFO names remained published"
+  _zrush_worker_start; eq "post-spawn writer overlap rejected" $? 1
+  [[ /dev/fd/0 -ef /dev/fd/$writer0 && /dev/fd/1 -ef /dev/fd/$writer1 \
+     && /dev/fd/2 -ef /dev/fd/$writer2 ]] || note "post-spawn writer rollback changed shell stdio"
+  stop_until_done || note "explicit writer rollback cleanup did not resolve both gates"
+  eq "writer rollback finalized" $_zrush_worker_stopping 0
+  eq "writer taint survives cleanup" $_zrush_worker_runtime_tainted 1
+  _zrush_worker_start; eq "tainted writer runtime remains unavailable" $? 1
+  [[ -d $writer_failed_runtime ]] || note "writer ownership ledger directory was lost before source cleanup"
+  _zrush_worker_runtime_destroy
+  _zrush_worker_runtime_tainted=0
+  _zrush_worker_runtime_prepare || note "fresh writer source-generation setup failed"
+  [[ $_zrush_worker_runtime_dir != $writer_failed_runtime ]] || note "fresh source reused writer-tainted runtime"
+  exec {writer0}>&- {writer1}>&- {writer2}>&-
+  verdict "writer: post-spawn ack-watcher failure aborts without replay and forbids runtime reuse"
+
+  # ---------------- one deadline, unacked EPIPE gate, response-EOF quarantine
+  reset_transport
+  REQ_FIFO=$WORK/blocked-request.fifo
+  typeset -g RESP_FIFO=$WORK/blocked-response.fifo GATE_FIFO=$WORK/writer-gate.fifo
+  command mkfifo $REQ_FIFO $RESP_FIFO $GATE_FIFO
+  typeset -gi RESP_ANCHOR RESP_W GATE_ANCHOR GATE_R GATE_W
+  sysopen -rw -o cloexec -u REQ_ANCHOR $REQ_FIFO
+  sysopen -r -o cloexec -u REQ_R $REQ_FIFO
+  sysopen -w -o cloexec -u _zrush_worker_wfd $REQ_FIFO
+  sysopen -rw -o cloexec -u RESP_ANCHOR $RESP_FIFO
+  sysopen -r -o cloexec -u _zrush_worker_rfd $RESP_FIFO
+  sysopen -w -o cloexec -u RESP_W $RESP_FIFO
+  sysopen -rw -o cloexec -u GATE_ANCHOR $GATE_FIFO
+  sysopen -r -o cloexec -u GATE_R $GATE_FIFO
+  sysopen -w -o cloexec -u GATE_W $GATE_FIFO
+  _zrush_worker_ready=1
+  _zrush_worker_register_callback data $_zrush_worker_rfd || note "response callback setup failed"
+  watcher_for_fd $_zrush_worker_rfd || note "response watcher was not observable before stopping"
+  typeset -gi stop_data_generation=$_zrush_worker_callback_generation[data]
+  typeset -g BIG=${(l:262144::x:)}
+  syswrite() {
+    if (( $# >= 2 )) && [[ $1 == -o && $2 == $_zrush_worker_wfd ]]; then
+      exec {REQ_R}>&- {REQ_ANCHOR}>&- {RESP_W}>&- {RESP_ANCHOR}>&-
+      exec {GATE_W}>&- {GATE_ANCHOR}>&-
+      local release
+      builtin sysread -i $GATE_R release
+      builtin syswrite "$@"
+      return $?
+    fi
+    builtin syswrite "$@"
   }
+  _zrush_worker_txq=( "$BIG" queued-never-handed )
+  _zrush_worker_flush
+  watcher_for_fd $_zrush_worker_ack_fd || note "ack watcher was not observable before stopping"
+  typeset -gi stop_ack_generation=$_zrush_worker_callback_generation[ack]
+  unfunction syswrite
+  exec {GATE_R}>&- {GATE_ANCHOR}>&-
+  typeset -ga STOP_DEADLINES=()
+  typeset -g ABORT_DEADLINE=
+  functions[_zrt_wait]=$functions[_zrush_worker_wait]
+  functions[_zrt_abort]=$functions[_zrush_worker_abort]
+  _zrush_worker_wait() { STOP_DEADLINES+=( "$1" ); return 1 }
+  _zrush_worker_abort() { ABORT_DEADLINE=$1; _zrt_abort "$@" }
+  typeset -gF stopped_at=$EPOCHREALTIME
+  _zrush_worker_shutdown; typeset -gi quarantine_st=$?
+  typeset -gF stop_elapsed=$(( EPOCHREALTIME - stopped_at ))
+  functions[_zrush_worker_wait]=$functions[_zrt_wait]
+  functions[_zrush_worker_abort]=$functions[_zrt_abort]
+  unfunction _zrt_wait _zrt_abort
+  (( quarantine_st != 0 )) || note "unresolved stop did not enter quarantine"
+  (( stop_elapsed < 0.35 )) || note "synchronous stop exceeded one bounded budget: $stop_elapsed"
+  (( $#STOP_DEADLINES >= 1 )) || note "healthy phase did not receive an absolute deadline"
+  [[ -n $ABORT_DEADLINE && $ABORT_DEADLINE == ${STOP_DEADLINES[1]:-missing} ]] ||
+    note "healthy-to-abort transition reset the deadline"
+  eq "quarantine gate" $_zrush_worker_stopping 1
+  eq "unhanded frame dropped" $#_zrush_worker_txq 0
+  (( _zrush_worker_ack_fd > 2 && _zrush_worker_rfd > 2 )) || note "completion predicates were not retained"
+  eq "response callback retained" ${_zrush_worker_callback_generation[data]} $stop_data_generation
+  eq "ack callback retained" ${_zrush_worker_callback_generation[ack]} $stop_ack_generation
+  _zrush_worker_start; eq "replacement rejected in quarantine" $? 1
+  exec {REQ_R}>&- {REQ_ANCHOR}>&-
+  syswrite -o $GATE_W -- x 2>/dev/null
+  exec {GATE_W}>&-
+  readable $_zrush_worker_ack_fd || note "failed writer notification never reached EOF"
+  _zrush_worker_stop_progress async
+  eq "EPIPE resolves writer gate" $_zrush_worker_ack_fd -1
+  eq "response EOF still gates replacement" $_zrush_worker_stopping 1
+  _zrush_worker_start; eq "replacement rejected before response EOF" $? 1
+  exec {RESP_W}>&- {RESP_ANCHOR}>&-
+  readable $_zrush_worker_rfd || note "response EOF did not become readable"
+  stop_until_done || note "readiness cleanup did not finalize after both predicates"
+  eq "quarantine finalized" $_zrush_worker_stopping 0
+  eq "response fd finalized" $_zrush_worker_rfd -1
+  command rm -f $REQ_FIFO $RESP_FIFO $GATE_FIFO
+  verdict "quarantine: one deadline, unacked EPIPE gate, and response EOF prevent replay/replacement"
 
-  # An outer frame carrying an `ok` response whose render plan is the smallest
-  # one _zrush_parse_plan accepts: no rows, no highlights, no positions.
-  msg_ok() {  # $1=request_id -> REPLY
-    emulate -L zsh
-    setopt localoptions nomultibyte
-    local LC_ALL=C
-    _zrush_encode_message ok "$1" $'\0'"0"$'\0'"0"$'\0'"0"$'\0'
-  }
+  # ------------------------------------ healthy request EOF + 8 MiB raw drain
+  reset_transport
+  export ZRUSH_REAL_BIN=$REAL_BIN
+  export ZRUSH_FAKE_CONTROL=$WORK/fake-control ZRUSH_FAKE_STATE=$WORK/fake-state
+  : >| $ZRUSH_FAKE_STATE
+  print -r -- drain >| $ZRUSH_FAKE_CONTROL
+  ZRUSH_BIN=$REPO/tests/zsh/fake-worker.py
+  start_ready || note "fake drain worker did not reach ready"
+  typeset -gi old_shutdown_ms=$_ZRUSH_WORKER_SHUTDOWN_MS
+  # Isolate the successful raw-drain path from scheduler/disk variance. The
+  # preceding quarantine case separately pins the one-deadline behavior.
+  _ZRUSH_WORKER_SHUTDOWN_MS=5000
+  _zrush_worker_shutdown; typeset -gi drain_st=$?
+  _ZRUSH_WORKER_SHUTDOWN_MS=$old_shutdown_ms
+  typeset -g fake_state=$(<$ZRUSH_FAKE_STATE)
+  eq "healthy raw-drain status" $drain_st 0
+  [[ $fake_state == *$'eof 1\ntail 1 8388608\nexit 1'* ]] || note "fake worker did not observe EOF/tail/exit order"
+  eq "raw-drain response EOF" $_zrush_worker_rfd -1
+  eq "healthy control retained until completion then closed" $_zrush_worker_control_wfd -1
+  eq "healthy gate finalized" $_zrush_worker_stopping 0
+  verdict "healthy: request EOF drains 8 MiB raw stdout through response EOF"
 
-  # ============================================================ case 8
-  # The target's terminal response ends the synchronous exchange.
-  sync_setup lone
-  msg_ok 1; _zrush_worker_rx=$REPLY
-  typeset -gF DEADLINE=$(( EPOCHREALTIME + 5 ))
-  _zrush_worker_read sync $DEADLINE; st=$?
-  eq "read status" $st 0
-  eq "exchange finished" $_zrush_sync_done 1
-  eq "exchange succeeded" $_zrush_sync_ok 1
-  eq "target no longer pending" ${+_zrush_worker_pending[1]} 0
-  eq "receive buffer consumed" ${#_zrush_worker_rx} 0
-  eq "session failures" $_zrush_worker_failures 0
-  eq "warnings" $#WARNINGS 0
-  sync_teardown
-  verdict "sync read: the target's terminal response commits the exchange"
+  # ----------------------------------------------------- SIGPIPE-safe abort
+  reset_transport
+  typeset -g PIPE_FIFO=$WORK/sigpipe.fifo
+  command mkfifo $PIPE_FIFO
+  typeset -gi PIPE_ANCHOR PIPE_R
+  sysopen -rw -o cloexec -u PIPE_ANCHOR $PIPE_FIFO
+  sysopen -r -o cloexec -u PIPE_R $PIPE_FIFO
+  sysopen -w -o cloexec -u _zrush_worker_control_wfd $PIPE_FIFO
+  exec {PIPE_R}>&- {PIPE_ANCHOR}>&-
+  exec {_zrush_worker_rfd}< /dev/null
+  exec {_zrush_worker_wfd}> /dev/null
+  _zrush_worker_abort $(( EPOCHREALTIME + 0.5 )); typeset -gi sigpipe_st=$?
+  eq "SIGPIPE abort status" $sigpipe_st 0
+  eq "SIGPIPE control closed" $_zrush_worker_control_wfd -1
+  eq "SIGPIPE gate finalized" $_zrush_worker_stopping 0
+  command rm -f $PIPE_FIFO
+  verdict "abort: closed control reader cannot terminate the interactive shell"
 
-  # ============================================================ case 9
-  # Same response, now followed by responses for other request_ids that arrived
-  # in the same read. The exchange ends at the target; the rest stays buffered
-  # for the asynchronous path instead of being processed inside the sync window.
-  sync_setup trailing
-  msg_ok 1; typeset -g TARGET=$REPLY
-  msg_ok 2; typeset -g TRAILING=$REPLY
-  msg_ok 3; TRAILING+=$REPLY
+  # ---------------------------- stopping branches + stale generation/fd reuse
+  reset_transport
+  typeset -gi STALE_FD STALE_READS=0 STALE_ACKS=0 STALE_STOPS=0
+  exec {STALE_FD}< /dev/null
+  _zrush_worker_rfd=$STALE_FD _zrush_worker_ack_fd=$STALE_FD _zrush_worker_drain_fd=$STALE_FD
+  _zrush_worker_callback_generation=( data 201 ack 202 drain 203 )
+  functions[_zrt_read]=$functions[_zrush_worker_read]
+  functions[_zrt_ack]=$functions[_zrush_worker_consume_ack]
+  functions[_zrt_progress]=$functions[_zrush_worker_stop_progress]
+  _zrush_worker_read() { (( ++STALE_READS )); return 0 }
+  _zrush_worker_consume_ack() { (( ++STALE_ACKS )); return 0 }
+  _zrush_worker_stop_progress() { (( ++STALE_STOPS )); return 0 }
+  _zrush_worker_stopping=1
+  _zrush_worker_on_data $STALE_FD 201
+  _zrush_worker_on_ack $STALE_FD 202
+  eq "current stopping callbacks avoid normal reads" $STALE_READS 0
+  eq "current stopping callbacks avoid normal ack consumption" $STALE_ACKS 0
+  eq "current stopping callbacks enter stop progress" $STALE_STOPS 2
+  STALE_STOPS=0
+  _zrush_worker_stopping=0
+  _zrush_worker_on_data $STALE_FD 200
+  _zrush_worker_on_ack $STALE_FD 200
+  _zrush_worker_on_drain $STALE_FD 200
+  _zrush_worker_stopping=1
+  _zrush_worker_on_data $STALE_FD 200
+  _zrush_worker_on_ack $STALE_FD 200
+  functions[_zrush_worker_read]=$functions[_zrt_read]
+  functions[_zrush_worker_consume_ack]=$functions[_zrt_ack]
+  functions[_zrush_worker_stop_progress]=$functions[_zrt_progress]
+  unfunction _zrt_read _zrt_ack _zrt_progress
+  eq "stale data/drain reads" $STALE_READS 0
+  eq "stale ack consumes" $STALE_ACKS 0
+  eq "stale stop progress" $STALE_STOPS 0
+  [[ -e /dev/fd/$STALE_FD ]] || note "stale callback closed reused fd"
+  _zrush_worker_rfd=-1 _zrush_worker_ack_fd=-1 _zrush_worker_drain_fd=-1
+  exec {STALE_FD}>&-
+  _zrush_worker_stopping=0
+  verdict "callbacks: retained data/ack watchers branch on stopping and stale dispatch is inert"
+
+  # -------------------------------- config/re-source fail-fast during quarantine
+  reset_transport
+  _zrush_worker_runtime_prepare
+  runtime=$_zrush_worker_runtime_dir
+  _zrush_worker_stopping=1 _zrush_installed=1
+  _zrush_worker_failures=7 _zrush_disabled=1 _zrush_enabled=0
+  typeset -g old_read_body=$functions[_zrush_worker_read]
+  typeset -g old_runtime=$runtime
+  ZRUSH_BIN=/definitely/not/invoked
+  _zrush_load_config reload; typeset -gi config_st=$?
+  typeset -g ZRUSH_NO_INIT=1
+  source $REPO/zsh/zrush.zsh; typeset -gi resource_st=$?
+  unset ZRUSH_NO_INIT
+  eq "quarantined config status" $config_st 1
+  eq "quarantined re-source status" $resource_st 1
+  eq "stopping state preserved" $_zrush_worker_stopping 1
+  eq "runtime preserved" $_zrush_worker_runtime_dir $old_runtime
+  eq "functions preserved" "$functions[_zrush_worker_read]" "$old_read_body"
+  eq "failure state preserved" $_zrush_worker_failures 7
+  _zrush_worker_stopping=0 _zrush_installed=0
+  _zrush_worker_runtime_destroy
+  verdict "reload: config and re-source fail fast without retrying quarantine"
+
+  # ----------------------------------------------------- exit + fd 0/1/2
+  reset_transport
+  ZRUSH_BIN=$REAL_BIN
+  _zrush_worker_runtime_prepare
+  runtime=$_zrush_worker_runtime_dir
+  exec {saved0}<&0 {saved1}>&1 {saved2}>&2
+  exec {_zrush_worker_rfd}< /dev/null
+  exec {_zrush_worker_wfd}> /dev/null
+  exec {_zrush_worker_control_wfd}> /dev/null
+  typeset -gi exit_rfd=$_zrush_worker_rfd exit_wfd=$_zrush_worker_wfd exit_ctl=$_zrush_worker_control_wfd
+  _zrush_zshexit
+  [[ ! -e $runtime ]] || note "zshexit retained runtime paths"
+  [[ ! -e /dev/fd/$exit_rfd && ! -e /dev/fd/$exit_wfd && ! -e /dev/fd/$exit_ctl ]] ||
+    note "zshexit retained owned session fds"
+  [[ /dev/fd/0 -ef /dev/fd/$saved0 && /dev/fd/1 -ef /dev/fd/$saved1 \
+     && /dev/fd/2 -ef /dev/fd/$saved2 ]] || note "zshexit changed shell stdio"
+  exec {saved0}>&- {saved1}>&- {saved2}>&-
+  verdict "exit: owned endpoints/runtime close without touching fd 0/1/2"
+
+  # ------------------------------------------------------------ job table
+  reset_transport
+  ZRUSH_BIN=$REAL_BIN
+  start_ready || note "job-table worker did not reach ready"
+  typeset -a job_ids=( ${(f)"$(jobs -p 2>/dev/null)"} )
+  eq "interactive job table" $#job_ids 0
+  _zrush_worker_shutdown || note "job-table worker did not stop cleanly"
+  eq "job-table stop gate" $_zrush_worker_stopping 0
+  verdict "job table: worker and delegated writers remain invisible"
+
+  # ------------------------------------------- synchronous history read seam
+  reset_transport
+  _zrush_worker_ready=1
+  _zrush_worker_pending=( 1 history 2 compsys )
+  _zrush_sync_target=1 _zrush_sync_done=0 _zrush_sync_ok=0
+  _zrush_encode_message ok 1 $'\0'"0"$'\0'"0"$'\0'"0"$'\0'; typeset -g TARGET=$REPLY
+  _zrush_encode_message error 2 invalid-request; typeset -g TRAILING=$REPLY
   _zrush_worker_rx=$TARGET$TRAILING
-  DEADLINE=$(( EPOCHREALTIME + 5 ))
-  _zrush_worker_read sync $DEADLINE; st=$?
-  eq "read status" $st 0
-  eq "exchange finished" $_zrush_sync_done 1
-  eq "exchange succeeded" $_zrush_sync_ok 1
-  eq "trailing bytes left buffered" ${#_zrush_worker_rx} ${#TRAILING}
-  eq "trailing bytes left untouched" "$_zrush_worker_rx" "$TRAILING"
-  eq "trailing requests still pending" $#_zrush_worker_pending 2
-  eq "session failures" $_zrush_worker_failures 0
-  eq "warnings" $#WARNINGS 0
-  sync_teardown
-  verdict "sync read: trailing responses are left to the asynchronous path"
+  _zrush_worker_read sync $(( EPOCHREALTIME + 1.0 )); typeset -gi sync_st=$?
+  eq "sync target status" $sync_st 0
+  eq "sync target committed" "$_zrush_sync_done:$_zrush_sync_ok" 1:1
+  eq "trailing response retained" "$_zrush_worker_rx" "$TRAILING"
+  verdict "sync read: target commits while trailing responses remain asynchronous"
 
-  # ============================================================ case 10
-  # The same buffer under a deadline that trips the instant the target's
-  # response is committed -- the worst moment there is, and the one a clock
-  # cannot be aimed at. A success already committed is never withdrawn.
-  sync_setup expiring
-  msg_ok 1; TARGET=$REPLY
-  msg_ok 2; TRAILING=$REPLY
-  msg_ok 3; TRAILING+=$REPLY
-  _zrush_worker_rx=$TARGET$TRAILING
-  typeset -g DEADLINE_FN=$functions[_zrush_worker_deadline_expired]
-  _zrush_worker_deadline_expired() { [[ -n $1 ]] && (( _zrush_sync_done )) }
-  DEADLINE=$(( EPOCHREALTIME + 5 ))   # the oracle, not this value, decides expiry
-  _zrush_worker_read sync $DEADLINE; st=$?
-  functions[_zrush_worker_deadline_expired]=$DEADLINE_FN
-  eq "read status" $st 0
-  eq "exchange finished" $_zrush_sync_done 1
-  eq "exchange succeeded" $_zrush_sync_ok 1
-  eq "trailing bytes left buffered" ${#_zrush_worker_rx} ${#TRAILING}
-  eq "session failures" $_zrush_worker_failures 0
-  eq "warnings" $#WARNINGS 0
-  sync_teardown
-  verdict "sync read: a deadline expiring after the commit cannot undo it"
-
+  reset_transport
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"
 } always {
-  (( $+functions[reap_spawned] )) && reap_spawned
-  [[ -n $WORK && $WORK == */zrush-transport.* ]] && rm -rf $WORK
+  (( $+functions[reset_transport] )) && reset_transport
+  [[ -n $WORK && $WORK == */zrush-transport.* ]] && command rm -rf $WORK
 }
 (( FAIL == 0 ))

--- a/tests/zsh/vectors.zsh
+++ b/tests/zsh/vectors.zsh
@@ -280,8 +280,8 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   exec {exit_rfd}< /dev/null
   exec {exit_wfd}> /dev/null
   _zrush_timer_fd=$exit_timer_fd _zrush_rfd=$exit_rfd _zrush_wfd=$exit_wfd
-  _zrush_pty= _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1
-  _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_setup_fd=-1
+  _zrush_pty=
+  _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_control_wfd=-1
   _zrush_worker_ack_fd=-1 _zrush_worker_drain_fd=-1
   _zrush_zshexit
   if (( _zrush_timer_fd == -1 && _zrush_rfd == -1 && _zrush_wfd == -1 )) \
@@ -303,7 +303,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   # Exercise the same incremental loop as _zrush_worker_read without a process
   # or zle. Every byte boundary is tried, and two responses deliberately share
   # one stream so delivery cannot depend on read chunking.
-  _zrush_encode_message ready 6
+  _zrush_encode_message ready 7
   local ready_frame=$REPLY
   _zrush_encode_message error 41 invalid-request
   local error_frame=$REPLY
@@ -330,7 +330,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
         fi
       done
     done
-    [[ -z $rx && $delivered == 2 && $got[1] == 'ready|6' \
+    [[ -z $rx && $delivered == 2 && $got[1] == 'ready|7' \
        && $got[2] == 'error|41|invalid-request' ]] || { framing_ok=0; break }
   done
   (( framing_ok )) \
@@ -467,31 +467,33 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
 
   # An explicit incompatible handshake opens the permanent shell-session
   # disable immediately; it is not counted as the first retryable failure.
+  # Populate every active endpoint slot needed by a healthy stop. stdout is
+  # already at EOF, so shutdown must raw-drain it before finalizing.
+  zmodload zsh/system zsh/datetime || { out "FATAL: lifecycle modules"; exit 1 }
   _zrush_worker_ready=0 _zrush_worker_failures=0 _zrush_disabled=0 _zrush_enabled=1
-  _zrush_worker_warned=0 _zrush_worker_pid=-1 _zrush_worker_setup_pid=-1
-  local -i mismatch_rfd mismatch_wfd mismatch_setup_fd mismatch_ack_fd mismatch_drain_fd
+  _zrush_worker_warned=0 _zrush_worker_stopping=0
+  local -i mismatch_rfd mismatch_wfd mismatch_control_fd mismatch_drain_fd
   exec {mismatch_rfd}< /dev/null
   exec {mismatch_wfd}> /dev/null
-  exec {mismatch_setup_fd}< /dev/null
-  exec {mismatch_ack_fd}< /dev/null
+  exec {mismatch_control_fd}> /dev/null
   exec {mismatch_drain_fd}< /dev/null
   _zrush_worker_rfd=$mismatch_rfd _zrush_worker_wfd=$mismatch_wfd
-  _zrush_worker_setup_fd=$mismatch_setup_fd
-  _zrush_worker_ack_fd=$mismatch_ack_fd _zrush_worker_drain_fd=$mismatch_drain_fd
+  _zrush_worker_control_wfd=$mismatch_control_fd
+  _zrush_worker_ack_fd=-1 _zrush_worker_drain_fd=$mismatch_drain_fd
   _zrush_encode_message incompatible 7
   local mismatch_frame=$REPLY
   _zrush_netstring_take "$mismatch_frame"
   _zrush_worker_handle_message "$REPLY" 2>/dev/null
   if (( _zrush_disabled && !_zrush_enabled && _zrush_worker_failures == 0 \
         && _zrush_worker_warned && _zrush_worker_rfd == -1 && _zrush_worker_wfd == -1 \
-        && _zrush_worker_setup_fd == -1 && _zrush_worker_ack_fd == -1 \
+        && _zrush_worker_control_wfd == -1 && _zrush_worker_ack_fd == -1 \
         && _zrush_worker_drain_fd == -1 )) \
      && [[ ! -e /dev/fd/$mismatch_rfd && ! -e /dev/fd/$mismatch_wfd \
-           && ! -e /dev/fd/$mismatch_setup_fd && ! -e /dev/fd/$mismatch_ack_fd \
+           && ! -e /dev/fd/$mismatch_control_fd \
            && ! -e /dev/fd/$mismatch_drain_fd ]]; then
     ok "worker lifecycle: protocol mismatch disables immediately and closes every transport fd"
   else
-    ng "worker lifecycle: mismatch state enabled=$_zrush_enabled disabled=$_zrush_disabled failures=$_zrush_worker_failures warned=$_zrush_worker_warned"
+    ng "worker lifecycle: mismatch state enabled=$_zrush_enabled disabled=$_zrush_disabled failures=$_zrush_worker_failures warned=$_zrush_worker_warned fds=$_zrush_worker_rfd,$_zrush_worker_wfd,$_zrush_worker_control_wfd,$_zrush_worker_ack_fd,$_zrush_worker_drain_fd"
   fi
   _zrush_disabled=0 _zrush_enabled=0 _zrush_worker_warned=0
 
@@ -501,7 +503,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   local saved_log=${ZRUSH_LOG:-}
   ZRUSH_LOG=$WORK/lifecycle.log
   _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_enabled=1
-  _zrush_worker_pid=-1 _zrush_worker_rfd=-1 _zrush_worker_wfd=-1
+  _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_control_wfd=-1
   _zrush_worker_session_fail fixture-first 2>/dev/null
   local -i first_failure_ok=$(( _zrush_worker_failures == 1 && _zrush_worker_warned \
     && !_zrush_disabled && _zrush_enabled ))

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -21,10 +21,17 @@
 # This runs while the previous definitions and ledgers are still available.
 # It is intentionally keyed on prior state, not _zrush_enabled: the circuit
 # breaker disables dispatch but leaves registrations that a re-source must undo.
-if (( ${_zrush_installed:-0} || ( ${+_zrush_bound} && $#_zrush_bound ) )); then
+if (( ${_zrush_installed:-0} || ${_zrush_worker_stopping:-0} ||
+      ( ${+_zrush_bound} && $#_zrush_bound ) )); then
   () {
     emulate -L zsh
     local seq w prev cur
+    # Re-entering source is not an explicit teardown retry.
+    (( !${_zrush_worker_stopping:-0} )) || return 1
+    if (( $+functions[_zrush_worker_shutdown] )); then
+      _zrush_worker_shutdown || return 1
+    fi
+    (( $+functions[_zrush_worker_runtime_destroy] )) && _zrush_worker_runtime_destroy
     for seq in "${(@k)_zrush_bound}"; do
       w=$_zrush_bound[$seq]
       cur=${${(z)"$(builtin bindkey -M main -- "$seq" 2>/dev/null)"}[2]:-}
@@ -45,15 +52,16 @@ if (( ${_zrush_installed:-0} || ( ${+_zrush_bound} && $#_zrush_bound ) )); then
     }
     (( $+functions[_zrush_disarm_timer] )) && _zrush_disarm_timer
     (( $+functions[_zrush_cancel_collection] )) && _zrush_cancel_collection
-    (( $+functions[_zrush_worker_transport_teardown] )) && _zrush_worker_transport_teardown resource
     (( $+functions[_zrush_rh_clear] )) && _zrush_rh_clear
+    return 0
   }
+  (( $? == 0 )) || return 1
 fi
 
 # ---------------------------------------------------------------- Global state
 typeset -g  ZRUSH_BIN=${ZRUSH_BIN:-}
 typeset -gi _zrush_enabled=0
-typeset -gi _ZRUSH_EXPECTED_PROTO=6
+typeset -gi _ZRUSH_EXPECTED_PROTO=7
 typeset -g  _zrush_cfg_path= _zrush_cfg_mtime=
 # Shell-session state intentionally survives a manual re-source.
 typeset -gi _zrush_request_seq=${_zrush_request_seq:-0}
@@ -61,6 +69,7 @@ typeset -gi _zrush_worker_warned=${_zrush_worker_warned:-0}
 typeset -gi _zrush_proto_warned=${_zrush_proto_warned:-0}
 typeset -gi _zrush_worker_failures=${_zrush_worker_failures:-0}
 typeset -gi _zrush_disabled=${_zrush_disabled:-0}
+typeset -gi _zrush_worker_stopping=${_zrush_worker_stopping:-0}
 typeset -gi _zrush_installed=0
 # Variables this script consumes from `zrush config` output (validation and rollback)
 typeset -ga _ZRUSH_CFG_VARS=(
@@ -81,16 +90,23 @@ typeset -gi _zrush_kick_fd=${_zrush_kick_fd:--1}  # shell-session permanent; see
 
 # Persistent Rust worker transport.
 typeset -gi _zrush_worker_rfd=-1 _zrush_worker_wfd=-1
+typeset -gi _zrush_worker_control_wfd=-1
 typeset -gi _zrush_worker_drain_fd=-1
-typeset -gi _zrush_worker_ack_fd=-1 _zrush_worker_writer_pid=-1
-typeset -gi _zrush_worker_pid=-1 _zrush_worker_ready=0
+typeset -gi _zrush_worker_ack_fd=-1 _zrush_worker_ready=0
+typeset -gi _zrush_worker_runtime_tainted=0
 typeset -g  _zrush_worker_rx=
 typeset -ga _zrush_worker_txq=()      # complete outbound frames; no send offset exists
-typeset -gi _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
-typeset -g  _zrush_worker_setup_req=
+typeset -g  _zrush_worker_runtime_dir= _zrush_worker_request_path=
+typeset -g  _zrush_worker_response_path= _zrush_worker_control_path=
+typeset -gi _zrush_worker_callback_seq=${_zrush_worker_callback_seq:-0}
+typeset -gA _zrush_worker_callback_generation=( data 0 ack 0 drain 0 )
+typeset -gA _zrush_worker_callback_handler=()
 typeset -gA _zrush_worker_pending=()
 typeset -gi _zrush_current_request=0
 typeset -gi _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
+# Lifecycle stops may block briefly, but each operation uses one 100ms
+# absolute budget, matching the existing synchronous history exchange.
+typeset -gi _ZRUSH_WORKER_SHUTDOWN_MS=100
 
 # Render plan received from the Rust worker (cli-protocol.md "render_plan").
 # zsh applies these verbatim; it never recomputes layout, offsets, or spans.
@@ -162,7 +178,7 @@ _zrush_close_internal_fd() {  # $1=owned fd; idempotent best-effort close
 # permanent self-pipe right after a registration forces the extra round, so a
 # silenced watcher never survives the poll that silenced it. Invariant:
 # every `zle -F -w` registration is followed by _zrush_kick.
-_zrush_kick_init() {  # ZLE widget context; idempotent
+_zrush_kick_init() {  # source-time; idempotent
   emulate -L zsh
   (( _zrush_kick_fd >= 0 )) && return 0
   local fifo=${TMPDIR:-/tmp}/zrush-kick-$$-$RANDOM
@@ -236,6 +252,7 @@ _zrush_config_mtime() {  # -> REPLY (numeric mtime or 'absent')
 # Returns 0 on success after updating global ZRUSH_CFG_* / ZRUSH_PROTOCOL_VERSION.
 _zrush_load_config() {
   emulate -L zsh
+  (( !${_zrush_worker_stopping:-0} )) || return 1
   local out
   out=$("$ZRUSH_BIN" config 2>/dev/null) || return 1
   # eval assigns the globals in place, so snapshot the previous values first;
@@ -255,7 +272,7 @@ _zrush_load_config() {
     fi
     _zrush_disabled=1
     _zrush_enabled=0
-    (( $+functions[_zrush_worker_transport_teardown] )) && _zrush_worker_transport_teardown incompatible
+    (( $+functions[_zrush_worker_shutdown] )) && _zrush_worker_shutdown
     return 1
   fi
   _zrush_config_mtime
@@ -868,115 +885,339 @@ _zrush_worker_warn_once() {
   _zrush_worker_warned=1
 }
 
+_zrush_worker_invalidate_callback() {  # data|ack|drain fd
+  emulate -L zsh
+  local kind=$1 handler=${_zrush_worker_callback_handler[$1]:-}
+  local -i fd=${2:--1}
+  # Invalidate the registration identity before removing its watcher, widget,
+  # or function: a callback already snapshotted by ZLE must fail its generation
+  # check even if the numeric fd has since been reused.
+  _zrush_worker_callback_generation[$kind]=0
+  _zrush_worker_callback_handler[$kind]=
+  (( fd >= 0 )) && zle -F $fd 2>/dev/null
+  if [[ -n $handler ]]; then
+    zle -D $handler 2>/dev/null
+    unfunction -- $handler 2>/dev/null
+  fi
+  return 0
+}
+
+_zrush_worker_register_callback() {  # data|ack|drain fd
+  emulate -L zsh
+  local kind=$1
+  local -i fd=$2 generation=$(( ++_zrush_worker_callback_seq ))
+  local handler=_zrush-worker-${kind}-${generation}
+  _zrush_worker_invalidate_callback $kind -1
+  _zrush_worker_callback_generation[$kind]=$generation
+  _zrush_worker_callback_handler[$kind]=$handler
+  functions[$handler]="_zrush_worker_on_${kind} \"\$1\" $generation"
+  if ! zle -N $handler $handler 2>/dev/null ||
+     ! zle -F -w $fd $handler 2>/dev/null; then
+    _zrush_worker_invalidate_callback $kind $fd
+    return 1
+  fi
+  return 0
+}
+
+_zrush_worker_callback_current() {  # kind fd generation
+  emulate -L zsh
+  local kind=$1
+  local -i fd=$2 generation=$3 expected_fd=-1
+  (( generation > 0 &&
+     generation == ${_zrush_worker_callback_generation[$kind]:-0} )) || return 1
+  case $kind in
+    data)  expected_fd=$_zrush_worker_rfd ;;
+    ack)   expected_fd=$_zrush_worker_ack_fd ;;
+    drain) expected_fd=$_zrush_worker_drain_fd ;;
+    *) return 1 ;;
+  esac
+  [[ $kind != drain ]] || (( !_zrush_worker_stopping )) || return 1
+  (( fd >= 0 && fd == expected_fd ))
+}
+
 _zrush_worker_disarm_drain() {
+  _zrush_worker_invalidate_callback drain $_zrush_worker_drain_fd
   if (( _zrush_worker_drain_fd >= 0 )); then
-    zle -F $_zrush_worker_drain_fd 2>/dev/null
     _zrush_close_internal_fd $_zrush_worker_drain_fd
     _zrush_worker_drain_fd=-1
   fi
 }
 
-_zrush_worker_terminate() {
+# Raw response drain. Return 0=EOF, 1=open/EAGAIN, 2=read error, 3=deadline.
+_zrush_worker_poll_eof() {  # fd [absolute-deadline [max-reads]]
   emulate -L zsh
-  local -i pid=$1
-  (( pid > 1 )) || return 0
-  kill -TERM $pid 2>/dev/null
-  if kill -0 $pid 2>/dev/null; then
-    zselect -t 1 2>/dev/null
-    kill -0 $pid 2>/dev/null && kill -KILL $pid 2>/dev/null
-  fi
-  kill -0 $pid 2>/dev/null && zselect -t 1 2>/dev/null
-  local -i gone=0
-  kill -0 $pid 2>/dev/null || gone=1
-  _zlog "worker: terminated pid=$pid gone=$gone"
-  return 0
+  local chunk= deadline=${2:-}
+  local -i fd=$1 st reads=0 max_reads=${3:-0}
+  while true; do
+    [[ -n $deadline ]] && (( EPOCHREALTIME >= deadline )) && return 3
+    sysread -t 0 -i $fd chunk; st=$?
+    if (( st == 0 )); then
+      (( ++reads ))
+      (( max_reads > 0 && reads >= max_reads )) && return 1
+      continue
+    fi
+    (( st == 4 )) && return 1
+    (( st == 5 )) && return 0
+    return 2
+  done
 }
 
-# Releases the notification fd of a writer child that has finished with the
-# frame it was handed; the child itself is never waited on (behavior.md
-# "worker ライフサイクル").
-_zrush_worker_release_writer() {
-  (( _zrush_worker_ack_fd >= 0 )) || return 0
-  zle -F $_zrush_worker_ack_fd 2>/dev/null
-  _zrush_close_internal_fd $_zrush_worker_ack_fd
-  _zrush_worker_ack_fd=-1
-  return 0
+# Ack alone releases the delegated writer slot. EOF before ack is failure.
+_zrush_worker_poll_writer() {  # [absolute-deadline]
+  emulate -L zsh
+  local ack= deadline=${1:-}
+  local -i st
+  [[ -n $deadline ]] && (( EPOCHREALTIME >= deadline )) && return 3
+  sysread -s 1 -t 0 -i $_zrush_worker_ack_fd ack; st=$?
+  (( st == 0 )) && { [[ $ack == 1 ]] && return 0 || return 2 }
+  (( st == 4 )) && return 1
+  (( st == 5 )) && return 2
+  return 2
 }
 
-_zrush_worker_transport_teardown() {
+_zrush_worker_wait() {  # deadline fd...
+  emulate -L zsh
+  local -F deadline=$1 remaining
+  shift
+  local -a args=()
+  local -i fd cs
+  for fd in "$@"; do (( fd >= 0 )) && args+=( -r $fd ); done
+  (( $#args )) || return 1
+  remaining=$(( deadline - EPOCHREALTIME ))
+  (( remaining > 0 )) || return 1
+  cs=$(( remaining * 100 ))
+  (( cs >= 1 )) || return 1
+  zselect -t $cs "${(@)args}" >/dev/null 2>&1
+}
+
+_zrush_worker_runtime_prepare() {
   emulate -L zsh
   setopt localoptions no_bg_nice
-  _zrush_worker_disarm_drain
-  _zrush_worker_txq=()
-  # _zrush_worker_writer_pid is >1 only while an ack fd exists, so signalling
-  # belongs inside this branch. Nothing readable after the bounded wait is the
-  # only state in which the child still owns that pid; once its single write is
-  # over the pid may already have been reused by an unrelated process.
-  if (( _zrush_worker_ack_fd >= 0 )); then
-    local ack=
-    local -i ack_st
-    zle -F $_zrush_worker_ack_fd 2>/dev/null
-    # The notification fd becomes readable on the ack byte and on the child's
-    # death alike, so this bounded wait cannot outlast the child.
-    zselect -t 1 -r $_zrush_worker_ack_fd >/dev/null 2>&1
-    sysread -t 0 -i $_zrush_worker_ack_fd ack; ack_st=$?
-    _zrush_worker_release_writer
-    if (( ack_st == 4 )); then
-      _zlog "worker: teardown terminating writer pid=$_zrush_worker_writer_pid"
-      _zrush_worker_terminate $_zrush_worker_writer_pid
-    else
-      _zlog "worker: teardown writer done pid=$_zrush_worker_writer_pid status=$ack_st"
-    fi
+  [[ -z $_zrush_worker_runtime_dir ]] || return 0
+  local old_umask=$(umask) dir= req= resp= control=
+  umask 077
+  dir=$(command mktemp -d "${TMPDIR:-/tmp}/zrush-${UID}.XXXXXX" 2>/dev/null) || {
+    umask $old_umask
+    return 1
+  }
+  req=$dir/request resp=$dir/response control=$dir/abort
+  if ! command chmod 700 "$dir" 2>/dev/null ||
+     ! command mkfifo "$req" "$resp" "$control" 2>/dev/null ||
+     ! command chmod 600 "$req" "$resp" "$control" 2>/dev/null; then
+    command rm -f "$req" "$resp" "$control" >/dev/null 2>&1
+    command rmdir "$dir" >/dev/null 2>&1
+    umask $old_umask
+    return 1
   fi
-  _zrush_worker_writer_pid=-1
-  if (( _zrush_worker_setup_fd >= 0 )); then
-    zle -F $_zrush_worker_setup_fd 2>/dev/null
-    _zrush_close_internal_fd $_zrush_worker_setup_fd
-    _zrush_worker_setup_fd=-1
-  fi
-  _zrush_worker_terminate $_zrush_worker_setup_pid
-  _zrush_worker_setup_pid=-1
-  if [[ -n $_zrush_worker_setup_req ]]; then
-    command rm -f "$_zrush_worker_setup_req" >/dev/null 2>&1 &!
-  fi
-  _zrush_worker_setup_req=
+  umask $old_umask
+  _zrush_worker_runtime_dir=$dir
+  _zrush_worker_request_path=$req
+  _zrush_worker_response_path=$resp
+  _zrush_worker_control_path=$control
+  return 0
+}
+
+_zrush_worker_runtime_valid() {
+  (( !_zrush_worker_runtime_tainted )) &&
+    [[ -n $_zrush_worker_runtime_dir && -d $_zrush_worker_runtime_dir &&
+       -p $_zrush_worker_request_path && -p $_zrush_worker_response_path &&
+       -p $_zrush_worker_control_path ]]
+}
+
+_zrush_worker_runtime_taint() {
+  emulate -L zsh
+  _zrush_worker_runtime_tainted=1
+  [[ -n $_zrush_worker_request_path ]] && command rm -f "$_zrush_worker_request_path" >/dev/null 2>&1
+  [[ -n $_zrush_worker_response_path ]] && command rm -f "$_zrush_worker_response_path" >/dev/null 2>&1
+  [[ -n $_zrush_worker_control_path ]] && command rm -f "$_zrush_worker_control_path" >/dev/null 2>&1
+}
+
+_zrush_worker_runtime_destroy() {
+  emulate -L zsh
+  local dir=$_zrush_worker_runtime_dir
+  [[ -n $_zrush_worker_request_path ]] && command rm -f "$_zrush_worker_request_path" >/dev/null 2>&1
+  [[ -n $_zrush_worker_response_path ]] && command rm -f "$_zrush_worker_response_path" >/dev/null 2>&1
+  [[ -n $_zrush_worker_control_path ]] && command rm -f "$_zrush_worker_control_path" >/dev/null 2>&1
+  [[ -n $dir ]] && command rmdir "$dir" >/dev/null 2>&1
+  _zrush_worker_runtime_dir= _zrush_worker_request_path=
+  _zrush_worker_response_path= _zrush_worker_control_path=
+}
+
+_zrush_worker_release_writer() {
+  local -i fd=$_zrush_worker_ack_fd
+  _zrush_worker_invalidate_callback ack $fd
+  (( fd >= 0 )) && _zrush_close_internal_fd $fd
+  _zrush_worker_ack_fd=-1
+}
+
+_zrush_worker_close_request() {
+  (( _zrush_worker_wfd >= 0 )) || return 0
+  _zrush_close_internal_fd $_zrush_worker_wfd
+  _zrush_worker_wfd=-1
+}
+
+_zrush_worker_close_control() {
+  (( _zrush_worker_control_wfd >= 0 )) || return 0
+  _zrush_close_internal_fd $_zrush_worker_control_wfd
+  _zrush_worker_control_wfd=-1
+}
+
+_zrush_worker_close_response() {
+  _zrush_worker_invalidate_callback data $_zrush_worker_rfd
   if (( _zrush_worker_rfd >= 0 )); then
-    zle -F $_zrush_worker_rfd 2>/dev/null
     _zrush_close_internal_fd $_zrush_worker_rfd
     _zrush_worker_rfd=-1
   fi
-  if (( _zrush_worker_wfd >= 0 )); then
-    _zrush_close_internal_fd $_zrush_worker_wfd
-    _zrush_worker_wfd=-1
-  fi
-  if (( _zrush_worker_pid > 1 )); then
-    _zrush_worker_terminate $_zrush_worker_pid
-  fi
-  _zrush_worker_pid=-1
-  _zrush_worker_ready=0
   _zrush_worker_rx=
+}
+
+_zrush_worker_begin_stop() {
+  emulate -L zsh
+  _zrush_worker_stopping=1
+  _zrush_worker_disarm_drain
+  _zrush_worker_txq=()
   _zrush_worker_pending=()
   _zrush_current_request=0
   _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
+}
+
+_zrush_worker_finalize() {
+  emulate -L zsh
+  (( _zrush_worker_ack_fd < 0 && _zrush_worker_rfd < 0 )) || return 1
+  _zrush_worker_disarm_drain
+  _zrush_worker_release_writer
+  _zrush_worker_close_request
+  _zrush_worker_close_control
+  _zrush_worker_ready=0
+  _zrush_worker_rx=
+  _zrush_worker_txq=()
+  _zrush_worker_pending=()
+  _zrush_current_request=0
+  _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
+  _zrush_worker_stopping=0
+  _zlog "worker: transport stopped"
   return 0
 }
 
-_zrush_worker_disable() {
+_zrush_worker_signal_abort() {
+  emulate -L zsh
+  setopt localoptions localtraps
+  (( _zrush_worker_control_wfd >= 0 )) || return 0
+  trap '' PIPE
+  syswrite -o $_zrush_worker_control_wfd -- x 2>/dev/null
+  return 0
+}
+
+_zrush_worker_stop_progress() {  # sync|async [absolute-deadline]
+  emulate -L zsh
+  local mode=${1:-async} deadline=${2:-}
+  local -i st
+  if (( _zrush_worker_ack_fd >= 0 )); then
+    if [[ $mode == sync ]]; then
+      _zrush_worker_poll_writer $deadline
+    else
+      _zrush_worker_poll_writer
+    fi
+    st=$?
+    if (( st == 0 || st == 2 )); then
+      _zlog "worker: stop writer slot released status=$st"
+      _zrush_worker_release_writer
+    fi
+  fi
+  if (( _zrush_worker_rfd >= 0 )); then
+    if [[ $mode == sync ]]; then
+      _zrush_worker_poll_eof $_zrush_worker_rfd $deadline
+    else
+      _zrush_worker_poll_eof $_zrush_worker_rfd '' 4
+    fi
+    st=$?
+    if (( st == 0 )); then
+      _zrush_worker_close_response
+    elif (( st == 2 )); then
+      _zlog "worker: stop response drain failed errno=$ERRNO"
+      _zrush_worker_invalidate_callback data $_zrush_worker_rfd
+    fi
+  fi
+  if (( _zrush_worker_ack_fd < 0 && _zrush_worker_rfd < 0 )); then
+    _zrush_worker_finalize
+    return $?
+  fi
+  return 1
+}
+
+_zrush_worker_abort() {  # [absolute-deadline]
+  emulate -L zsh
+  setopt localoptions no_bg_nice
+  (( _zrush_worker_stopping )) || _zrush_worker_begin_stop
+  _zrush_worker_signal_abort
+  _zrush_worker_close_control
+  _zrush_worker_close_request
+  local -F deadline=${1:-$(( EPOCHREALTIME + _ZRUSH_WORKER_SHUTDOWN_MS / 1000.0 ))}
+  while (( EPOCHREALTIME < deadline )); do
+    _zrush_worker_stop_progress sync $deadline && return 0
+    _zrush_worker_wait $deadline $_zrush_worker_ack_fd $_zrush_worker_rfd || break
+  done
+  _zrush_worker_stop_progress async && return 0
+  _zlog "worker: abort quarantined after absolute deadline=$deadline"
+  return 1
+}
+
+_zrush_worker_shutdown() {
+  emulate -L zsh
+  setopt localoptions no_bg_nice
+  if (( _zrush_worker_stopping )); then
+    _zrush_worker_stop_progress async
+    return $?
+  fi
+  _zrush_worker_begin_stop
+  local -F deadline=$(( EPOCHREALTIME + _ZRUSH_WORKER_SHUTDOWN_MS / 1000.0 ))
+  local -i st
+
+  while (( _zrush_worker_ack_fd >= 0 )); do
+    _zrush_worker_poll_writer $deadline; st=$?
+    if (( st == 0 )); then
+      _zrush_worker_release_writer
+      break
+    fi
+    if (( st == 2 || st == 3 )) ||
+       ! _zrush_worker_wait $deadline $_zrush_worker_ack_fd; then
+      _zlog "worker: healthy writer did not ack; aborting"
+      _zrush_worker_abort $deadline
+      return $?
+    fi
+  done
+
+  _zrush_worker_close_request
+  _zrush_worker_rx=
+  while (( _zrush_worker_rfd >= 0 )); do
+    _zrush_worker_poll_eof $_zrush_worker_rfd $deadline; st=$?
+    if (( st == 0 )); then
+      _zrush_worker_close_response
+      break
+    fi
+    if (( st == 2 || st == 3 )) ||
+       ! _zrush_worker_wait $deadline $_zrush_worker_rfd; then
+      _zlog "worker: healthy response drain failed or expired; aborting"
+      _zrush_worker_abort $deadline
+      return $?
+    fi
+  done
+  _zrush_worker_finalize
+}
+_zrush_worker_disable_policy() {
   emulate -L zsh
   _zlog "worker: disabling: $1"
   _zrush_worker_warn_once
-  _zrush_worker_transport_teardown disable
-  _zrush_teardown
   _zrush_disabled=1
   _zrush_enabled=0
 }
 
-_zrush_worker_session_fail() {
+_zrush_worker_fail_session() {
   emulate -L zsh
   local why=$1
   _zlog "worker: session failure: $why"
   _zrush_worker_warn_once
-  _zrush_worker_transport_teardown failure
+  _zrush_worker_abort
   _zrush_teardown
   (( ++_zrush_worker_failures ))
   if (( _zrush_worker_failures >= 2 )); then
@@ -987,140 +1228,133 @@ _zrush_worker_session_fail() {
   return 1
 }
 
+_zrush_worker_session_fail() {
+  (( !_zrush_worker_stopping )) || return 1
+  _zrush_worker_fail_session "$1"
+}
+
 _zrush_worker_start() {
   emulate -L zsh
-  setopt localoptions no_monitor no_notify no_bg_nice
-  (( !_zrush_disabled )) || return 1
-  (( _zrush_worker_pid > 1 )) && return 0
-  (( _zrush_worker_setup_fd >= 0 )) && return 0
+  setopt localoptions no_monitor no_notify no_bg_nice localtraps
+  (( !_zrush_disabled && !_zrush_worker_stopping && !_zrush_worker_runtime_tainted )) || return 1
+  (( _zrush_worker_rfd >= 0 )) && return 0
+  _zrush_worker_runtime_valid || {
+    _zrush_worker_session_fail "worker runtime unavailable"
+    return 1
+  }
 
-  local base=${TMPDIR:-/tmp}/zrush-worker-$$-$RANDOM
-  _zrush_worker_setup_req=$base.in
-  local fd
-  exec {fd}< <(
-    umask 077
-    if command mkfifo "$_zrush_worker_setup_req" 2>/dev/null; then
-      print -rn -- 1
-    else
-      print -rn -- 0
-    fi
+  local req_anchor= child_in= parent_w=
+  local resp_anchor= parent_r= child_out=
+  local ctl_anchor= child_ctl= parent_ctl= spawn_fd=
+  local -i fd endpoint_failed=0 spawn_ok=0 watcher_ok=0 spawn_st
+  if ! sysopen -rw -o cloexec -u req_anchor "$_zrush_worker_request_path" ||
+       ! sysopen -r -o cloexec -u child_in "$_zrush_worker_request_path" ||
+       ! sysopen -w -o cloexec -u parent_w "$_zrush_worker_request_path" ||
+       ! sysopen -rw -o cloexec -u resp_anchor "$_zrush_worker_response_path" ||
+       ! sysopen -r -o cloexec -u parent_r "$_zrush_worker_response_path" ||
+       ! sysopen -w -o cloexec -u child_out "$_zrush_worker_response_path" ||
+       ! sysopen -rw -o cloexec -u ctl_anchor "$_zrush_worker_control_path" ||
+       ! sysopen -r -u child_ctl "$_zrush_worker_control_path" ||
+       ! sysopen -w -o cloexec -u parent_ctl "$_zrush_worker_control_path"; then
+    endpoint_failed=1
+  fi
+  for fd in $req_anchor $child_in $parent_w $resp_anchor $parent_r \
+            $child_out $ctl_anchor $child_ctl $parent_ctl; do
+    (( fd > 2 )) || endpoint_failed=1
+  done
+
+  if (( endpoint_failed )); then
+    for fd in $req_anchor $child_in $parent_w $resp_anchor $parent_r \
+              $child_out $ctl_anchor $child_ctl $parent_ctl; do
+      [[ -n $fd ]] && (( fd > 2 )) && _zrush_close_internal_fd $fd
+    done
+    _zrush_worker_session_fail "worker endpoint acquisition failed"
+    return 1
+  fi
+
+  exec {spawn_fd}< <(
+    exec 0<&$child_in || exit 1
+    exec 1>&$child_out || exit 1
+    exec {child_in}>&- {child_out}>&-
+    exec {req_anchor}>&- {parent_w}>&-
+    exec {resp_anchor}>&- {parent_r}>&-
+    exec {ctl_anchor}>&- {parent_ctl}>&-
+    exec "$ZRUSH_BIN" worker --control-fd "$child_ctl" 2>>| "${ZRUSH_LOG:-/dev/null}"
   )
-  _zrush_worker_setup_fd=$fd
-  _zrush_worker_setup_pid=${sysparams[procsubstpid]:--1}
+  spawn_st=$?
+  (( spawn_st == 0 )) && [[ -n $spawn_fd ]] && (( spawn_fd > 2 )) && spawn_ok=1
+  for fd in $spawn_fd $req_anchor $child_in $resp_anchor $child_out $ctl_anchor $child_ctl; do
+    [[ -n $fd ]] && (( fd > 2 )) && _zrush_close_internal_fd $fd
+  done
+
+  if (( spawn_ok )) && _zrush_worker_register_callback data $parent_r; then
+    watcher_ok=1
+  fi
+  if (( !spawn_ok || !watcher_ok )); then
+    _zrush_worker_begin_stop
+    _zrush_worker_rfd=$parent_r
+    _zrush_worker_wfd=$parent_w
+    _zrush_worker_control_wfd=$parent_ctl
+    _zrush_worker_ready=0
+    _zrush_worker_rx=
+    if (( !watcher_ok )); then
+      if (( !spawn_ok )) && _zrush_worker_register_callback data $parent_r; then
+        watcher_ok=1
+        _zrush_kick
+      else
+        _zrush_worker_runtime_taint
+      fi
+    fi
+    _zrush_worker_fail_session "worker post-spawn publication failed"
+    return 1
+  fi
+
+  _zrush_worker_rfd=$parent_r
+  _zrush_worker_wfd=$parent_w
+  _zrush_worker_control_wfd=$parent_ctl
   _zrush_worker_ready=0
   _zrush_worker_rx=
   _zrush_encode_message hello "$_ZRUSH_EXPECTED_PROTO"
   _zrush_worker_txq=( "$REPLY" )
-  if ! zle -F -w $fd _zrush-worker-on-setup 2>/dev/null; then
-    _zrush_worker_session_fail "setup fd registration failed"
-    return 1
-  fi
   _zrush_kick
-  _zlog "worker: asynchronous pipe setup pid=$_zrush_worker_setup_pid fd=$fd"
-  return 0
-}
-
-_zrush_worker_finish_start() {
-  emulate -L zsh
-  setopt localoptions no_monitor no_notify no_bg_nice
-  local req=$_zrush_worker_setup_req
-  local req_anchor child_in
-  local -i failed=0
-  if ! sysopen -rw -o cloexec -u req_anchor "$req" ||
-     ! sysopen -r -o cloexec -u child_in "$req" ||
-     ! sysopen -w -o cloexec -u _zrush_worker_wfd "$req"; then
-    failed=1
-  else
-    # The substitution forks before sysopen runs, so record the pid whether or not
-    # sysopen succeeded: a failure here still has a worker to terminate.
-    sysopen -r -o cloexec -u _zrush_worker_rfd \
-      <( exec "$ZRUSH_BIN" worker <&$child_in 2>>| "${ZRUSH_LOG:-/dev/null}" ) || failed=1
-    _zrush_worker_pid=${sysparams[procsubstpid]:--1}
-  fi
-  if (( failed )); then
-    _zrush_worker_terminate $_zrush_worker_pid
-    _zrush_worker_pid=-1
-    _zrush_close_internal_fd ${req_anchor:--1}
-    _zrush_close_internal_fd ${child_in:--1}
-    _zrush_close_internal_fd $_zrush_worker_wfd
-    _zrush_close_internal_fd $_zrush_worker_rfd
-    _zrush_worker_wfd=-1 _zrush_worker_rfd=-1
-    return 1
-  fi
-
-  _zrush_close_internal_fd $req_anchor
-  _zrush_close_internal_fd $child_in
-  command rm -f "$req" >/dev/null 2>&1 &!
-  _zrush_worker_setup_req=
-  if ! zle -F -w $_zrush_worker_rfd _zrush-worker-on-data 2>/dev/null; then
-    _zrush_worker_session_fail "data fd registration failed"
-    return 1
-  fi
-  _zrush_kick
-  _zlog "worker: started pid=$_zrush_worker_pid rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd"
+  _zlog "worker: started rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd controlfd=$_zrush_worker_control_wfd"
   _zrush_worker_flush
 }
 
-_zrush_worker_consume_setup() {
-  emulate -L zsh
-  local signal= st
-  local -i setup_pid=$_zrush_worker_setup_pid
-  sysread -t 0 -i $_zrush_worker_setup_fd signal; st=$?
-  (( st == 0 )) || return 1
-  zle -F $_zrush_worker_setup_fd 2>/dev/null
-  _zrush_close_internal_fd $_zrush_worker_setup_fd
-  _zrush_worker_setup_fd=-1 _zrush_worker_setup_pid=-1
-  _zrush_worker_terminate $setup_pid
-  [[ $signal == 1 ]] || return 1
-  _zrush_worker_finish_start
-}
-
-_zrush_worker_on_setup() {
-  emulate -L zsh
-  (( $1 == _zrush_worker_setup_fd )) || return 0
-  _zrush_worker_consume_setup_checked
-  return 0
-}
-
-_zrush_worker_consume_setup_checked() {
-  emulate -L zsh
-  local -i failures_before=$_zrush_worker_failures
-  _zrush_worker_consume_setup && return 0
-  (( _zrush_worker_failures != failures_before || _zrush_disabled )) && return 1
-  _zrush_worker_session_fail "pipe setup failed"
-}
-
-# Hands the head frame to a short-lived writer child and returns to ZLE at
-# once; the interactive shell itself never writes to the request FIFO.
-# `--` keeps syswrite's option parser away from the frame's bytes, and the
-# child inherits the cloexec write fd because cloexec acts at exec, not fork.
 _zrush_worker_flush() {
   emulate -L zsh
   setopt localoptions no_monitor no_notify no_bg_nice
   local LC_ALL=C
+  (( !_zrush_worker_stopping )) || return 0
   (( $#_zrush_worker_txq )) || return 0
   (( _zrush_worker_ack_fd >= 0 )) && return 0
-  if (( _zrush_worker_wfd < 0 )); then
-    (( _zrush_worker_setup_fd >= 0 )) && return 0
-    return 1
-  fi
+  (( _zrush_worker_wfd >= 0 )) || return 1
   local frame=$_zrush_worker_txq[1] fd=
-  exec {fd}< <( syswrite -o $_zrush_worker_wfd -- "$frame" && print -rn -- 1 )
-  # An unset fd means no child exists; assigning it would leave the integer
-  # global at 0 and aim the watcher at the shell's own stdin.
-  if [[ -z $fd ]]; then
+  local -i spawn_st
+  exec {fd}< <(
+    { exec {_zrush_worker_rfd}>&- } 2>/dev/null
+    { exec {_zrush_worker_control_wfd}>&- } 2>/dev/null
+    (( _zrush_worker_drain_fd >= 0 )) && { exec {_zrush_worker_drain_fd}>&- } 2>/dev/null
+    syswrite -o $_zrush_worker_wfd -- "$frame" &&
+      exec {_zrush_worker_wfd}>&- &&
+      print -rn -- 1
+  )
+  spawn_st=$?
+  if (( spawn_st != 0 )) || [[ -z $fd ]] || (( fd <= 2 )); then
+    [[ -n $fd ]] && (( fd > 2 )) && _zrush_close_internal_fd $fd
+    _zrush_worker_runtime_taint
     _zrush_worker_session_fail "writer child spawn failed"
     return 1
   fi
   _zrush_worker_ack_fd=$fd
-  _zrush_worker_writer_pid=${sysparams[procsubstpid]:--1}
-  shift _zrush_worker_txq
-  if ! zle -F -w $fd _zrush-worker-on-ack 2>/dev/null; then
+  if ! _zrush_worker_register_callback ack $fd; then
+    _zrush_worker_runtime_taint
     _zrush_worker_session_fail "ack fd registration failed"
     return 1
   fi
+  shift _zrush_worker_txq
   _zrush_kick
-  _zlog "worker: sending frame writer_pid=$_zrush_worker_writer_pid ackfd=$fd bytes=${#frame} queued=$#_zrush_worker_txq"
+  _zlog "worker: sending frame ackfd=$fd bytes=${#frame} queued=$#_zrush_worker_txq"
   return 0
 }
 
@@ -1129,25 +1363,29 @@ _zrush_worker_flush() {
 # without one means the write failed.
 _zrush_worker_consume_ack() {
   emulate -L zsh
+  (( !_zrush_worker_stopping )) || return 0
   (( _zrush_worker_ack_fd >= 0 )) || return 0
-  local ack=
-  local -i st writer_pid=$_zrush_worker_writer_pid
-  sysread -t 0 -i $_zrush_worker_ack_fd ack; st=$?
-  (( st == 4 )) && return 0
-  _zrush_worker_release_writer
-  _zrush_worker_writer_pid=-1
-  if [[ $ack != 1 ]]; then
-    _zrush_worker_session_fail "frame write failed writer_pid=$writer_pid status=$st"
+  local -i st
+  _zrush_worker_poll_writer; st=$?
+  (( st == 1 )) && return 0
+  if (( st == 2 )); then
+    _zrush_worker_session_fail "frame write failed"
     return 1
   fi
-  _zlog "worker: frame sent writer_pid=$writer_pid queued=$#_zrush_worker_txq"
+  _zrush_worker_release_writer
+  _zlog "worker: frame sent queued=$#_zrush_worker_txq"
   _zrush_worker_flush
 }
 
 _zrush_worker_on_ack() {
   emulate -L zsh
-  (( $1 == _zrush_worker_ack_fd )) || return 0
-  _zrush_worker_consume_ack
+  local -i fd=$1 generation=${2:--1}
+  _zrush_worker_callback_current ack $fd $generation || return 0
+  if (( _zrush_worker_stopping )); then
+    _zrush_worker_stop_progress async
+  else
+    _zrush_worker_consume_ack
+  fi
   return 0
 }
 
@@ -1158,6 +1396,7 @@ _zrush_worker_deadline_expired() {
 _zrush_worker_handle_message() {  # message [absolute-deadline]
   emulate -L zsh
   setopt localoptions extendedglob
+  (( !_zrush_worker_stopping )) || return 0
   local message=$1 deadline=${2:-}
   if _zrush_worker_deadline_expired "$deadline"; then
     _zrush_worker_session_fail "history deadline exceeded request_id=$_zrush_sync_target"
@@ -1172,11 +1411,15 @@ _zrush_worker_handle_message() {  # message [absolute-deadline]
       _zlog "worker: handshake ready"
       return 0
     fi
-    if (( $#f == 2 )) && [[ $f[1] == incompatible ]]; then
-      _zrush_worker_disable "incompatible worker version ${(qqqq)f[2]}"
+    if (( $#f == 2 )) && [[ $f[1] == incompatible && $f[2] == [1-9][0-9]# ]]; then
+      _zrush_worker_disable_policy "incompatible worker version ${(qqqq)f[2]}"
+      _zrush_worker_shutdown
+      _zrush_teardown
       return 1
     fi
-    _zrush_worker_disable "invalid handshake response"
+    _zrush_worker_disable_policy "invalid handshake response"
+    _zrush_worker_abort
+    _zrush_teardown
     return 1
   fi
 
@@ -1243,11 +1486,25 @@ _zrush_worker_handle_message() {  # message [absolute-deadline]
 }
 
 _zrush_worker_arm_drain() {
+  (( !_zrush_worker_stopping )) || return 0
   (( _zrush_worker_drain_fd < 0 )) || return 0
-  local fd
-  exec {fd}< <( zselect -t 1; print )
+  local fd=
+  local -i open_st
+  exec {fd}< <(
+    { exec {_zrush_worker_rfd}>&- } 2>/dev/null
+    { exec {_zrush_worker_wfd}>&- } 2>/dev/null
+    { exec {_zrush_worker_control_wfd}>&- } 2>/dev/null
+    zselect -t 1
+    print
+  )
+  open_st=$?
+  if (( open_st != 0 )) || [[ -z $fd ]] || (( fd <= 2 )); then
+    [[ -n $fd ]] && (( fd > 2 )) && _zrush_close_internal_fd $fd
+    _zrush_worker_session_fail "read continuation fd allocation failed"
+    return 1
+  fi
   _zrush_worker_drain_fd=$fd
-  zle -F -w $fd _zrush-worker-on-drain 2>/dev/null || {
+  _zrush_worker_register_callback drain $fd || {
     _zrush_close_internal_fd $fd
     _zrush_worker_drain_fd=-1
     _zrush_worker_session_fail "read continuation fd registration failed"
@@ -1259,9 +1516,11 @@ _zrush_worker_arm_drain() {
 
 _zrush_worker_read() {  # async | sync [absolute-deadline]
   emulate -L zsh
+  (( !_zrush_worker_stopping )) || return 0
   local mode=${1:-async} deadline=${2:-} chunk= st
   local -i reads=0 bytes=0 frames=0 got=0
   while true; do
+    (( !_zrush_worker_stopping )) || return 0
     if [[ $mode == sync ]] && _zrush_worker_deadline_expired "$deadline"; then
       _zrush_worker_session_fail "history deadline exceeded request_id=$_zrush_sync_target"
       return 1
@@ -1298,6 +1557,7 @@ _zrush_worker_read() {  # async | sync [absolute-deadline]
     fi
     (( st == 4 )) && return 0
     if (( st == 5 )); then
+      _zrush_worker_close_response
       _zrush_worker_session_fail "unexpected stdout EOF"
     else
       _zrush_worker_session_fail "read error status=$st errno=$ERRNO"
@@ -1308,7 +1568,12 @@ _zrush_worker_read() {  # async | sync [absolute-deadline]
 
 _zrush_worker_on_data() {
   emulate -L zsh
-  (( $1 == _zrush_worker_rfd )) || return 0
+  local -i fd=$1 generation=${2:--1}
+  _zrush_worker_callback_current data $fd $generation || return 0
+  if (( _zrush_worker_stopping )); then
+    _zrush_worker_stop_progress async
+    return 0
+  fi
   # The ack is usually ready in the same wakeup as the response it precedes.
   # Consuming it before the plan is painted leaves the ack watcher's own
   # dispatch with nothing to do, because work running in a callback after a
@@ -1322,10 +1587,11 @@ _zrush_worker_on_data() {
 
 _zrush_worker_on_drain() {
   emulate -L zsh
-  local -i fd=$1
-  zle -F $fd 2>/dev/null
+  local -i fd=$1 generation=${2:--1}
+  _zrush_worker_callback_current drain $fd $generation || return 0
+  _zrush_worker_invalidate_callback drain $fd
   _zrush_close_internal_fd $fd
-  (( fd == _zrush_worker_drain_fd )) && _zrush_worker_drain_fd=-1
+  _zrush_worker_drain_fd=-1
   _zrush_worker_read async
   return 0
 }
@@ -1334,6 +1600,7 @@ _zrush_request_plan() {  # payload producer query trailing-space
   emulate -L zsh
   setopt localoptions typesetsilent no_monitor no_notify
   local payload=$1 producer=$2 query=$3 tspace=$4
+  (( !_zrush_worker_stopping && !_zrush_worker_runtime_tainted )) || return 1
 
   # cli-protocol.md "起動": rows = min(max-lines, LINES - 1), clamped to >= 1
   # unconditionally (not just when LINES > 1 -- LINES <= 1 must still clamp
@@ -1345,13 +1612,15 @@ _zrush_request_plan() {  # payload producer query trailing-space
   (( width < 1 )) && width=1
 
   (( _zrush_request_seq < 9223372036854775807 )) || {
-    _zrush_worker_disable "request_id exhausted"
+    _zrush_worker_disable_policy "request_id exhausted"
+    _zrush_worker_shutdown
+    _zrush_teardown
     return 1
   }
   local -i id=$(( ++_zrush_request_seq ))
   _zrush_current_request=$id
   _zrush_worker_pending[$id]=$producer
-  if (( _zrush_worker_pid <= 1 )); then
+  if (( _zrush_worker_rfd < 0 )); then
     local -i failures_before=$_zrush_worker_failures
     if ! _zrush_worker_start; then
       (( _zrush_worker_failures != failures_before )) || _zrush_worker_session_fail "startup failed"
@@ -1582,17 +1851,6 @@ _zrush_request_plan_sync() {
     fi
     cs=$(( remaining * 100 ))
     (( cs < 1 )) && cs=1
-    if (( _zrush_worker_setup_fd >= 0 )); then
-      local -i select_st
-      zselect -t $cs -r $_zrush_worker_setup_fd >/dev/null 2>&1; select_st=$?
-      if (( EPOCHREALTIME >= deadline )); then
-        _zrush_worker_session_fail "history deadline exceeded request_id=$target"
-        return 1
-      fi
-      (( select_st == 0 )) || continue
-      _zrush_worker_consume_setup_checked || return 1
-      continue
-    fi
     if (( _zrush_worker_ack_fd >= 0 )); then
       zselect -t $cs -r $_zrush_worker_rfd -r $_zrush_worker_ack_fd >/dev/null 2>&1
     else
@@ -1728,7 +1986,6 @@ _zrush_line_pre_redraw() {
 
 _zrush_line_init() {
   emulate -L zsh
-  _zrush_kick_init
   _zrush_last_buffer=
   _zrush_last_cursor=-1
   # A new ZLE session can follow an exit that bypassed _zrush_line_finish
@@ -2121,8 +2378,13 @@ _zrush_apply_keybinds() {
 # ---------------------------------------------------------------- Exit cleanup
 _zrush_zshexit() {
   emulate -L zsh
-  # ZLE is inactive here; leave it untouched and reliably close only fds and zpty.
-  _zrush_worker_transport_teardown exit
+  # ZLE is inactive here; readiness cleanup cannot be relied upon after this hook.
+  _zrush_worker_shutdown
+  _zrush_worker_release_writer
+  _zrush_worker_close_response
+  _zrush_worker_close_request
+  _zrush_worker_close_control
+  _zrush_worker_runtime_destroy
   (( _zrush_timer_fd >= 0 )) && { _zrush_close_internal_fd $_zrush_timer_fd; _zrush_timer_fd=-1 }
   if (( _zrush_rfd >= 0 )); then _zrush_close_internal_fd $_zrush_rfd; _zrush_rfd=-1; fi
   if (( _zrush_wfd >= 0 )); then _zrush_close_internal_fd $_zrush_wfd; _zrush_wfd=-1; fi
@@ -2167,6 +2429,12 @@ _zrush_init() {
   fi
   (( _zrush_disabled )) && return 1
 
+  _zrush_worker_runtime_prepare || {
+    _zrush_warn "worker runtime FIFO setup failed; zrush disabled"
+    _zrush_disabled=1 _zrush_enabled=0
+    return 1
+  }
+
   # Detect compinit via _main_complete, including setups delegated to zsh-autocomplete.
   if (( ! $+functions[_main_complete] )); then
     _zrush_warn "compsys not initialized (run compinit before sourcing zrush.zsh); completions will be empty"
@@ -2174,12 +2442,9 @@ _zrush_init() {
 
   # Register widgets; _zrush-capture-* are invoked only inside the fork.
   zle -N _zrush-kick-drain _zrush_kick_drain
+  _zrush_kick_init
   zle -N _zrush-on-data _zrush_on_data
   zle -N _zrush-timer-fire _zrush_timer_fire
-  zle -N _zrush-worker-on-data _zrush_worker_on_data
-  zle -N _zrush-worker-on-ack _zrush_worker_on_ack
-  zle -N _zrush-worker-on-drain _zrush_worker_on_drain
-  zle -N _zrush-worker-on-setup _zrush_worker_on_setup
   zle -N _zrush-capture-entry _zrush_capture_entry
   zle -C _zrush-capture-comp list-choices _zrush_capture_complete
   zle -N _zrush-line-pre-redraw _zrush_line_pre_redraw


### PR DESCRIPTION
Issue #32 の残作業として、正常な worker shutdown と異常時の abort を分離します。従来の数値 PID を zsh から signal する方式では PID 再利用を構造的に排除できないため、PID-free の control channel へ置き換えました。

## Summary

- source generation ごとに private な request / response / abort-control FIFO を作成
- Rust worker に `--control-fd` と watchdog thread を追加し、abort byte / EOF で即時終了
- 正常停止は frame ack → request EOF → response raw drain → EOF の順で完了
- 異常停止は control byteを送り、response EOFまで replacementをquarantine
- spawn後のpublication失敗をfail-closedにし、tainted runtimeを再利用しない
- stale ZLE callbackをgenerationで無効化
- worker protocolを7へ更新
- 数値PID、lifetime pipe、TERM/KILL state machineを削除

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`
- `zsh tests/zsh/transport.zsh` — 16/16
- `zsh tests/zsh/vectors.zsh` — 74/74
- `tests/zsh/driver.zsh` — 154/154
- `tests/docker/run.sh 5.8.1`
- `tests/docker/run.sh 5.9`

`tests/zsh/driver-coexist.zsh` はローカル環境にoptional依存がないため、所定のdependency SKIPを確認しました。

Closes #32