### PR TITLE
test(vectors): silence the stray REPLY line printed by a top-level local

### DIFF
--- a/tests/zsh/vectors.zsh
+++ b/tests/zsh/vectors.zsh
@@ -32,7 +32,7 @@
 # Unlike driver.zsh (a zle/compsys end-to-end smoke test over zpty), nothing
 # here touches zle, so a failure points at the encoder or decoder itself.
 emulate -L zsh
-setopt extended_glob
+setopt extended_glob typeset_silent
 
 typeset -g HERE=${${(%):-%N}:A:h}
 typeset -g REPO=${HERE:h:h}


### PR DESCRIPTION
`tests/zsh/vectors.zsh` currently prints a stray `REPLY=''` line because a top-level `local` redeclares an already-set parameter. Enable `TYPESET_SILENT` in the vector runner so its output remains limited to reporter lines, including for future top-level declarations of the same kind.

Closes #91

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`
- `zsh -f tests/zsh/vectors.zsh`
- `zsh -f tests/zsh/driver.zsh <isolated-playground>` (154 passed)
- `zsh -f tests/zsh/transport.zsh` (17 passed)
- `zsh -f tests/zsh/driver-coexist.zsh <isolated-playground>` (skipped: optional dependencies unavailable)