### PR TITLE
fix(worker): let a shell recover from a disabled zrush session

### DIFF
--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -28,7 +28,9 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
   既に worker が起動していた場合は新 generation の worker も直ちに起動し直す。まだ遅延起動前なら lazy 状態を保つ。
   試行は 1 回だけで、成功時は警告せず `ZRUSH_LOG` にだけ記録する。re-source 自体の失敗、または
   re-source 中の再度の不一致は警告を 1 回表示して zrush を無効化する。後の明示的 re-source は
-  この stale-build 無効化を巻き戻せるが、障害起因の shell-session 無効化は巻き戻さない。
+  この stale-build 無効化を巻き戻せる。session failure の circuit breaker は、旧 worker の停止が完了した
+  後の明示的 re-source でだけ解除できる。自動 re-source、quarantine 中の re-source、その他の disable reason は
+  解除しない。
 - 未知の引数を渡された `zrush` は exit 2 で拒否する(前方互換より誤用の早期検出を優先する意図的選択。
   build 不整合は上記のスタンプ照合で検知される)。
 

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -132,6 +132,11 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   代替 worker を 1 個だけ遅延起動する。終端応答なしの 2 回目でその shell の zrush を無効化し、
   無限 respawn や one-shot fallback は行わない。ただし taint された runtime generation はこの通常の 1 回交換の
   対象外であり、cleanup 後も fresh re-source まで代替 worker を起動しない。
+- 2 回目の session failure による circuit breaker は `session-failure` の disable reason を持つ。
+  worker が健全に finalization された後、ユーザーが明示的に re-source した場合だけ、この reason と
+  failure counter を 0 に戻して新しい worker 起動を許可する。request_id、callback generation、warning latch は
+  戻さず、未完了 request の replay もしない。自動 build-stamp re-source はこの解除を行わない。
+  invalid handshake、request_id 枯渇、runtime setup failure など別の disable reason はこの操作で解除しない。
 - 正しい形の `incompatible`、stamp の異なる `ready`、source/config の build-stamp 不一致は stale build として
   失敗回数を介さず `$ZRUSH_BIN init zsh` の自動 re-source を 1 回だけ試みる。成功時は警告せず診断ログだけを残し、
   検出時点の未完了 request はすべて破棄して replay しない。re-source の失敗または re-source 中の再不一致だけが
@@ -146,13 +151,16 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   deadline 超過時は re-source 自体を失敗させ、非同期 cleanup は旧 worker session の finalization だけを行う。
   新 generation の導入は cleanup 完了後の次の re-source invocation に任せる。
   旧 generation が quarantine 中の re-source は fail fast し、新旧 transport を重複させない。
-  request_id と callback generation の単調性・警告済み状態・連続失敗回数・障害起因の無効化状態は巻き戻さない。
-  stale build のガード失敗による無効化だけは、後の明示的 re-source が新しい追従試行として巻き戻せる。
+  request_id と callback generation の単調性・警告済み状態は巻き戻さない。session-failure の disable reason と
+  連続失敗回数だけは、旧 generation の停止が完了した後の明示的 re-source で新しい recovery epoch として
+  巻き戻せる。自動 re-source、quarantine 中の re-source、その他の disable reason は巻き戻さない。
 - `zshexit` も同じ停止を開始し、同期待ちは 100ms を超えない。deadline で未完了でも shell exit を妨げず、
   control/request/response を含む所有 fd を閉じ、所有する正確な FIFO path と runtime directory を unlink する。
   control EOF により worker watchdog は abort し、この経路も numeric PID・`wait`・exit status を使わない。
-- worker 障害の user warning は同じ shell session で高々 1 回表示する。`ZRUSH_LOG` が設定されていれば
-  warning 抑止後も診断を追記する。worker stderr は端末へ流さない。
+- worker 障害の user notice は同じ shell session で高々 1 回表示し、ZLE の status line を使う。
+  最初の失敗では次の要求で 1 回だけ retry することを示し、circuit breaker が開いた後は
+  `source <(zrush init zsh)` による recovery 方法を disable 中の status line に表示し続ける。
+  `ZRUSH_LOG` が設定されていれば notice 抑止後も診断を追記する。worker stderr は端末へ流さない。
 - worker の起動・正常 shutdown・異常 abort・交換・quarantine・re-source・disable・exit の全経路で、
   internal fd 操作は対話シェル自身の fd 0 / 1 / 2 の open/closed 状態と接続先を変えない。
   internal close error の抑止を shell stderr へ恒久適用しない。

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -77,8 +77,9 @@ zrush が入力を勝手に書き換えることはない。`~` は展開され�
 - source 時または最初の補完時に「build stamp」の警告が出る → 通常の rebuild 後は自動追従するため、
   `$ZRUSH_BIN init zsh` の再 source が失敗した状態。`ZRUSH_BIN` が現行の zrush を指すことを確認して
   `cargo build --release` 後に明示的に re-source する。
-- worker の障害を示す警告が出て一覧が止まる → 次の要求で 1 回だけ worker を再起動する。
-  再度失敗すると、そのシェルでは zrush が無効になる。新しいシェルで再試行し、必要なら
-  `ZRUSH_LOG=<ファイル>` で診断ログを確認する。
+- worker の障害を示す notice が出て一覧が止まる → 次の要求で 1 回だけ worker を再起動する。
+  再度失敗すると、そのシェルでは zrush が無効になり、status line に recovery 方法が表示される。
+  worker の停止が完了した後に `source <(zrush init zsh)` を明示的に実行すると、その shell 内で再試行できる。
+  必要なら `ZRUSH_LOG=<ファイル>` で診断ログを確認する。
 - 設定の警告が出る → メッセージに「どのキーが・なぜ・どの値に戻したか」が出ている。
   該当行を修正すれば次のプロンプトから反映される。

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -1116,10 +1116,10 @@ sec_death() {
   wait_fake "die $death_first_session " $fake_die0 10 || active_death_ok=0
   wait_log 'worker: session failure:' $err_fail0 10 || active_death_ok=0
   local worker_warning_output=${EXPECT_BUF//$'\e['[0-9;]#m/}
-  if [[ $worker_warning_output == *'zrush: worker transport failed; suppressing further warnings this session'* ]]; then
-    ok "(fd-5a) worker warning reaches stderr after worker startup"
+  if [[ $worker_warning_output == *'zrush: worker transport failed; retrying once'* ]]; then
+    ok "(fd-5a) worker failure notice reaches the ZLE status line after worker startup"
   else
-    ng "(fd-5a) worker warning missing from pty output: ${(qqqq)worker_warning_output}"
+    ng "(fd-5a) worker failure notice missing from pty output: ${(qqqq)worker_warning_output}"
   fi
   local err_log_delta=$(sed -n "$(( err_log_line0 + 1 )),\$p" $ZRUSH_LOG 2>/dev/null)
   local -i fake_started_count=$(print -r -- "$err_log_delta" | grep -cF 'worker: started rfd=' 2>/dev/null)
@@ -1204,11 +1204,17 @@ sec_death() {
   assert_buffer 'ls fx/basic/al' "(err-2) pending Tab resolved against an actively-dead worker inserts nothing"
   if dump_get $'\C-xw' TESTWORKER \
      && (( second_death_clean && third_death_clean )) \
-     && worker_state_has "$REPLY" failures=2 disabled=1 warned=1 pending=0 \
+     && worker_state_has "$REPLY" failures=2 disabled=1 reason=session-failure warned=1 pending=0 \
      && (( $(grep -c '^start ' $ZRUSH_FAKE_STATE) == death_starts0 + 3 )); then
     ok "(err-3) two consecutive active-session deaths open the breaker after one lazy replacement"
   else
     ng "(err-3) active-death breaker state missing: second-clean=$second_death_clean third-clean=$third_death_clean state=${REPLY:-<none>}"
+  fi
+  local worker_disabled_output=${EXPECT_BUF//$'\e['[0-9;]#m/}
+  if [[ $worker_disabled_output == *'zrush: worker disabled after repeated failures; source <(zrush init zsh) to retry'* ]]; then
+    ok "(err-3a) disabled worker remains visible with an explicit recovery action"
+  else
+    ng "(err-3a) disabled worker status missing from pty output: ${(qqqq)worker_disabled_output}"
   fi
 
   clear_line
@@ -1224,8 +1230,28 @@ sec_death() {
   # No sync_prompt here: the expect above already covers this command's prompt.
   drain 0.2
 
-  # Hand the fake worker back to proxy mode: the sections after this one
-  # need a working worker even when (10) below is filtered out.
+  # An explicit re-source starts a new recovery epoch for the session-failure
+  # breaker. It must leave the monotonic request counter intact and make the
+  # fake worker available again without starting it until the next request.
+  print -r -- proxy > $ZRUSH_FAKE_CONTROL
+  send_line 'source <($ZRUSH_REAL_BIN init zsh)'
+  if sync_prompt 10 && dump_get $'\C-xw' TESTWORKER \
+     && worker_state_has "$REPLY" ready=0 failures=0 disabled=0 reason= stale=0 stopping=0 \
+          rfd=-1 wfd=-1 control=-1 ack=-1 pending=0; then
+    ok "(err-5a) explicit re-source clears only the session-failure breaker"
+  else
+    ng "(err-5a) explicit re-source did not restore a lazy worker: ${REPLY:-<none>}"
+  fi
+  if send_keys_wait_plan nonempty 'ls fx/basic/al' 10; then
+    ok "(err-5b) the recovered session serves the next completion request"
+  else
+    ng "(err-5b) recovered session did not serve a completion request"
+  fi
+  clear_line
+  drain 0.3
+
+  # Keep the fake worker in proxy mode for sections after this one even when
+  # the death section is filtered out.
   print -r -- proxy > $ZRUSH_FAKE_CONTROL
 }
 

--- a/tests/zsh/rc/minimal.zshrc
+++ b/tests/zsh/rc/minimal.zshrc
@@ -25,7 +25,7 @@ bindkey '^Xh' _zrt-dump-rh
 # ^Xw: persistent-worker lifecycle state. This exposes only stable invariants
 # needed by driver.zsh (lazy start, reuse, monotonic ids, and clean teardown).
 _zrt_dump_worker() {
-  _zlog "TESTWORKER=ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled stale=$_zrush_stale_disabled warned=$_zrush_worker_warned buildwarned=$_zrush_build_warned following=$_zrush_build_following verifying=$_zrush_build_verifying stopping=$_zrush_worker_stopping tainted=$_zrush_worker_runtime_tainted rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd control=$_zrush_worker_control_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending runtime=${_zrush_worker_runtime_dir:-<none>}"
+  _zlog "TESTWORKER=ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled reason=$_zrush_disable_reason stale=$_zrush_stale_disabled warned=$_zrush_worker_warned buildwarned=$_zrush_build_warned following=$_zrush_build_following verifying=$_zrush_build_verifying stopping=$_zrush_worker_stopping tainted=$_zrush_worker_runtime_tainted rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd control=$_zrush_worker_control_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending runtime=${_zrush_worker_runtime_dir:-<none>}"
 }
 zle -N _zrt-dump-worker _zrt_dump_worker
 bindkey '^Xw' _zrt-dump-worker

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -95,7 +95,7 @@ unset ZDOTDIR
     _zrush_current_request=0 _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
     _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_build_warned=0
     _zrush_build_following=0 _zrush_build_verifying=0 _zrush_stale_disabled=0
-    _zrush_disabled=0 _zrush_enabled=0
+    _zrush_disabled=0 _zrush_disable_reason= _zrush_notice= _zrush_enabled=0
     _zrush_worker_callback_generation=( data 0 ack 0 drain 0 )
     _zrush_worker_callback_handler=()
     WARNINGS=()
@@ -591,21 +591,38 @@ unset ZDOTDIR
   unset ZRUSH_NO_INIT
   eq "explicit re-source after stale failure" $stale_resource_st 0
   eq "explicit re-source clears stale disable" $_zrush_stale_disabled 0
-  _zrush_disabled=1
+  _zrush_disabled=1 _zrush_disable_reason=session-failure _zrush_worker_failures=2 _zrush_build_following=1
+  typeset -g ZRUSH_NO_INIT=1
+  source $REPO/zsh/zrush.zsh; typeset -gi auto_fault_resource_st=$?
+  unset ZRUSH_NO_INIT
+  eq "automatic re-source with fault disable status" $auto_fault_resource_st 0
+  eq "automatic re-source preserves fault disable" $_zrush_disabled 1
+  eq "automatic re-source preserves fault counter" $_zrush_worker_failures 2
+  _zrush_build_following=0
+  _zrush_disabled=1 _zrush_disable_reason=session-failure
   typeset -g ZRUSH_NO_INIT=1
   source $REPO/zsh/zrush.zsh; typeset -gi fault_resource_st=$?
   unset ZRUSH_NO_INIT
   eq "fault-state test re-source status" $fault_resource_st 0
-  eq "explicit re-source preserves fault disable" $_zrush_disabled 1
-  _zrush_disabled=0
-  verdict "build follow: failed auto-source disables one generation while explicit source preserves only fault disable"
+  eq "explicit re-source clears session-failure disable" $_zrush_disabled 0
+  eq "explicit re-source clears session-failure reason" $_zrush_disable_reason ""
+  eq "explicit re-source clears session-failure counter" $_zrush_worker_failures 0
+  _zrush_disabled=1 _zrush_disable_reason=policy
+  typeset -g ZRUSH_NO_INIT=1
+  source $REPO/zsh/zrush.zsh; typeset -gi policy_resource_st=$?
+  unset ZRUSH_NO_INIT
+  eq "policy-state re-source status" $policy_resource_st 0
+  eq "explicit re-source preserves policy disable" $_zrush_disabled 1
+  eq "explicit re-source preserves policy reason" $_zrush_disable_reason policy
+  _zrush_disabled=0 _zrush_disable_reason=
+  verdict "build follow: explicit source clears only session-failure disable"
 
   # -------------------------------- config/re-source fail-fast during quarantine
   reset_transport
   _zrush_worker_runtime_prepare
   runtime=$_zrush_worker_runtime_dir
   _zrush_worker_stopping=1 _zrush_installed=1
-  _zrush_worker_failures=7 _zrush_disabled=1 _zrush_enabled=0
+  _zrush_worker_failures=7 _zrush_disabled=1 _zrush_disable_reason=session-failure _zrush_enabled=0
   typeset -g old_read_body=$functions[_zrush_worker_read]
   typeset -g old_runtime=$runtime
   ZRUSH_BIN=/definitely/not/invoked

--- a/tests/zsh/vectors.zsh
+++ b/tests/zsh/vectors.zsh
@@ -391,7 +391,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   # A handshake alone is not a successful terminal response and therefore
   # must not reset the consecutive-session failure streak. A request-level
   # error is terminal, clears its pending request, and does reset the streak.
-  _zrush_worker_ready=0 _zrush_worker_failures=1 _zrush_disabled=0 _zrush_enabled=1
+  _zrush_worker_ready=0 _zrush_worker_failures=1 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
   _zrush_netstring_take "$ready_frame"
   _zrush_worker_handle_message "$REPLY"
   local -i ready_kept_failures=$(( _zrush_worker_ready == 1 && _zrush_worker_failures == 1 ))
@@ -411,7 +411,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   read_vector $VECTORS/plan/empty-stdin/expected \
     || { out "FATAL: $REPLY"; exit 1 }
   local stale_plan=$REPLY
-  _zrush_worker_ready=1 _zrush_worker_failures=1 _zrush_disabled=0 _zrush_enabled=1
+  _zrush_worker_ready=1 _zrush_worker_failures=1 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
   typeset -gA _zrush_worker_pending=( 41 compsys )
   _zrush_current_request=42
   _zrush_plan_text=sentinel _zrush_plan_cp=sentinel-cp _zrush_plan_kind=history
@@ -438,7 +438,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   functions[_zrush_arm_timer]='return 0'
   typeset -gi _zrt_settle_calls=0
   functions[_zrush_settle_plan]='(( ++_zrt_settle_calls )); _zrush_tab_pending=0; return 0'
-  _zrush_enabled=1 _zrush_disabled=0 _zrush_current_request=41
+  _zrush_enabled=1 _zrush_disabled=0 _zrush_disable_reason= _zrush_current_request=41
   _zrush_last_buffer=old _zrush_last_cursor=0
   BUFFER=new LBUFFER=new CURSOR=3
   _zrush_plan_kind=none _zrush_tab_pending=0 _zrush_selected=0
@@ -471,7 +471,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   # Populate every active endpoint slot needed by a healthy stop. stdout is
   # already at EOF, so shutdown must raw-drain it before finalizing.
   zmodload zsh/system zsh/datetime || { out "FATAL: lifecycle modules"; exit 1 }
-  _zrush_worker_ready=0 _zrush_worker_failures=0 _zrush_disabled=0 _zrush_enabled=1
+  _zrush_worker_ready=0 _zrush_worker_failures=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
   _zrush_worker_warned=0 _zrush_build_warned=0 _zrush_worker_stopping=0
   _zrush_build_following=1 _zrush_stale_disabled=0
   local -i mismatch_rfd mismatch_wfd mismatch_control_fd mismatch_drain_fd
@@ -499,23 +499,27 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
     ng "worker lifecycle: mismatch state enabled=$_zrush_enabled disabled=$_zrush_disabled stale=$_zrush_stale_disabled failures=$_zrush_worker_failures warned=$_zrush_build_warned fds=$_zrush_worker_rfd,$_zrush_worker_wfd,$_zrush_worker_control_wfd,$_zrush_worker_ack_fd,$_zrush_worker_drain_fd"
   fi
   _zrush_build_following=0 _zrush_stale_disabled=0
-  _zrush_disabled=0 _zrush_enabled=0 _zrush_worker_warned=0 _zrush_build_warned=0
+  _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=0 _zrush_worker_warned=0 _zrush_build_warned=0
 
   # Two failed sessions without an intervening terminal response open the
-  # circuit breaker. The user-facing warning latch remains set after the first
+  # circuit breaker. The user-facing notice latch remains set after the first
   # failure, while detailed reasons continue to be logged for both sessions.
   local saved_log=${ZRUSH_LOG:-}
   ZRUSH_LOG=$WORK/lifecycle.log
-  _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_enabled=1
+  _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
   _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_control_wfd=-1
   _zrush_worker_session_fail fixture-first 2>/dev/null
   local -i first_failure_ok=$(( _zrush_worker_failures == 1 && _zrush_worker_warned \
     && !_zrush_disabled && _zrush_enabled ))
+  local first_notice=$_zrush_notice
   _zrush_enabled=1
   _zrush_worker_session_fail fixture-second 2>/dev/null
   local lifecycle_log="$(<$ZRUSH_LOG)"
   if (( first_failure_ok && _zrush_worker_failures == 2 && _zrush_disabled \
         && !_zrush_enabled && _zrush_worker_warned )) \
+     && [[ $first_notice == 'zrush: worker transport failed; retrying once' \
+           && $_zrush_disable_reason == session-failure \
+           && $_zrush_notice == 'zrush: worker disabled after repeated failures; source <(zrush init zsh) to retry' ]] \
      && [[ $lifecycle_log == *'fixture-first'* && $lifecycle_log == *'fixture-second'* \
            && $lifecycle_log == *'circuit breaker opened'* ]]; then
     ok "worker lifecycle: second consecutive session failure disables; warning latches once"
@@ -523,7 +527,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
     ng "worker lifecycle: breaker state/log mismatch"
   fi
   ZRUSH_LOG=$saved_log
-  _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_enabled=0
+  _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=0
 
   # ---------------- History payload sender ----------------
   # `print -s` leaves its newest entry as the current event until another

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -66,24 +66,38 @@ fi
 typeset -g  ZRUSH_BIN=${ZRUSH_BIN:-}
 typeset -gi _zrush_enabled=0
 typeset -g  _zrush_cfg_path= _zrush_cfg_mtime=
-# Shell-session state intentionally survives a manual re-source.
+# Shell-session identity/latches survive a manual re-source; the
+# session-failure breaker below is the explicit recovery exception.
 typeset -gi _zrush_request_seq=${_zrush_request_seq:-0}
 typeset -gi _zrush_worker_warned=${_zrush_worker_warned:-0}
 typeset -gi _zrush_build_warned=${_zrush_build_warned:-0}
 typeset -gi _zrush_worker_failures=${_zrush_worker_failures:-0}
 typeset -gi _zrush_disabled=${_zrush_disabled:-0}
+typeset -g  _zrush_disable_reason=${_zrush_disable_reason:-}
+typeset -g  _zrush_notice=${_zrush_notice:-}
 typeset -gi _zrush_build_following=${_zrush_build_following:-0}
 if (( _zrush_build_following )); then
   typeset -gi _zrush_build_verifying=${_zrush_build_verifying:-0}
 else
   # An explicit source is a fresh stale-build recovery attempt.
   typeset -gi _zrush_build_verifying=0
+  if (( _zrush_disabled )) && [[ $_zrush_disable_reason == session-failure ]]; then
+    # A user-requested re-source starts a new recovery epoch. Automatic build
+    # following keeps this state latched; see behavior.md "worker ライフサイクル".
+    _zrush_disabled=0
+    _zrush_disable_reason=
+    _zrush_worker_failures=0
+    typeset -g _zrush_notice=
+    zle -R 2>/dev/null
+  fi
 fi
 # A stale-build guard failure disables only this loaded generation. A later
-# explicit re-source starts a fresh attempt; fault-policy disable above survives.
+# explicit re-source starts a fresh attempt; fault-policy disable above survives
+# unless it is the session-failure breaker handled above.
 typeset -gi _zrush_stale_disabled=0
 typeset -gi _zrush_worker_stopping=${_zrush_worker_stopping:-0}
 typeset -gi _zrush_installed=0
+typeset -gi _zrush_status_rendering=0
 # Variables this script consumes from `zrush config` output (validation and rollback)
 typeset -ga _ZRUSH_CFG_VARS=(
   ZRUSH_CFG_MAX_LINES ZRUSH_CFG_DELAY_MS ZRUSH_CFG_MIN_INPUT
@@ -164,6 +178,30 @@ typeset -gi _zrush_dsp_n=${_zrush_dsp_n:-0}
 _zlog() { [[ -n $ZRUSH_LOG ]] && print -r -- "[$$ ${EPOCHREALTIME:-0}] $1" >>| $ZRUSH_LOG; return 0 }
 
 _zrush_warn() { print -ru2 -- "zrush: $1" }
+
+# Display worker state through ZLE's redraw-safe status line. `zle -R` is a
+# no-op outside an active editor, which keeps source-time and headless tests
+# free of a terminal dependency. The hook calls this again on every redraw so
+# a latched notice remains visible while the state lasts.
+_zrush_status_refresh() {
+  emulate -L zsh
+  [[ -n $_zrush_notice ]] || return 0
+  (( _zrush_status_rendering )) && return 0
+  _zrush_status_rendering=1
+  zle -R "$_zrush_notice" 2>/dev/null
+  _zrush_status_rendering=0
+  return 0
+}
+
+_zrush_status_set() {
+  emulate -L zsh
+  typeset -g _zrush_notice=$1
+  if [[ -n $_zrush_notice ]]; then
+    _zrush_status_refresh
+  else
+    zle -R 2>/dev/null
+  fi
+}
 
 _zrush_close_internal_fd() {  # $1=owned fd; idempotent best-effort close
   emulate -L zsh
@@ -965,8 +1003,8 @@ _zrush_encode_message() {
 
 _zrush_worker_warn_once() {
   (( _zrush_worker_warned )) && return 0
-  _zrush_warn "worker transport failed; suppressing further warnings this session"
   _zrush_worker_warned=1
+  _zrush_status_set "zrush: worker transport failed; retrying once"
 }
 
 _zrush_worker_invalidate_callback() {  # data|ack|drain fd
@@ -1291,9 +1329,11 @@ _zrush_worker_shutdown() {
 _zrush_worker_disable_policy() {
   emulate -L zsh
   _zlog "worker: disabling: $1"
-  _zrush_worker_warn_once
+  (( _zrush_worker_warned )) || _zrush_worker_warned=1
+  _zrush_disable_reason=policy
   _zrush_disabled=1
   _zrush_enabled=0
+  _zrush_status_set "zrush: worker disabled ($1); start a new shell"
 }
 
 _zrush_worker_fail_session() {
@@ -1305,8 +1345,10 @@ _zrush_worker_fail_session() {
   _zrush_teardown
   (( ++_zrush_worker_failures ))
   if (( _zrush_worker_failures >= 2 )); then
+    _zrush_disable_reason=session-failure
     _zrush_disabled=1
     _zrush_enabled=0
+    _zrush_status_set "zrush: worker disabled after repeated failures; source <(zrush init zsh) to retry"
     _zlog "worker: circuit breaker opened"
   fi
   return 1
@@ -1530,6 +1572,7 @@ _zrush_worker_handle_message() {  # message [absolute-deadline]
     fi
     unset "_zrush_worker_pending[$id]"
     _zrush_worker_failures=0
+    _zrush_status_set ""
     if (( id == _zrush_sync_target )); then
       _zrush_sync_done=1 _zrush_sync_ok=0
     elif (( id == _zrush_current_request )); then
@@ -1552,6 +1595,7 @@ _zrush_worker_handle_message() {  # message [absolute-deadline]
   fi
   unset "_zrush_worker_pending[$id]"
   _zrush_worker_failures=0
+  _zrush_status_set ""
   if (( id == _zrush_sync_target )); then
     _zrush_plan_kind=$producer
     _zrush_sync_done=1 _zrush_sync_ok=1
@@ -2024,6 +2068,7 @@ _zrush_timer_fire() {  # zle -F -w handler ($1=fd)
 # ---------------------------------------------------------------- ZLE hooks
 _zrush_line_pre_redraw() {
   emulate -L zsh
+  _zrush_status_refresh
   (( _zrush_enabled )) || return 0
   [[ -n $ZRUSH_INTERNAL ]] && return 0
   [[ $BUFFER == "$_zrush_last_buffer" ]] && (( CURSOR == _zrush_last_cursor )) && return 0
@@ -2081,6 +2126,7 @@ _zrush_line_init() {
   _zrush_disarm_timer
   _zrush_cancel_collection
   _zrush_teardown
+  _zrush_status_refresh
   return 0
 }
 
@@ -2535,7 +2581,9 @@ _zrush_init() {
 
   _zrush_worker_runtime_prepare || {
     _zrush_warn "worker runtime FIFO setup failed; zrush disabled"
+    _zrush_disable_reason=runtime
     _zrush_disabled=1 _zrush_enabled=0
+    _zrush_notice="zrush: worker disabled (runtime setup failed); start a new shell"
     return 1
   }
 


### PR DESCRIPTION
Fixes #44

## Summary

A worker session failure currently opens a breaker that leaves zrush disabled for the rest of the shell session. This change makes that state recoverable through an explicit re-source after the old worker has finalized.

- Track disable reasons and distinguish session-failure recovery from policy/runtime disables.
- Clear only the session-failure breaker and failure counter on explicit `source <(zrush init zsh)`.
- Preserve request ID monotonicity, callback generations, and the warning latch; do not replay requests.
- Show retry and recovery guidance through the redraw-safe ZLE status line.
- Update the behavior and protocol documentation and add lifecycle/re-source coverage.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`
- `tests/zsh/vectors.zsh`: 74 passed
- `tests/zsh/transport.zsh`: 18 passed
- `tests/zsh/keybinds.zsh`: 4 passed
- `tests/zsh/driver.zsh`: 160 passed
- `tests/zsh/driver-coexist.zsh`: 32 passed; tmux checks skipped because the sandbox denied socket creation