### PR TITLE
refactor(wire): consolidate render-plan wire knowledge into one module

### DIFF
--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -16,7 +16,7 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 ## プロトコル版
 
-> 検証: 版番号のコピーの一致 — `src/config.rs` のテスト `protocol_version_matches_docs_and_zsh`。
+> 検証: 版番号のコピーの一致 — `src/wire.rs` のテスト `protocol_version_matches_docs_and_zsh`。
 
 - **PROTOCOL_VERSION = 7**
 - `zrush config` の出力に `ZRUSH_PROTOCOL_VERSION` が含まれる。
@@ -34,10 +34,10 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 ### 版番号を上げる手順
 
-1. `src/config.rs` の `PROTOCOL_VERSION` を上げる。
+1. `src/wire.rs` の `PROTOCOL_VERSION` を上げる。
 2. `cargo test --no-fail-fast` を実行する。追従が必要な残りの箇所は、落ちたテストがすべて指す
    (`--no-fail-fast` を付けないと最初に落ちたテストターゲットで止まり、`tests/cli.rs` の分は次の実行まで出てこない):
-   - `protocol_version_matches_docs_and_zsh`(`src/config.rs`)が、この文書の 2 行
+   - `protocol_version_matches_docs_and_zsh`(`src/wire.rs`)が、この文書の 2 行
      (この節の `- **PROTOCOL_VERSION = N**` と「zrush config」節の出力例の
      `typeset -g  ZRUSH_PROTOCOL_VERSION='N'`)と `zsh/zrush.zsh` の
      `typeset -gi _ZRUSH_EXPECTED_PROTO=N` のうち、追従できていないものを列挙する。

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,9 +9,7 @@ use std::path::PathBuf;
 
 use crate::keybind;
 use crate::matching::Mode;
-
-/// Protocol version emitted as ZRUSH_PROTOCOL_VERSION (cli-protocol.md).
-pub const PROTOCOL_VERSION: &str = "7";
+use crate::wire::PROTOCOL_VERSION;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabBehavior {
@@ -700,9 +698,8 @@ mod tests {
         assert!(out.contains("ty'\\''po"), "{out}");
     }
 
-    // Reads a repo file by path relative to the crate root, for tests that
-    // read the contract doc or cross-check hand-written copies of
-    // PROTOCOL_VERSION elsewhere in the repo.
+    // Reads a repo file by path relative to the crate root for tests that
+    // read the contract doc.
     fn read_repo_file(relative_path: &str) -> String {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
         std::fs::read_to_string(&path)
@@ -710,49 +707,6 @@ mod tests {
     }
 
     const CONTRACT: &str = "docs/internal/contracts/cli-protocol.md";
-
-    /// PROTOCOL_VERSION is hand-written in four places: this const, two
-    /// lines in the cli-protocol.md contract doc, and zsh/zrush.zsh. This
-    /// cross-checks the other three against this const so a bump here can't
-    /// silently drift from docs or the zsh side. (The remaining copy, in
-    /// tests/cli.rs's golden, is covered by the test that owns it.)
-    #[test]
-    fn protocol_version_matches_docs_and_zsh() {
-        let expected: [(&str, String); 3] = [
-            (
-                CONTRACT,
-                format!("- **PROTOCOL_VERSION = {PROTOCOL_VERSION}**"),
-            ),
-            (
-                CONTRACT,
-                format!("typeset -g  ZRUSH_PROTOCOL_VERSION='{PROTOCOL_VERSION}'"),
-            ),
-            (
-                "zsh/zrush.zsh",
-                format!("typeset -gi _ZRUSH_EXPECTED_PROTO={PROTOCOL_VERSION}"),
-            ),
-        ];
-
-        let mismatches: Vec<String> = expected
-            .iter()
-            .filter(|(relative_path, expected_line)| {
-                !read_repo_file(relative_path)
-                    .lines()
-                    .any(|line| line.trim() == expected_line)
-            })
-            .map(|(relative_path, expected_line)| {
-                format!("{relative_path}: expected a line \"{expected_line}\"")
-            })
-            .collect();
-
-        assert!(
-            mismatches.is_empty(),
-            "PROTOCOL_VERSION mismatch: src/config.rs::PROTOCOL_VERSION is \
-             {PROTOCOL_VERSION:?}, but the following locations disagree (or are \
-             missing the anchor line) and need to be updated to match:\n{}",
-            mismatches.join("\n")
-        );
-    }
 
     /// The default `zrush config` output as the contract specifies it: the
     /// fenced zsh block that opens the "stdout" section of "zrush config".

--- a/src/framing.rs
+++ b/src/framing.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use crate::wire::{Decimal, DecimalError};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Error {
     MissingLength,
@@ -54,26 +56,15 @@ impl std::error::Error for FeedError {
 
 #[derive(Debug)]
 enum State {
-    Length {
-        value: usize,
-        digits: usize,
-        leading_zero: bool,
-    },
-    Payload {
-        remaining: usize,
-        bytes: Vec<u8>,
-    },
+    Length(Decimal),
+    Payload { remaining: usize, bytes: Vec<u8> },
     Comma(Vec<u8>),
     Failed,
 }
 
 impl State {
     fn length() -> Self {
-        Self::Length {
-            value: 0,
-            digits: 0,
-            leading_zero: false,
-        }
+        Self::Length(Decimal::default())
     }
 }
 
@@ -111,21 +102,23 @@ impl Decoder {
         while offset < input.len() {
             let state = std::mem::replace(&mut self.state, State::Failed);
             match state {
-                State::Length {
-                    value,
-                    digits,
-                    leading_zero,
-                } => {
+                State::Length(mut decimal) => {
                     let byte = input[offset];
                     offset += 1;
 
                     if byte == b':' {
-                        if digits == 0 {
+                        if decimal.is_empty() {
                             return Err(FeedError {
                                 completed,
                                 error: Error::MissingLength,
                             });
                         }
+                        let Ok(value) = usize::try_from(decimal.value()) else {
+                            return Err(FeedError {
+                                completed,
+                                error: Error::LengthOverflow,
+                            });
+                        };
                         self.state = if value == 0 {
                             State::Comma(Vec::new())
                         } else {
@@ -135,27 +128,25 @@ impl Decoder {
                             }
                         };
                     } else if byte.is_ascii_digit() {
-                        if leading_zero {
+                        if let Err(error) = decimal.push_canonical(byte) {
                             return Err(FeedError {
                                 completed,
-                                error: Error::LeadingZero,
+                                error: match error {
+                                    DecimalError::LeadingZero => Error::LeadingZero,
+                                    DecimalError::Overflow => Error::LengthOverflow,
+                                    DecimalError::InvalidDigit => unreachable!(
+                                        "ASCII digit was checked before decimal accumulation"
+                                    ),
+                                },
                             });
                         }
-                        let digit = usize::from(byte - b'0');
-                        let Some(value) = value
-                            .checked_mul(10)
-                            .and_then(|value| value.checked_add(digit))
-                        else {
+                        if usize::try_from(decimal.value()).is_err() {
                             return Err(FeedError {
                                 completed,
                                 error: Error::LengthOverflow,
                             });
-                        };
-                        self.state = State::Length {
-                            value,
-                            digits: digits + 1,
-                            leading_zero: digits == 0 && byte == b'0',
-                        };
+                        }
+                        self.state = State::Length(decimal);
                     } else {
                         return Err(FeedError {
                             completed,
@@ -208,7 +199,7 @@ impl Decoder {
     /// a truncated length, payload, or trailing comma.
     pub(crate) fn finish(&mut self) -> Result<(), Error> {
         match self.state {
-            State::Length { digits: 0, .. } => Ok(()),
+            State::Length(decimal) if decimal.is_empty() => Ok(()),
             State::Failed => Err(Error::DecoderFailed),
             _ => {
                 self.state = State::Failed;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -25,6 +25,7 @@ use unicode_width::UnicodeWidthChar;
 
 use crate::record::{Batch, Candidate};
 use crate::span::CharSpan;
+use crate::wire::{Navigation as Nav, Role};
 
 /// Column cap and gutter width: Rust-internal constants, not part of the
 /// protocol (cli-protocol.md "列数").
@@ -51,44 +52,14 @@ impl Style {
     }
 }
 
-/// Highlight role (cli-protocol.md "ハイライト"). `heading` entries carry
-/// `pos == 0`; `match` and `history-number` entries carry their position.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Role {
-    Match,
-    Heading,
-    HistoryNumber,
-}
-
-impl Role {
-    /// The render-plan wire token (cli-protocol.md "ハイライト").
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Role::Match => "match",
-            Role::Heading => "heading",
-            Role::HistoryNumber => "history-number",
-        }
-    }
-}
-
-/// One "role pos start len" render-plan entry. `span` is a char range
-/// over the full listing text (rows joined by `\n`, no leading newline);
-/// plan.rs's serializer turns it into the wire's `start len`.
+/// A computed highlight whose `span` is a char range over the full listing
+/// text (rows joined by `\n`, no leading newline). The wire boundary converts
+/// this end-exclusive range to its serialized form.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Highlight {
     pub role: Role,
     pub pos: usize,
     pub span: CharSpan,
-}
-
-/// One "next prev left right" render-plan entry, absolute position numbers
-/// (0 = unselected). cli-protocol.md "ナビ".
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(crate) struct Nav {
-    pub next: usize,
-    pub prev: usize,
-    pub left: usize,
-    pub right: usize,
 }
 
 /// The rendered plan: display rows plus, for each of the `P` selectable

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,5 +1,4 @@
-//! Orchestration for worker plan requests (cli-protocol.md "`zrush worker`",
-//! source of truth for the whole pipeline and render-plan wire format).
+//! Orchestration for worker plan requests (cli-protocol.md "`zrush worker`").
 //!
 //! Pipeline: record::parse -> hidden-file exclusion -> matching::QueryMatcher
 //! (score every remaining candidate + common-prefix over the *untruncated*
@@ -12,18 +11,16 @@
 //! grouping/highlights/nav, further truncated to the real per-group row
 //! budget) -> insert::build per displayed position
 //! (this is where `-f` directory-synthesis stat happens, and only for
-//! positions layout actually kept) -> flat NUL-terminated serialization.
+//! positions layout actually kept) -> wire::serialize.
 //!
 //! `run` takes one complete candidate payload and an injected
 //! `is_dir` predicate, so it stays free of I/O and is directly testable.
 //! The only error this pipeline itself can produce is candidate framing
 //! violation (record.rs); session I/O belongs to worker.rs.
 
-use std::io::Write;
-
 use crate::matching::{Mode, QueryMatcher, Tier};
 use crate::span::CharSpan;
-use crate::{insert, layout, ranking, record};
+use crate::{insert, layout, ranking, record, wire};
 
 /// Snapshot of a plan request's scalar fields; producer selects result
 /// ordering and layout geometry.
@@ -138,61 +135,12 @@ pub(crate) fn run(
         })
         .collect();
 
-    Ok(serialize(common_prefix, &built, &insert_texts))
-}
-
-/// Flatten the plan into the render-plan wire format: NUL-terminated fields,
-/// fixed order, total count
-/// `4 + L + H + 3P`. A plan with `L == P == H == 0` (nothing matched)
-/// naturally serializes to exactly the "0 マッチ" 4-field form.
-fn serialize(common_prefix: &[u8], plan: &layout::Plan, insert_texts: &[Vec<u8>]) -> Vec<u8> {
-    let mut out = Vec::new();
-    push_bytes(&mut out, common_prefix);
-    let _ = write!(out, "{}", plan.rows.len());
-    out.push(0);
-    let _ = write!(out, "{}", plan.positions.len());
-    out.push(0);
-    for row in &plan.rows {
-        push_bytes(&mut out, row);
-    }
-    let _ = write!(out, "{}", plan.highlights.len());
-    out.push(0);
-    // The end-exclusive spans become the wire's `start len` here, and
-    // only here (span.rs).
-    for h in &plan.highlights {
-        let _ = write!(
-            out,
-            "{} {} {} {}",
-            h.role.as_str(),
-            h.pos,
-            h.span.start,
-            h.span.len()
-        );
-        out.push(0);
-    }
-    for cell in &plan.cell_ranges {
-        let _ = write!(out, "{} {}", cell.start, cell.len());
-        out.push(0);
-    }
-    for n in &plan.nav {
-        let _ = write!(out, "{} {} {} {}", n.next, n.prev, n.left, n.right);
-        out.push(0);
-    }
-    for text in insert_texts {
-        push_bytes(&mut out, text);
-    }
-    out
-}
-
-fn push_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
-    out.extend_from_slice(bytes);
-    out.push(0);
+    Ok(wire::serialize(common_prefix, &built, &insert_texts))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wire;
     use proptest::prelude::*;
 
     #[derive(Debug)]

--- a/src/span.rs
+++ b/src/span.rs
@@ -8,8 +8,8 @@
 //! `match_span_uses_end_exclusive_semantics_not_start_len` pins one).
 //!
 //! The end-exclusive form therefore travels as this type, and
-//! [`CharSpan::len`] is the single place the wire's `len` is derived from
-//! it.
+//! [`CharSpan::len`] is the single operation the wire serializer uses to
+//! derive `len` from it.
 
 /// A `[start, end)` range of chars over the lossy UTF-8 reading of some
 /// text -- the offset unit of cli-protocol.md "オフセット規律", never a

--- a/src/wire.rs
+++ b/src/wire.rs
@@ -1,6 +1,80 @@
-//! Reference parser for the render-plan wire format.
+//! Render-plan wire serialization and reference parsing.
 
 use std::fmt;
+use std::io::Write as _;
+
+use crate::layout;
+
+/// Protocol version shared by config output and the worker handshake
+/// (cli-protocol.md "プロトコル版").
+pub(crate) const PROTOCOL_VERSION: &str = "7";
+
+/// Incremental, overflow-checked ASCII decimal accumulation shared by the
+/// protocol's complete-field parsers and streaming netstring decoder.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct Decimal {
+    value: u64,
+    digits: usize,
+    leading_zero: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DecimalError {
+    InvalidDigit,
+    LeadingZero,
+    Overflow,
+}
+
+impl Decimal {
+    pub(crate) fn push(&mut self, byte: u8) -> Result<(), DecimalError> {
+        let digit = byte
+            .checked_sub(b'0')
+            .filter(|digit| *digit <= 9)
+            .ok_or(DecimalError::InvalidDigit)?;
+        self.value = self
+            .value
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(u64::from(digit)))
+            .ok_or(DecimalError::Overflow)?;
+        self.leading_zero = self.digits == 0 && digit == 0;
+        self.digits += 1;
+        Ok(())
+    }
+
+    pub(crate) fn push_canonical(&mut self, byte: u8) -> Result<(), DecimalError> {
+        if !byte.is_ascii_digit() {
+            return Err(DecimalError::InvalidDigit);
+        }
+        if self.leading_zero {
+            return Err(DecimalError::LeadingZero);
+        }
+        self.push(byte)
+    }
+
+    pub(crate) fn is_empty(self) -> bool {
+        self.digits == 0
+    }
+
+    pub(crate) fn value(self) -> u64 {
+        self.value
+    }
+}
+
+pub(crate) fn parse_ascii_u64(value: &[u8]) -> Option<u64> {
+    let mut decimal = Decimal::default();
+    for &byte in value {
+        decimal.push(byte).ok()?;
+    }
+    (!decimal.is_empty()).then_some(decimal.value())
+}
+
+pub(crate) fn parse_canonical_u64(value: &[u8]) -> Option<u64> {
+    let mut decimal = Decimal::default();
+    for &byte in value {
+        decimal.push_canonical(byte).ok()?;
+    }
+    (!decimal.is_empty()).then_some(decimal.value())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Plan {
@@ -19,6 +93,27 @@ pub enum Role {
     HistoryNumber,
 }
 
+impl Role {
+    fn parse(value: &[u8]) -> Option<Self> {
+        match value {
+            b"match" => Some(Self::Match),
+            b"heading" => Some(Self::Heading),
+            b"history-number" => Some(Self::HistoryNumber),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Match => "match",
+            Self::Heading => "heading",
+            Self::HistoryNumber => "history-number",
+        }
+    }
+}
+
+/// A decoded highlight, preserving the wire's `start len` representation.
+/// Layout computation keeps its end-exclusive span type until serialization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Highlight {
     pub role: Role,
@@ -27,12 +122,64 @@ pub struct Highlight {
     pub len: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Navigation {
     pub next: usize,
     pub prev: usize,
     pub left: usize,
     pub right: usize,
+}
+
+/// Flatten a computed plan into the render-plan wire format. Internal spans
+/// stay end-exclusive until this boundary converts them to `start len`.
+pub(crate) fn serialize(
+    common_prefix: &[u8],
+    plan: &layout::Plan,
+    insert_texts: &[Vec<u8>],
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    push_bytes(&mut out, common_prefix);
+    let _ = write!(out, "{}", plan.rows.len());
+    out.push(0);
+    let _ = write!(out, "{}", plan.positions.len());
+    out.push(0);
+    for row in &plan.rows {
+        push_bytes(&mut out, row);
+    }
+    let _ = write!(out, "{}", plan.highlights.len());
+    out.push(0);
+    for highlight in &plan.highlights {
+        let _ = write!(
+            out,
+            "{} {} {} {}",
+            highlight.role.as_str(),
+            highlight.pos,
+            highlight.span.start,
+            highlight.span.len()
+        );
+        out.push(0);
+    }
+    for cell in &plan.cell_ranges {
+        let _ = write!(out, "{} {}", cell.start, cell.len());
+        out.push(0);
+    }
+    for navigation in &plan.nav {
+        let _ = write!(
+            out,
+            "{} {} {} {}",
+            navigation.next, navigation.prev, navigation.left, navigation.right
+        );
+        out.push(0);
+    }
+    for text in insert_texts {
+        push_bytes(&mut out, text);
+    }
+    out
+}
+
+fn push_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.extend_from_slice(bytes);
+    out.push(0);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -195,21 +342,12 @@ fn count(value: &[u8], field: &'static str) -> Result<usize, Error> {
     // zsh's `<->` accepts unbounded digit strings and does not numerically
     // convert cell ranges; this typed reference API deliberately rejects
     // `usize` overflow because the Rust serializer cannot produce it.
-    if value.is_empty() || !value.iter().all(u8::is_ascii_digit) {
-        return Err(Error::InvalidCount {
+    parse_ascii_u64(value)
+        .and_then(|number| usize::try_from(number).ok())
+        .ok_or_else(|| Error::InvalidCount {
             field,
             value: value.to_vec(),
-        });
-    }
-    value.iter().try_fold(0usize, |number, digit| {
-        number
-            .checked_mul(10)
-            .and_then(|number| number.checked_add(usize::from(*digit - b'0')))
-            .ok_or_else(|| Error::InvalidCount {
-                field,
-                value: value.to_vec(),
-            })
-    })
+        })
 }
 
 /// `start + len` must stay inside the listing text (cli-protocol.md
@@ -243,12 +381,7 @@ fn parse_highlight(
             value: value.to_vec(),
         });
     }
-    let role = match parts[0] {
-        b"match" => Role::Match,
-        b"heading" => Role::Heading,
-        b"history-number" => Role::HistoryNumber,
-        other => return Err(Error::InvalidRole(other.to_vec())),
-    };
+    let role = Role::parse(parts[0]).ok_or_else(|| Error::InvalidRole(parts[0].to_vec()))?;
     let pos = count(parts[1], "highlight pos")?;
     if pos > positions {
         return Err(Error::OutOfRange {
@@ -333,6 +466,54 @@ fn tuple_parts(value: &[u8]) -> Vec<&[u8]> {
 mod tests {
     use super::*;
 
+    const CONTRACT: &str = "docs/internal/contracts/cli-protocol.md";
+
+    fn read_repo_file(relative_path: &str) -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+    }
+
+    /// PROTOCOL_VERSION is hand-written here, in two contract lines, and in
+    /// zsh/zrush.zsh. The tests/cli.rs config golden owns its remaining copy.
+    #[test]
+    fn protocol_version_matches_docs_and_zsh() {
+        let expected: [(&str, String); 3] = [
+            (
+                CONTRACT,
+                format!("- **PROTOCOL_VERSION = {PROTOCOL_VERSION}**"),
+            ),
+            (
+                CONTRACT,
+                format!("typeset -g  ZRUSH_PROTOCOL_VERSION='{PROTOCOL_VERSION}'"),
+            ),
+            (
+                "zsh/zrush.zsh",
+                format!("typeset -gi _ZRUSH_EXPECTED_PROTO={PROTOCOL_VERSION}"),
+            ),
+        ];
+
+        let mismatches: Vec<String> = expected
+            .iter()
+            .filter(|(relative_path, expected_line)| {
+                !read_repo_file(relative_path)
+                    .lines()
+                    .any(|line| line.trim() == expected_line)
+            })
+            .map(|(relative_path, expected_line)| {
+                format!("{relative_path}: expected a line \"{expected_line}\"")
+            })
+            .collect();
+
+        assert!(
+            mismatches.is_empty(),
+            "PROTOCOL_VERSION mismatch: src/wire.rs::PROTOCOL_VERSION is \
+             {PROTOCOL_VERSION:?}, but the following locations disagree (or are \
+             missing the anchor line) and need to be updated to match:\n{}",
+            mismatches.join("\n")
+        );
+    }
+
     fn fields(values: &[&[u8]]) -> Vec<u8> {
         let mut output = Vec::new();
         for value in values {
@@ -376,6 +557,11 @@ mod tests {
     #[test]
     fn signed_l_is_rejected() {
         assert_invalid_count(&count_plan(b"-1", b"0", b"0"), "L");
+    }
+
+    #[test]
+    fn leading_zero_counts_are_accepted_as_nonnegative_digit_strings() {
+        assert!(parse(&count_plan(b"00", b"00", b"00")).is_ok());
     }
 
     #[test]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -8,10 +8,10 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
 
-use crate::config::PROTOCOL_VERSION;
 use crate::framing::{self, Decoder};
 use crate::matching::Mode;
 use crate::plan::{self, Producer};
+use crate::wire::{PROTOCOL_VERSION, parse_canonical_u64};
 
 const READ_BUFFER_SIZE: usize = 8192;
 const REQUEST_FIELD_COUNT: usize = 11;
@@ -320,16 +320,6 @@ fn parse_positive_usize(value: &[u8]) -> Option<usize> {
 
 fn is_canonical_positive(value: &[u8]) -> bool {
     parse_canonical_u64(value).is_some_and(|number| number > 0)
-}
-
-fn parse_canonical_u64(value: &[u8]) -> Option<u64> {
-    if value.is_empty() || (value.len() > 1 && value[0] == b'0') {
-        return None;
-    }
-    value.iter().try_fold(0_u64, |number, byte| {
-        let digit = byte.checked_sub(b'0').filter(|digit| *digit <= 9)?;
-        number.checked_mul(10)?.checked_add(u64::from(digit))
-    })
 }
 
 fn decode_fields(message: &[u8]) -> Result<Vec<Vec<u8>>, Error> {


### PR DESCRIPTION
Closes #56

render-plan のシリアライザと参照パーサ、共有可能なワイヤ型、プロトコル版・10進数処理の所有場所が複数モジュールに分かれていた。本変更ではワイヤ形式を変えずに、それらの知識を `src/wire.rs` へ集約する。

## Details

- `plan.rs::serialize` を `wire.rs` へ移し、`plan.rs` は計算済みプランを `wire::serialize` に渡す構成にした。
- `layout::Role` と `layout::Nav` の重複定義を削除し、`wire::Role` / `wire::Navigation` をレイアウトとパーサで共有した。
- #67 で導入した型安全性を維持するため、layout 内部の end-exclusive `CharSpan` を持つ `Highlight` と、デコード後のワイヤ表現 `start len` を持つ `wire::Highlight` は意図的に分離した。変換は `wire::serialize` の境界だけで行う。
- ASCII 10進数のオーバーフロー検出付き蓄積処理を共通化した。worker / netstring framing の canonical 規則と、render-plan が非負の数字列として先頭ゼロを許容する既存規則はそれぞれ維持した。
- `PROTOCOL_VERSION` とコピー一致テストを `wire.rs` へ移し、契約文書の所有場所表記を追随させた。
- ワイヤ形式とゴールデンベクタに変更はない。

## Tests

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`
- `zsh -f tests/zsh/vectors.zsh` (`PASS=74 FAIL=0`)
- `git diff --check`