### PR TITLE
refactor(plan): drop the duplicate framing error type

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -57,20 +57,13 @@ impl Producer {
     }
 }
 
-/// The only error `run` itself can produce. Session I/O failures are
-/// worker.rs's concern, not this pure pipeline's.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Error {
-    Framing,
-}
-
 /// Run the full pipeline and return the serialized render plan.
 pub(crate) fn run(
     params: &Params,
     payload: &[u8],
     is_dir: &dyn Fn(&[u8]) -> bool,
-) -> Result<Vec<u8>, Error> {
-    let parsed = record::parse(payload).map_err(|_| Error::Framing)?;
+) -> Result<Vec<u8>, record::FramingError> {
+    let parsed = record::parse(payload)?;
 
     let mut qm = QueryMatcher::new(&params.query, params.mode, params.smart_case);
     let mut matched: Vec<(usize, crate::matching::TierHit)> = Vec::new();
@@ -338,7 +331,7 @@ mod tests {
     fn framing_error_is_reported() {
         // no trailing NUL: framing violation (record.rs).
         let err = run(&params("a", Mode::Typo, 10, 40, true), b"b", &no_dir).unwrap_err();
-        assert_eq!(err, Error::Framing);
+        assert_eq!(err, crate::record::FramingError);
     }
 
     #[test]

--- a/src/record.rs
+++ b/src/record.rs
@@ -79,8 +79,8 @@ pub(crate) struct Parsed<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct FramingError;
 
-/// Parse one complete candidate payload per cli-protocol.md. Mapping a
-/// `FramingError` to the worker response belongs to plan.rs/worker.rs.
+/// Parse one complete candidate payload per cli-protocol.md.
+/// Mapping a `FramingError` to the worker response belongs to worker.rs.
 pub(crate) fn parse(input: &[u8]) -> Result<Parsed<'_>, FramingError> {
     // NUL-terminated records: a non-empty stream must end with NUL, and
     // stripping it yields exactly the record list.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use crate::framing::{self, Decoder};
 use crate::matching::Mode;
 use crate::plan::{self, Producer};
+use crate::record;
 use crate::wire::{BUILD_STAMP, parse_canonical_u64};
 
 const READ_BUFFER_SIZE: usize = 8192;
@@ -244,7 +245,7 @@ fn process_request<W: Write>(fields: &[Vec<u8>], output: &mut W) -> Result<(), E
             let is_dir = |path: &[u8]| is_dir_from(cwd, path);
             match plan::run(&params, payload, &is_dir) {
                 Ok(render_plan) => write_message(output, &[b"ok", request_id, &render_plan]),
-                Err(plan::Error::Framing) => {
+                Err(record::FramingError) => {
                     write_message(output, &[b"error", request_id, b"invalid-payload"])
                 }
             }


### PR DESCRIPTION
Closes #52

## Summary
- remove the single-variant `plan::Error`
- propagate `record::FramingError` directly from `plan::run` to the worker
- preserve the existing `invalid-payload` response behavior

## Tests
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- `cargo test`