### PR TITLE
fix(zle): release the previous dispatch widget when a keybinding moves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: cargo test
       - name: zle driver
         run: zsh -f tests/zsh/driver.zsh "$(mktemp -d)"
+      - name: zsh keybind ownership
+        run: zsh -f tests/zsh/keybinds.zsh
       - name: zsh plan-decoder vectors
         run: zsh -f tests/zsh/vectors.zsh
       - name: zsh worker transport

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ cargo test
 ```
 
 For changes touching `zsh/`, the zle-integration drivers `tests/zsh/driver.zsh` and `tests/zsh/driver-coexist.zsh` must also pass — run them locally.
-CI runs the headless `driver.zsh`, `tests/zsh/vectors.zsh` (capture-encoder and plan-decoder golden vectors), and `tests/zsh/transport.zsh` (worker transport write path); `driver-coexist.zsh` remains local-only.
+CI runs the headless `driver.zsh`, `tests/zsh/keybinds.zsh` (dispatch-widget ownership), `tests/zsh/vectors.zsh` (capture-encoder and plan-decoder golden vectors), and `tests/zsh/transport.zsh` (worker transport write path); `driver-coexist.zsh` remains local-only.
 CI's Linux jobs run the whole suite in a container whose zsh is built from source, as a matrix over the supported versions; the same run reproduces locally (needs Docker) with
 
 ```sh

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -407,6 +407,10 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 
 - キーのフォールバックは前任者チェーン(builtin 直呼びはしない)。
   config リロードでの再適用時に自分自身を前任者として捕まえない。
+- config リロードまたは re-source で不要になった dispatch layer は、キーと widget の両方を
+  zrush が直接所有している場合に限り、キーを前任者へ戻して function/widget 登録を解放する。
+  第三者の binding または wrapper が上にある layer は上書きも解放もせず、非 active な
+  dispatcher として前任者へ委譲させ、第三者を含む既存チェーンを維持する。
 - `zle-line-pre-redraw` は `add-zle-hook-widget` で登録する。
 - fork 内で候補を収集するときは、他プラグイン(zsh-autosuggestions など)が定義した
   compadd ラッパーを除去してから compsys を呼ぶ。この変更は fork 内に限られ、

--- a/tests/docker/run.sh
+++ b/tests/docker/run.sh
@@ -6,7 +6,7 @@
 #
 # Builds tests/docker/Dockerfile (cached by the Docker daemon) and runs
 # tests/docker/suite.zsh inside it: cargo build/test plus the headless zsh
-# suites (driver.zsh, vectors.zsh, transport.zsh). CI's Linux matrix calls
+# suites (driver.zsh, keybinds.zsh, vectors.zsh, transport.zsh). CI's Linux matrix calls
 # exactly this script, so a CI failure reproduces locally with one command.
 #
 # bash, not zsh: this is the one script that must run on hosts whose zsh is

--- a/tests/docker/suite.zsh
+++ b/tests/docker/suite.zsh
@@ -8,5 +8,6 @@ print -r -- "== $(zsh --version) =="
 cargo build --release
 cargo test
 zsh -f tests/zsh/driver.zsh "$(mktemp -d)"
+zsh -f tests/zsh/keybinds.zsh
 zsh -f tests/zsh/vectors.zsh
 zsh -f tests/zsh/transport.zsh

--- a/tests/zsh/keybinds.zsh
+++ b/tests/zsh/keybinds.zsh
@@ -1,0 +1,165 @@
+#!/bin/zsh -f
+# Headless regression tests for dispatch-widget ownership across config reload
+# and re-source. No worker, pty, interactive ZLE session, or real config is used.
+emulate -L zsh
+setopt extendedglob typesetsilent
+
+typeset -g HERE=${${(%):-%N}:A:h}
+typeset -g REPO=${HERE:h:h}
+typeset -gi PASS=0 FAIL=0
+typeset -ga WHY=()
+
+out() { print -r -u2 -- "$@" }
+ok() { out "PASS: $1"; (( ++PASS )) }
+ng() { out "FAIL: $1"; (( ++FAIL )) }
+eq() { [[ $2 == "$3" ]] || WHY+=( "$1: got ${(qqq)2}, want ${(qqq)3}" ) }
+note() { WHY+=( "$1" ) }
+verdict() {
+  if (( $#WHY == 0 )); then
+    ok "$1"
+  else
+    ng "$1"
+    local why
+    for why in "${(@)WHY}"; do out "      - $why"; done
+  fi
+  WHY=()
+}
+
+typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-keybinds.XXXXXX)
+export HOME=$WORK/home XDG_CONFIG_HOME=$WORK/xdg HISTFILE=$WORK/history
+mkdir -p $HOME $XDG_CONFIG_HOME
+unset ZDOTDIR
+TRAPEXIT() { command rm -rf -- $WORK }
+
+typeset -g ZRUSH_NO_INIT=1
+source $REPO/zsh/zrush.zsh || { out "FATAL: cannot source zrush.zsh"; exit 1 }
+
+typeset -ga DSP_FUNCTIONS=() DSP_WIDGETS=()
+dispatch_snapshot() {
+  DSP_FUNCTIONS=( ${(M)${(k)functions}:#_zrush-dsp-*} )
+  DSP_WIDGETS=( ${(M)${(k)widgets}:#_zrush-dsp-*} )
+}
+
+bound_for() {  # $1=key sequence in bindkey notation -> REPLY=dispatcher
+  emulate -L zsh
+  local target=$1 k v
+  typeset -g REPLY=
+  for k v in "${(@kv)_zrush_bound}"; do
+    if [[ $k == $target ]]; then
+      REPLY=$v
+      return 0
+    fi
+  done
+  return 1
+}
+
+key_widget() {  # $1=key sequence in bindkey notation -> REPLY=current widget
+  typeset -g REPLY=${${(z)"$(builtin bindkey -M main -- "$1" 2>/dev/null)"}[2]:-}
+}
+
+# Moving one action repeatedly must release every direct-owned superseded
+# dispatcher. Tab remains the second active/bound dispatcher throughout.
+typeset -ga ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^A' )
+_zrush_apply_keybinds
+bound_for '^X^A' || note "initial ^X^A binding missing"
+typeset -g FIRST_DISPATCH=$REPLY
+key_widget '^X^B'
+typeset -g B_PREDECESSOR=$REPLY
+integer i
+for (( i = 0; i < 100; ++i )); do
+  ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^B' ); _zrush_apply_keybinds
+  ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^A' ); _zrush_apply_keybinds
+done
+dispatch_snapshot
+eq "move function count" $#DSP_FUNCTIONS 2
+eq "move widget count" $#DSP_WIDGETS 2
+eq "move binding count" $#_zrush_bound 2
+eq "move active count" $#_zrush_active_dsp 2
+eq "move predecessor-ledger count" $#_zrush_dsp_prev 2
+(( !$+functions[$FIRST_DISPATCH] )) || note "first moved function remains"
+(( !$+widgets[$FIRST_DISPATCH] )) || note "first moved widget remains"
+key_widget '^X^B'; eq "removed key restored" $REPLY $B_PREDECESSOR
+verdict "moving a key releases superseded dispatch registrations"
+
+# Reapplying the same sequence, including changing only its action, must keep
+# the same dispatcher rather than release and recreate it.
+bound_for '^X^A' || note "stable ^X^A binding missing"
+typeset -g STABLE_DISPATCH=$REPLY
+for (( i = 0; i < 100; ++i )); do
+  ZRUSH_CFG_KEYBINDS=( dismiss 'seq:^X^A' ); _zrush_apply_keybinds
+  ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^A' ); _zrush_apply_keybinds
+done
+bound_for '^X^A' || note "post-reapply ^X^A binding missing"
+eq "same-sequence dispatcher" $REPLY $STABLE_DISPATCH
+dispatch_snapshot
+eq "same-sequence function count" $#DSP_FUNCTIONS 2
+eq "same-sequence widget count" $#DSP_WIDGETS 2
+verdict "an unchanged sequence retains its dispatch registration"
+
+# A successful re-source restores direct-owned keys before rebuilding. The
+# serial remains monotonic, but only the new generation's registrations live.
+for (( i = 0; i < 20; ++i )); do
+  source $REPO/zsh/zrush.zsh || note "re-source $i failed"
+  ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^A' )
+  _zrush_apply_keybinds
+done
+dispatch_snapshot
+eq "re-source function count" $#DSP_FUNCTIONS 2
+eq "re-source widget count" $#DSP_WIDGETS 2
+eq "re-source binding count" $#_zrush_bound 2
+eq "re-source active count" $#_zrush_active_dsp 2
+eq "re-source predecessor-ledger count" $#_zrush_dsp_prev 2
+verdict "re-source releases the previous direct-owned generation"
+
+# Model zsh-syntax-highlighting's in-place wrapper: it moves the original
+# function behind a backup widget, then replaces our widget name with its own
+# function. This old layer is live predecessor state and must be retained.
+bound_for '^X^A' || note "pre-wrapper ^X^A binding missing"
+typeset -g WRAPPED_DISPATCH=$REPLY
+typeset -g BACKUP_WIDGET=_zrt-orig-$WRAPPED_DISPATCH
+typeset -g WRAPPER_FUNCTION=_zrt-wrap-$WRAPPED_DISPATCH
+zle -N $BACKUP_WIDGET $WRAPPED_DISPATCH
+functions[$WRAPPER_FUNCTION]="zle ${(q)BACKUP_WIDGET} -w"
+zle -N $WRAPPED_DISPATCH $WRAPPER_FUNCTION
+_zrush_apply_keybinds
+bound_for '^X^A' || note "wrapped reapply ^X^A binding missing"
+typeset -g LAYERED_DISPATCH=$REPLY
+[[ $LAYERED_DISPATCH != $WRAPPED_DISPATCH ]] || note "wrapper did not force a new layer"
+eq "layered predecessor" ${_zrush_dsp_prev[$LAYERED_DISPATCH]:-} $WRAPPED_DISPATCH
+(( $+functions[$WRAPPED_DISPATCH] )) || note "wrapped predecessor function removed"
+[[ ${widgets[$WRAPPED_DISPATCH]:-} == user:$WRAPPER_FUNCTION ]] ||
+  note "third-party wrapper widget replaced"
+
+# Removing the action releases only the direct outer layer and restores the
+# wrapped predecessor. Repeated re-source then stays bounded at that retained
+# layer plus the two current dispatchers (the action and fixed Tab hook).
+ZRUSH_CFG_KEYBINDS=()
+_zrush_apply_keybinds
+key_widget '^X^A'; eq "wrapped predecessor restored" $REPLY $WRAPPED_DISPATCH
+(( !$+functions[$LAYERED_DISPATCH] )) || note "outer layered function remains"
+(( !$+widgets[$LAYERED_DISPATCH] )) || note "outer layered widget remains"
+(( $+functions[$WRAPPED_DISPATCH] )) || note "wrapped function removed with outer layer"
+[[ ${widgets[$WRAPPED_DISPATCH]:-} == user:$WRAPPER_FUNCTION ]] ||
+  note "wrapped widget removed with outer layer"
+
+ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^A' )
+_zrush_apply_keybinds
+for (( i = 0; i < 20; ++i )); do
+  source $REPO/zsh/zrush.zsh || note "wrapped re-source $i failed"
+  ZRUSH_CFG_KEYBINDS=( confirm 'seq:^X^A' )
+  _zrush_apply_keybinds
+done
+bound_for '^X^A' || note "post-wrapper-resource ^X^A binding missing"
+typeset -g CURRENT_DISPATCH=$REPLY
+eq "post-re-source wrapped predecessor" ${_zrush_dsp_prev[$CURRENT_DISPATCH]:-} $WRAPPED_DISPATCH
+dispatch_snapshot
+eq "wrapped re-source function count" $#DSP_FUNCTIONS 3
+eq "wrapped re-source widget count" $#DSP_WIDGETS 3
+eq "wrapped re-source active count" $#_zrush_active_dsp 2
+(( $+functions[$WRAPPED_DISPATCH] )) || note "wrapped predecessor function lost"
+[[ ${widgets[$WRAPPED_DISPATCH]:-} == user:$WRAPPER_FUNCTION ]] ||
+  note "wrapped predecessor widget lost"
+verdict "third-party wrapper layers are retained without unbounded growth"
+
+out "keybinds: $PASS passed, $FAIL failed"
+(( FAIL == 0 ))

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -38,7 +38,11 @@ if (( ${_zrush_installed:-0} || ${_zrush_worker_stopping:-0} ||
       # Do not overwrite a third-party binding installed above zrush.
       if [[ $cur == $w && ${widgets[$w]:-} == user:$w ]]; then
         prev=${_zrush_dsp_prev[$w]:-}
-        builtin bindkey -M main -- "$seq" ${prev:-undefined-key}
+        if builtin bindkey -M main -- "$seq" ${prev:-undefined-key}; then
+          zle -D $w 2>/dev/null
+          unfunction -- $w 2>/dev/null
+          unset "_zrush_dsp_prev[$w]"
+        fi
       fi
     done
     (( $+functions[add-zle-hook-widget] )) && {
@@ -2280,6 +2284,16 @@ _zrush_dispatch() {  # $1=action $2=predecessor $3=dispatcher name
 }
 
 # ---------------------------------------------------------------- Apply key bindings
+# behavior.md "プラグイン共存": caller has restored a directly owned layer.
+_zrush_release_dispatch() {  # $1=unbound dispatch widget name
+  emulate -L zsh
+  local w=$1
+  zle -D $w 2>/dev/null
+  unfunction -- $w 2>/dev/null
+  unset "_zrush_dsp_prev[$w]"
+  return 0
+}
+
 # Resolve key:<name> into bindable sequences using terminfo plus both CSI/SS3 arrows.
 _zrush_key_seqs() {  # $1=key:<name> -> reply=(sequences...)
   emulate -L zsh
@@ -2363,8 +2377,10 @@ _zrush_apply_keybinds() {
       local cur=${${(z)"$(builtin bindkey -M main -- "$seq" 2>/dev/null)"}[2]:-}
       if [[ $cur == $w && ${widgets[$w]:-} == user:$w ]]; then
         p=${_zrush_dsp_prev[$w]:-}
-        builtin bindkey -M main -- "$seq" ${p:-undefined-key}
-        _zlog "keybinds: restored ${(qqqq)seq} -> ${p:-undefined-key}"
+        if builtin bindkey -M main -- "$seq" ${p:-undefined-key}; then
+          _zrush_release_dispatch $w
+          _zlog "keybinds: restored ${(qqqq)seq} -> ${p:-undefined-key}; released $w"
+        fi
       fi
     fi
   done


### PR DESCRIPTION
## Summary

- release directly owned dispatch widgets and functions after restoring their predecessor during config reload or re-source
- preserve third-party wrapper layers so predecessor chains remain intact
- specify dispatch-layer ownership and add a headless keybind lifecycle suite to macOS/Linux CI

Closes #43

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`
- `zsh -f tests/zsh/driver.zsh <isolated-playground>`
- `zsh -f tests/zsh/keybinds.zsh`
- `zsh -f tests/zsh/vectors.zsh`
- `zsh -f tests/zsh/transport.zsh`

`tests/zsh/driver-coexist.zsh` exited successfully via its dependency-missing skip path on Linux. The new headless suite models the zsh-syntax-highlighting wrapper structure directly; the bounded-table behavior was also checked against the installed Linux zsh-syntax-highlighting.