### PR TITLE
test(zle): port the small driver sections to the Rust harness

### DIFF
--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -493,9 +493,9 @@ NUL(`\0`)終端フィールドの平坦列。数値は ASCII 10 進表記。順�
 
 #### 適用(zsh 側の規範)
 
-> 検証: いずれも実際の zle 配線に対するスモークテスト。
-> `POSTDISPLAY` の組み立て — `tests/zsh/driver.zsh`。
-> 補完一覧の確定時の `LBUFFER` 置換と `RBUFFER` 保持 — `tests/driver/confirm.rs`(`cargo test --test driver`)。
+> 検証: いずれも実際の zle 配線に対するスモークテスト(`cargo test --test driver`)。
+> `POSTDISPLAY` の組み立て — `tests/driver/apply.rs`。
+> 補完一覧の確定時の `LBUFFER` 置換と `RBUFFER` 保持 — `tests/driver/confirm.rs`。
 
 - **表示**: `L > 0` なら `POSTDISPLAY` を「改行 1 個 + L 個の表示行テキストを改行で連結したもの」に
   置き換える(オフセット規律の `$#BUFFER + 1` 加算は、この先頭の改行 1 個に対応する)。

--- a/tests/driver/apply.rs
+++ b/tests/driver/apply.rs
@@ -1,0 +1,31 @@
+//! Plan application: POSTDISPLAY assembly and region_highlight
+//! (docs/internal/contracts/cli-protocol.md "適用(zsh 側の規範)").
+
+use crate::host::{Host, PlanShape, keys, unquote};
+
+#[test]
+fn postdisplay_and_region_highlight_after_a_listing_plan() {
+    let mut host = Host::boot();
+    host.send_keys_wait_plan(PlanShape::Nonempty, "ls fx/basic/al");
+
+    let post = host
+        .dump_get(keys::DUMP_POSTDISPLAY, "TESTPOST")
+        .map(|raw| unquote(&raw))
+        .unwrap_or_else(|| panic!("(apl-1a) POSTDISPLAY dump did not run"));
+    assert!(
+        post.starts_with('\n') && post.contains("alpha.txt") && post.contains("alsoalpha.txt"),
+        "(apl-1a) POSTDISPLAY malformed: {post:?}"
+    );
+
+    let rh = host
+        .dump_get(keys::DUMP_RH, "TESTRH")
+        .unwrap_or_else(|| panic!("(apl-1b/c) region_highlight dump did not run"));
+    assert!(
+        rh.contains("underline"),
+        "(apl-1b) no match-role highlight found: {rh}"
+    );
+    assert!(
+        !host.has_memo() || rh.contains("memo=zrush"),
+        "(apl-1c) memo=zrush missing on zsh >=5.9: {rh}"
+    );
+}

--- a/tests/driver/async_plumbing.rs
+++ b/tests/driver/async_plumbing.rs
@@ -1,0 +1,34 @@
+//! Async plumbing: a slow compsys fork must not block input
+//! (docs/internal/specs/behavior.md:27 「入力は決してブロックしない」),
+//! and its result still renders once it completes.
+
+use std::time::Duration;
+
+use crate::host::Host;
+
+#[test]
+fn slow_fork_does_not_block_input_and_still_completes() {
+    let mut host = Host::boot();
+    host.send_line(
+        "_zrushtestslow() { local -a m=(slowcandA slowcandB slowcandC); sleep 0.5; compadd -a m }",
+    );
+    host.sync_prompt(Duration::from_secs(5));
+    host.send_line("compdef _zrushtestslow zrushtestslow");
+    host.sync_prompt(Duration::from_secs(5));
+
+    host.send_keys("zrushtestslow ");
+    host.drain(Duration::from_millis(400)); // let debounce elapse and the fork start (still sleeping)
+    host.send_keys("zzz"); // typed while the fork is asleep
+    assert!(
+        host.expect_in_order(&["z", "z", "z"], Duration::from_secs(2)),
+        "(async-1a) input blocked during slow collection"
+    );
+
+    host.clear_line();
+    host.drain(Duration::from_millis(800)); // let the stale in-flight collection settle (cancelled)
+    host.send_keys("zrushtestslow ");
+    assert!(
+        host.expect("slowcandA", Duration::from_secs(5)),
+        "(async-1b) slow-completion candidates never rendered"
+    );
+}

--- a/tests/driver/cache.rs
+++ b/tests/driver/cache.rs
@@ -1,0 +1,38 @@
+//! Empty-word collection cache: a second command-position query hits the
+//! cache and forks nothing (docs/internal/specs/behavior.md "空語収集キャッシュ").
+
+use std::time::Duration;
+
+use crate::host::{Host, PlanShape};
+
+#[test]
+fn second_command_position_query_hits_the_cache_without_forking() {
+    let mut host = Host::boot();
+    // Warm-up: a host's very first completion commonly lazy-loads at least one
+    // compsys function, which changes the fingerprint (function count) the
+    // empty-word cache checks and costs exactly one extra miss (behavior.md
+    // "空語収集キャッシュ" 「既知の癖」). Absorb it here so the pair below
+    // observes the steady-state fingerprint.
+    host.send_keys_wait_plan(PlanShape::Nonempty, "whic");
+    host.clear_line();
+    host.drain(Duration::from_millis(500));
+
+    host.send_keys_wait_plan(PlanShape::Nonempty, "whic");
+    host.clear_line();
+    host.drain(Duration::from_millis(500));
+
+    let hit_baseline = host.log_count("cache: hit");
+    let collecting_baseline = host.log_count("request: collecting");
+    host.send_keys("whic");
+    assert!(
+        host.wait_log("cache: hit", hit_baseline, Duration::from_secs(5)),
+        "(cc-1a) cache hit not logged"
+    );
+
+    host.drain(Duration::from_millis(500));
+    let collecting_after = host.log_count("request: collecting");
+    assert_eq!(
+        collecting_after, collecting_baseline,
+        "(cc-1b) a fork ran despite the expected cache hit ({collecting_baseline} -> {collecting_after})"
+    );
+}

--- a/tests/driver/dismiss.rs
+++ b/tests/driver/dismiss.rs
@@ -1,0 +1,61 @@
+//! Dismiss and accept-line: closing a list leaves the buffer untouched, a
+//! dismiss wins a race against an in-flight collection, and accept-line
+//! resets zrush's line-scoped state (docs/internal/specs/behavior.md
+//! "選択・キーバインド", "確定(挿入)").
+
+use std::time::Duration;
+
+use crate::host::{Host, PlanShape, keys, unquote};
+
+#[test]
+fn dismiss_closes_the_list_without_changing_the_buffer() {
+    let mut host = Host::boot();
+    host.send_keys_wait_plan(PlanShape::Nonempty, "ls fx/basic/");
+
+    host.assert_log_grows(
+        "dismiss: closing list",
+        &[keys::DISMISS],
+        "(dis-1a) dismiss did not work",
+    );
+    host.assert_buffer("ls fx/basic/", "(dis-1b) buffer is unchanged after dismiss");
+}
+
+/// Regression (dis-2): dismiss must cancel any still-armed debounce timer or
+/// in-flight collection for a newer keystroke, or a late-arriving result can
+/// silently reopen the list right after the user closed it. Reproduced with
+/// git's naturally slow (~150ms+) subcommand completion; no extra fixture
+/// needed.
+#[test]
+fn dismiss_cancels_an_in_flight_collection() {
+    let mut host = Host::boot();
+    host.send_keys_wait_plan(PlanShape::Nonempty, "git c"); // first list applied
+    host.send_keys("hec"); // -> 'git chec': re-arms debounce/collection
+    host.send_keys(keys::DISMISS); // dismiss immediately, no drain in between
+    host.drain(Duration::from_secs(1)); // comfortably longer than 'git chec' compsys (~150-200ms)
+
+    let post = host
+        .dump_get(keys::DUMP_POSTDISPLAY, "TESTPOST")
+        .map(|raw| unquote(&raw))
+        .unwrap_or_else(|| panic!("(dis-2) POSTDISPLAY dump did not run"));
+    assert!(
+        post.is_empty(),
+        "(dis-2) list reappeared after dismiss (stale collection not cancelled): {post:?}"
+    );
+}
+
+#[test]
+fn accept_line_executes_and_resets_zrush_state() {
+    let mut host = Host::boot();
+    let baseline = host.log_count("line-finish: cleared");
+    host.send_keys("print HISTMARK-ACCEPT");
+    host.send_keys(keys::ENTER);
+    assert!(
+        host.expect("HISTMARK-ACCEPT", Duration::from_secs(5)),
+        "(acc-1a) command did not execute"
+    );
+    host.sync_prompt(Duration::from_secs(5));
+    assert!(
+        host.wait_log("line-finish: cleared", baseline, Duration::from_secs(3)),
+        "(acc-1b) line-finish not logged after accept-line"
+    );
+}

--- a/tests/driver/fifo.rs
+++ b/tests/driver/fifo.rs
@@ -1,0 +1,41 @@
+//! FIFO-capacity frame delegation: a candidate_payload larger than the
+//! request-FIFO buffer must still cross in one delegated `syswrite`
+//! (docs/internal/specs/behavior.md:81, "writer は 1 回の `syswrite` で
+//! frame 全体を書き").
+
+use std::time::Duration;
+
+use crate::host::Host;
+
+#[test]
+fn overflow_payload_delegates_in_one_frame_and_renders() {
+    let mut host = Host::boot_with_overflow();
+
+    let queued_before = host.log_count("worker: queued request_id=");
+    host.send_keys("ls fx/overflow/");
+    assert!(
+        host.expect("0000-marker.txt", Duration::from_secs(15)),
+        "(fifo-1a) list not displayed for an over-capacity payload"
+    );
+
+    assert!(
+        host.wait_log(
+            "worker: queued request_id=",
+            queued_before,
+            Duration::from_secs(5)
+        ),
+        "(fifo-1b) no 'worker: queued request_id=' log line for the overflow request"
+    );
+    let line = host
+        .last_log_line("worker: queued request_id=")
+        .expect("(fifo-1b) queued-request log line vanished after wait_log succeeded");
+    let bytes: usize = line
+        .rsplit_once("bytes=")
+        .and_then(|(_, rest)| rest.split_whitespace().next())
+        .and_then(|token| token.parse().ok())
+        .unwrap_or_else(|| panic!("(fifo-1b) no bytes= field in {line:?}"));
+    assert!(
+        bytes > 65536,
+        "(fifo-1b) queued frame was not actually over-capacity (need > 65536): bytes={bytes} line={line:?}"
+    );
+}

--- a/tests/driver/fixtures.rs
+++ b/tests/driver/fixtures.rs
@@ -1,11 +1,15 @@
 //! Per-test candidate trees, created under the host's isolated `$HOME`.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 /// Width that forces the grid to a single column at 80 terminal columns, so
 /// select-left/right land on the group's first/last position deterministically.
 const LONGCOL_PAD: usize = 90;
+/// Entries sized to overflow the request-FIFO buffer on either platform
+/// (8192 bytes macOS / 65536 Linux) once collected into a candidate_payload.
+const OVERFLOW_ITEMS: u32 = 7000;
 
 pub fn build(home: &Path) {
     // fx/basic: two candidates sharing a prefix, plus a subdirectory for the
@@ -36,4 +40,46 @@ fn touch(path: &Path) {
     let parent = path.parent().expect("fixture path has a parent");
     fs::create_dir_all(parent).unwrap_or_else(|e| panic!("create {}: {e}", parent.display()));
     fs::File::create(path).unwrap_or_else(|e| panic!("create {}: {e}", path.display()));
+}
+
+/// `0000-marker.txt` sorts first, so it always lands in the rendered listing
+/// no matter how the grid clips.
+/// Built at a deterministic path under `target/` so the tree survives across
+/// runs instead of being rebuilt every time; `OnceLock` gives one build check
+/// per process.
+fn overflow_tree() -> &'static Path {
+    static OVERFLOW: OnceLock<PathBuf> = OnceLock::new();
+    OVERFLOW.get_or_init(|| {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/tmp/zrush-overflow-fixture");
+        ensure_overflow_tree(&dir);
+        dir
+    })
+}
+
+/// Rebuild only when the entry count doesn't already match (same caching idea
+/// as `ensure_many_dir` in tests/zsh/driver-coexist.zsh), so a repeated test
+/// run reuses the tree instead of recreating 7001 files every time.
+fn ensure_overflow_tree(dir: &Path) {
+    let want = OVERFLOW_ITEMS as usize + 1; // + 0000-marker.txt
+    let have = fs::read_dir(dir)
+        .map(|entries| entries.count())
+        .unwrap_or(0);
+    if have == want {
+        return;
+    }
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap_or_else(|e| panic!("create {}: {e}", dir.display()));
+    touch(&dir.join("0000-marker.txt"));
+    for n in 1..=OVERFLOW_ITEMS {
+        touch(&dir.join(format!("item-{n:04}.txt")));
+    }
+}
+
+/// Symlink the shared overflow tree into `home`'s `fx/overflow`.
+pub fn link_overflow(home: &Path) {
+    let fx = home.join("fx");
+    fs::create_dir_all(&fx).unwrap_or_else(|e| panic!("create {}: {e}", fx.display()));
+    let link = fx.join("overflow");
+    std::os::unix::fs::symlink(overflow_tree(), &link)
+        .unwrap_or_else(|e| panic!("symlink overflow tree at {}: {e}", link.display()));
 }

--- a/tests/driver/host.rs
+++ b/tests/driver/host.rs
@@ -18,7 +18,11 @@ pub mod keys {
     pub const RIGHT: &str = "\x1b[C";
     pub const LEFT: &str = "\x1b[D";
     pub const ENTER: &str = "\r";
+    pub const TAB: &str = "\t";
+    pub const DISMISS: &str = "\x07";
+    pub const SEND_BREAK: &str = "\x03";
     pub const DUMP_BUFFER: &str = "\x18b";
+    pub const DUMP_POSTDISPLAY: &str = "\x18p";
     pub const DUMP_RH: &str = "\x18h";
     pub const CURSOR_LEFT_THREE: &str = "\x18v";
 }
@@ -29,12 +33,13 @@ const POLL: Duration = Duration::from_millis(50);
 /// Cadence at which log-watching loops re-read the log, draining in between.
 const LOG_POLL: Duration = Duration::from_millis(150);
 const DUMP_DEADLINE: Duration = Duration::from_secs(8);
-/// Set to print per-host startup timings; see tmp/issue-76-rust-driver.
+/// Set to make `Host::drop` print each host's boot/worker-ready timings.
 const TIMING_ENV: &str = "ZRUSH_DRIVER_TIMING";
 
 pub struct Host {
     tmp: Option<TempDir>,
     log: PathBuf,
+    xdg: PathBuf,
     pty: Pty,
     child: Child,
     /// Observation window (#63): everything the host has emitted since the
@@ -47,6 +52,17 @@ pub struct Host {
 
 impl Host {
     pub fn boot() -> Self {
+        Self::boot_with(|_home| {})
+    }
+
+    /// Like [`Host::boot`], but symlinks the shared 7001-file overflow tree
+    /// (built once per process, cached under `target/`) into `fx/overflow`
+    /// under the host's home.
+    pub fn boot_with_overflow() -> Self {
+        Self::boot_with(fixtures::link_overflow)
+    }
+
+    fn boot_with(extra_fixtures: impl FnOnce(&Path)) -> Self {
         let tmp = TempDir::new().expect("create work dir");
         let home = tmp.path().join("home");
         let work = tmp.path().join("work");
@@ -57,6 +73,7 @@ impl Host {
         fs::create_dir_all(&zdot).expect("create zdotdir");
         fs::create_dir_all(xdg.join("zrush")).expect("create config dir");
         fixtures::build(&home);
+        extra_fixtures(&home);
 
         let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
         let rc = repo.join("tests/zsh/rc/minimal.zshrc");
@@ -92,6 +109,7 @@ impl Host {
         let mut host = Self {
             tmp: Some(tmp),
             log,
+            xdg,
             pty,
             child,
             window: Vec::new(),
@@ -113,6 +131,19 @@ impl Host {
         self.pty
             .write_all(keys.as_bytes())
             .expect("write keys to host pty");
+    }
+
+    /// Send a line of shell source for the host to execute (a definition, a
+    /// `compdef`, a `:` no-op to force a config-mtime recheck, ...), followed
+    /// by its terminating newline.
+    pub fn send_line(&mut self, line: &str) {
+        self.send_keys(&format!("{line}\n"));
+    }
+
+    /// `^U`: discard the current physical line without executing it.
+    pub fn clear_line(&mut self) {
+        self.send_keys("\x15");
+        self.drain(Duration::from_millis(200));
     }
 
     /// Read the pty for `how_long`. Every wait loop calls this: a host that is
@@ -146,14 +177,33 @@ impl Host {
             || contains(&strip_sgr(&self.window), text.as_bytes())
     }
 
+    /// Like [`Host::expect`], but for callers that (like the zsh driver's
+    /// occasional `'*a*b*c*'` pattern) only need `needles` to appear in order,
+    /// not contiguously: a zle redraw between two keystrokes' echoes can
+    /// interleave escape sequences the caller does not care about.
+    pub fn expect_in_order(&mut self, needles: &[&str], timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if in_order(&self.window, needles) || in_order(&strip_sgr(&self.window), needles) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            let chunk = self.pty.read_available(POLL);
+            self.window.extend_from_slice(&chunk);
+        }
+    }
+
     fn window_tail(&self) -> String {
         let start = self.window.len().saturating_sub(300);
         String::from_utf8_lossy(&self.window[start..]).into_owned()
     }
 
-    pub fn sync_prompt(&mut self, timeout: Duration) {
-        self.expect("HP>", timeout);
+    pub fn sync_prompt(&mut self, timeout: Duration) -> bool {
+        let ok = self.expect("HP>", timeout);
         self.drain(Duration::from_millis(100));
+        ok
     }
 
     pub fn press(&mut self, keys: &str) {
@@ -172,6 +222,15 @@ impl Host {
             .split(|&b| b == b'\n')
             .filter(|line| contains(line, needle.as_bytes()))
             .count()
+    }
+
+    /// The freshest log line containing `needle` (`grep -F | tail -1` semantics).
+    pub fn last_log_line(&self, needle: &str) -> Option<String> {
+        let bytes = fs::read(&self.log).ok()?;
+        bytes
+            .split(|&b| b == b'\n')
+            .rfind(|line| contains(line, needle.as_bytes()))
+            .map(|line| String::from_utf8_lossy(line).into_owned())
     }
 
     pub fn wait_log(&mut self, needle: &str, baseline: usize, timeout: Duration) -> bool {
@@ -241,12 +300,7 @@ impl Host {
         while Instant::now() < deadline {
             self.send_keys(key);
             if self.wait_log(&needle, baseline, Duration::from_secs(1)) {
-                let bytes = fs::read(&self.log).expect("read host log");
-                let last = bytes
-                    .split(|&b| b == b'\n')
-                    .rfind(|line| contains(line, needle.as_bytes()))
-                    .map(|line| String::from_utf8_lossy(line).into_owned())
-                    .expect("matching log line");
+                let last = self.last_log_line(&needle).expect("matching log line");
                 let value = last
                     .split_once(&needle)
                     .expect("log line carries the tag")
@@ -268,6 +322,19 @@ impl Host {
     /// zsh tags its own region_highlight entries with `memo=` only from 5.9 on.
     pub fn has_memo(&self) -> bool {
         zsh_version() >= (5, 9)
+    }
+
+    // ---- per-test config (tab: `[insert].tab` needs a non-default value) ----
+
+    /// Config lives solely at `$XDG_CONFIG_HOME/zrush/config.toml`
+    /// (docs/internal/specs/config-schema.md); write it directly rather than
+    /// exercising `zrush config`'s own CLI, since that path is `tests/cli.rs`'s.
+    pub fn write_config(&self, toml: &str) {
+        fs::write(self.config_path(), toml).expect("write config.toml");
+    }
+
+    fn config_path(&self) -> PathBuf {
+        self.xdg.join("zrush/config.toml")
     }
 
     // ---- failure evidence and measurement ----
@@ -351,6 +418,26 @@ fn contains(haystack: &[u8], needle: &[u8]) -> bool {
         && haystack.windows(needle.len()).any(|w| w == needle)
 }
 
+/// Whether every one of `needles` occurs in `haystack`, each strictly after
+/// the previous match ends.
+fn in_order(haystack: &[u8], needles: &[&str]) -> bool {
+    let mut pos = 0;
+    for needle in needles {
+        let bytes = needle.as_bytes();
+        if bytes.is_empty() {
+            return false;
+        }
+        match haystack
+            .get(pos..)
+            .and_then(|rest| rest.windows(bytes.len()).position(|w| w == bytes))
+        {
+            Some(offset) => pos += offset + bytes.len(),
+            None => return false,
+        }
+    }
+    true
+}
+
 /// Drop each SGR sequence together with the NUL run that follows it (some
 /// terminfo entries pad every SGR with NULs, #64). Unrelated literal NULs stay.
 fn strip_sgr(bytes: &[u8]) -> Vec<u8> {
@@ -383,7 +470,7 @@ fn strip_sgr(bytes: &[u8]) -> Vec<u8> {
 /// multibyte characters stay raw. Decoding builds a byte string and validates
 /// it once, so a dumped value that is not UTF-8 -- or an escape form zsh is not
 /// known to produce -- fails loudly instead of turning into plausible garbage.
-fn unquote(text: &str) -> String {
+pub(crate) fn unquote(text: &str) -> String {
     let body = text
         .strip_prefix("$'")
         .and_then(|rest| rest.strip_suffix('\''))

--- a/tests/driver/main.rs
+++ b/tests/driver/main.rs
@@ -5,8 +5,15 @@
 //! candidates, ships them to the persistent worker, and applies the returned
 //! plan to POSTDISPLAY/region_highlight/BUFFER under real key input.
 
+mod apply;
+mod async_plumbing;
+mod cache;
 mod confirm;
+mod dismiss;
+mod fifo;
 mod fixtures;
 mod host;
 mod pty;
 mod select;
+mod sendbreak;
+mod tab;

--- a/tests/driver/sendbreak.rs
+++ b/tests/driver/sendbreak.rs
@@ -1,0 +1,37 @@
+//! Regression: send-break leaves a clean new prompt (fix 3). An exit that
+//! bypasses `_zrush_line_finish` (send-break and similar) must not leak the
+//! previous session's plan state into the next one.
+//!
+//! The 15s prompt-resync deadline is sized against an observed >5s pty-^C
+//! interrupt-handling cost on a loaded host (#47).
+
+use std::time::Duration;
+
+use crate::host::{Host, PlanShape, keys};
+
+#[test]
+fn send_break_resets_plan_state_for_the_next_prompt() {
+    let mut host = Host::boot();
+    // A test-only widget dumps _zrush_plan_npos/_zrush_listing directly, since
+    // neither is observable through POSTDISPLAY/BUFFER alone once the new
+    // prompt's line-init has already cleared the display.
+    host.send_line(
+        r#"_zrt_dump_plan() { _zlog "TESTPLAN=npos=$_zrush_plan_npos listing=$_zrush_listing" }; zle -N _zrt-dump-plan _zrt_dump_plan; bindkey "^Xy" _zrt-dump-plan"#,
+    );
+    host.sync_prompt(Duration::from_secs(5));
+
+    host.send_keys_wait_plan(PlanShape::Nonempty, "ls fx/basic/al"); // real, non-empty _zrush_plan_* now populated
+    host.send_keys(keys::SEND_BREAK); // send-break: abandon the line, bypassing line-finish
+    assert!(
+        host.sync_prompt(Duration::from_secs(15)),
+        "(sb-1a) no new prompt appeared after send-break"
+    );
+
+    let plan = host
+        .dump_get("\x18y", "TESTPLAN")
+        .unwrap_or_else(|| panic!("(sb-1b) plan-state dump did not run"));
+    assert!(
+        plan.contains("npos=0") && plan.contains("listing=0"),
+        "(sb-1b) stale plan state survived send-break: {plan}"
+    );
+}

--- a/tests/driver/tab.rs
+++ b/tests/driver/tab.rs
@@ -1,0 +1,63 @@
+//! Tab: pending-before-candidates and `tab = "common-prefix"` over a
+//! leading dash run (docs/internal/specs/behavior.md "Tab", "候補収集"
+//! 「広げ規則」).
+
+use std::time::Duration;
+
+use crate::host::{Host, PlanShape, keys};
+
+#[test]
+fn pending_tab_starts_selection_once_candidates_arrive() {
+    // Default [insert].tab=menu, so a Tab that lands before candidates arrive
+    // must, once they arrive, start selection -- not change the buffer.
+    let mut host = Host::boot();
+    let pending_baseline = host.log_count("tab: pending");
+    let select_baseline = host.log_count("select: start");
+    host.send_keys("ls fx/basic/al\t"); // Tab in the same burst, before debounce elapses
+    assert!(
+        host.wait_log("tab: pending", pending_baseline, Duration::from_secs(3)),
+        "(tab-1a) pending path not logged"
+    );
+    assert!(
+        host.wait_log("select: start", select_baseline, Duration::from_secs(5)),
+        "(tab-1b) pending Tab was not applied on arrival"
+    );
+}
+
+/// `[insert].tab = "common-prefix"` over a leading dash run. The widening
+/// rule keeps the run in the collection string so compsys yields option
+/// candidates, and compsys returns those dash-included; the run must
+/// therefore stay in the query too, or the common-prefix insertion prepends a
+/// second dash (behavior.md "広げ規則"). A compdef fixture pins the candidate
+/// set: the real `ls -` option list differs per platform.
+#[test]
+fn common_prefix_tab_over_a_leading_dash_run_does_not_double_the_dash() {
+    let mut host = Host::boot();
+    host.send_line("_zrushtestopt() { local -a m=(-alpha -alt); compadd -a m }");
+    host.sync_prompt(Duration::from_secs(5));
+    host.send_line("compdef _zrushtestopt zrushtestopt");
+    host.sync_prompt(Duration::from_secs(5));
+    host.write_config("[insert]\ntab = \"common-prefix\"\n");
+    host.send_line(":");
+    host.sync_prompt(Duration::from_secs(5));
+
+    host.send_keys_wait_plan(PlanShape::Nonempty, "zrushtestopt -");
+    let applied_baseline = host.log_count("plan: applied");
+    host.press(keys::TAB);
+    host.assert_buffer(
+        "zrushtestopt -al",
+        "(tab-2a) tab=common-prefix over a lone '-' inserts the common prefix without doubling the dash",
+    );
+
+    // The partial insertion is not a confirmation: it retriggers collection,
+    // and that second listing is what the Tab below acts on.
+    assert!(
+        host.wait_log("plan: applied", applied_baseline, Duration::from_secs(5)),
+        "(tab-2b) the common-prefix insertion did not retrigger collection"
+    );
+    host.press(keys::TAB);
+    host.assert_buffer(
+        "zrushtestopt -alpha ",
+        "(tab-2b) a common-prefix that no longer grows falls back to confirming the top candidate",
+    );
+}

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -46,7 +46,6 @@ setopt extended_glob
 zmodload zsh/zpty    || { print -u2 FATAL: zpty; exit 1 }
 zmodload zsh/zselect || { print -u2 FATAL: zselect; exit 1 }
 zmodload zsh/system  || { print -u2 FATAL: system; exit 1 }
-autoload -Uz is-at-least
 
 typeset -F SECONDS
 typeset -g HERE=${${(%):-%N}:A:h}
@@ -57,7 +56,7 @@ typeset -g PLAYGROUND=${1:?usage: driver.zsh <playground-dir> [section ...]}
 # Canonical execution order of the test sections. Any sections named on the
 # command line run in this order, never in argument order; an empty selection
 # means every section.
-typeset -ga SECTIONS=( capture fifo async apply dismiss cache tab sendbreak death hist jobtable inflight )
+typeset -ga SECTIONS=( capture death hist jobtable inflight )
 typeset -gA PICKED=()
 for SECTION_ARG in "${@[2,-1]}"; do
   (( ${SECTIONS[(I)$SECTION_ARG]} )) || { print -u2 "FATAL: unknown section '$SECTION_ARG' (valid: $SECTIONS)"; exit 1 }
@@ -81,7 +80,6 @@ ok()  { out "PASS: $1"; (( ++PASS )) }
 ng()  { out "FAIL: $1"; (( ++FAIL )) }
 # SKIP: a check this environment could not run; OBSV: a non-failing observation.
 typeset -gi SKIP=0 OBSV=0
-skip() { out "SKIP: $1"; (( ++SKIP )) }
 obsv() { out "OBSV: $1"; (( ++OBSV )) }
 
 typeset -g WORK=$(mktemp -d ${TMPDIR:-/tmp}/zrush-test.XXXXXX)
@@ -120,13 +118,6 @@ typeset -gi FAKE_DRAIN_TAIL_BYTES=8388608
 export ZRUSH_HISTORY_DEADLINE_MS=5000
 
 print "source $REPO/tests/zsh/rc/minimal.zshrc" > $ZDOTDIR/.zshrc
-
-# Whether this zsh build can tag region_highlight entries with memo=zrush
-# (cli-protocol.md / behavior.md "region_highlight の自エントリ"); on 5.8 the
-# ^Xh dump still lists this plugin's own entries (via the internal _zrush_rh
-# ledger, not memo filtering), so only the memo-suffix assertion is gated.
-typeset -gi HAVE_MEMO=0
-is-at-least 5.9 $ZSH_VERSION && HAVE_MEMO=1
 
 # ---------------------------------------------------------------- Fixtures
 # fx/basic: two candidates sharing a prefix (for match-highlight/selection
@@ -748,250 +739,6 @@ sec_capture() {
   fi
   clear_line
   drain 0.3
-}
-
-sec_fifo() {
-  # ================================================================ FIFO-capacity frame delegation
-  # (fifo-1a/b) fx/overflow's candidate_payload is well over the request-FIFO
-  # buffer on either platform (8192 bytes on macOS, 65536 on Linux), so it can
-  # only reach the worker if the writer child actually delegates the whole
-  # frame in one syswrite (behavior.md worker-lifecycle "1 フレームの送信は...
-  # 委譲する"); a naive blocking write from the parent would deadlock instead
-  # of rendering.
-  log_count 'worker: queued request_id='; local -i overflow_queued_before=$REPLY
-  send_keys 'ls fx/overflow/'
-  if expect '*0000-marker.txt*' 15; then
-    ok "(fifo-1a) a candidate_payload larger than the FIFO buffer still crosses in one delegated write and renders"
-  else
-    ng "(fifo-1a) list not displayed for an over-capacity payload"
-  fi
-  if wait_log 'worker: queued request_id=' $overflow_queued_before 5; then
-    local overflow_queued_line=$(grep -F 'worker: queued request_id=' $ZRUSH_LOG 2>/dev/null | tail -1)
-    local -i overflow_frame_bytes=${${overflow_queued_line##*bytes=}%% *}
-    if (( overflow_frame_bytes > 65536 )); then
-      ok "(fifo-1b) the queued frame's byte count ($overflow_frame_bytes) actually exceeded the FIFO buffer on both platforms (8192 macOS / 65536 Linux)"
-    else
-      ng "(fifo-1b) queued frame was not actually over-capacity (need > 65536): bytes=$overflow_frame_bytes line=${overflow_queued_line:-<none>}"
-    fi
-  else
-    ng "(fifo-1b) no 'worker: queued request_id=' log line for the overflow request"
-  fi
-  clear_line
-  drain 0.3
-}
-
-sec_async() {
-  # ================================================================ (2) Async plumbing does not block input
-  # A fake completion function that sleeps inside the fork; the parent shell
-  # must keep echoing keystrokes while it runs.
-  send_line '_zrushtestslow() { local -a m=(slowcandA slowcandB slowcandC); sleep 0.5; compadd -a m }'
-  sync_prompt
-  send_line 'compdef _zrushtestslow zrushtestslow'
-  sync_prompt
-  send_keys 'zrushtestslow '
-  drain 0.4                     # let debounce elapse and the fork start (still sleeping)
-  local -F t0=$SECONDS
-  send_keys 'zzz'                # typed while the fork is asleep
-  if expect '*z*z*z*' 2; then
-    ok "(async-1a) input keeps echoing while a slow fork collection is in flight ($(( SECONDS - t0 ))s)"
-  else
-    ng "(async-1a) input blocked during slow collection"
-  fi
-  clear_line
-  drain 0.8                      # let the stale in-flight collection settle (cancelled)
-  send_keys 'zrushtestslow '
-  if expect '*slowcandA*' 5; then
-    ok "(async-1b) the pipeline completes end-to-end once the slow fork finishes"
-  else
-    ng "(async-1b) slow-completion candidates never rendered"
-  fi
-  clear_line
-  drain 0.3
-}
-
-sec_apply() {
-  # ================================================================ (3) Plan application: POSTDISPLAY + region_highlight
-  send_keys_wait_plan nonempty 'ls fx/basic/al'
-  if dump_get $'\C-xp' TESTPOST; then
-    local post=${(Q)REPLY}
-    if [[ $post == $'\n'* && $post == *alpha.txt* && $post == *alsoalpha.txt* ]]; then
-      ok "(apl-1a) POSTDISPLAY = leading newline + listing text for both candidates"
-    else
-      ng "(apl-1a) POSTDISPLAY malformed: ${(qqqq)post}"
-    fi
-  else
-    ng "(apl-1a) POSTDISPLAY dump did not run"
-  fi
-  if dump_get $'\C-xh' TESTRH; then
-    if [[ $REPLY == *underline* ]]; then
-      ok "(apl-1b) region_highlight carries a match-role entry mapped to the default 'underline' spec"
-    else
-      ng "(apl-1b) no match-role highlight found: ${REPLY:-<none>}"
-    fi
-    if (( ! HAVE_MEMO )) || [[ $REPLY == *memo=zrush* ]]; then
-      ok "(apl-1c) region_highlight entries are memo-tagged (or zsh<5.9, where memo is unavailable)"
-    else
-      ng "(apl-1c) memo=zrush missing on zsh >=5.9: ${REPLY:-<none>}"
-    fi
-  else
-    ng "(apl-1b/c) region_highlight dump did not run"
-  fi
-  clear_line
-  drain 0.3
-}
-
-sec_dismiss() {
-  # ================================================================ (6) dismiss / accept-line
-  send_keys_wait_plan nonempty 'ls fx/basic/'
-  log_count 'dismiss: closing list'; local -i c_dis=$REPLY
-  press $'\C-g'
-  wait_log 'dismiss: closing list' $c_dis 3 && ok "(dis-1a) dismiss closes the list" || ng "(dis-1a) dismiss did not work"
-  assert_buffer 'ls fx/basic/' "(dis-1b) buffer is unchanged after dismiss"
-  clear_line
-  drain 0.3
-
-  # Regression (dis-2): dismiss must cancel any still-armed debounce timer /
-  # in-flight collection for a newer keystroke, or a late-arriving result can
-  # silently reopen the list right after the user closed it. Reproduced with
-  # git's naturally slow (~150ms+) subcommand completion -- no extra fixture
-  # needed. The buffer edit below never goes through a blank state, so the
-  # first (broader) list stays visible (no-flash design) while the narrowing
-  # 'git chec' collection is armed/in flight; dismissing at that instant must
-  # win the race even though the narrower collection is still pending.
-  send_keys_wait_plan nonempty 'git c'   # first list applied; _zrush_listing=1
-  send_keys 'hec'                     # -> 'git chec': re-arms debounce/collection
-  send_keys $'\C-g'                   # dismiss immediately, no drain in between
-  drain 1.0                           # comfortably longer than 'git chec' compsys (~150-200ms)
-  if dump_get $'\C-xp' TESTPOST; then
-    local post_dis2=${(Q)REPLY}
-    if [[ -z $post_dis2 ]]; then
-      ok "(dis-2) dismiss cancels the in-flight collection; no late result reopens the list"
-    else
-      ng "(dis-2) list reappeared after dismiss (stale collection not cancelled): ${(qqqq)post_dis2}"
-    fi
-  else
-    ng "(dis-2) POSTDISPLAY dump did not run"
-  fi
-  clear_line
-  drain 0.3
-
-  log_count 'line-finish: cleared'; local -i c_fin=$REPLY
-  send_keys 'print HISTMARK-ACCEPT'
-  send_keys $'\r'
-  if expect '*HISTMARK-ACCEPT*' 5; then
-    ok "(acc-1a) Enter without a selection executes the command via the predecessor chain"
-  else
-    ng "(acc-1a) command did not execute"
-  fi
-  sync_prompt
-  wait_log 'line-finish: cleared' $c_fin 3 && ok "(acc-1b) accept-line resets zrush state (line-finish)" || ng "(acc-1b) line-finish not logged after accept-line"
-}
-
-sec_cache() {
-  # ================================================================ (7) Empty-word collection cache: no fork on hit
-  clear_line
-  drain 0.5
-  send_keys_wait_plan nonempty 'whic'
-  clear_line
-  drain 0.5
-  log_count 'cache: hit';          local -i cc_hit=$REPLY
-  log_count 'request: collecting'; local -i cc_col=$REPLY
-  send_keys 'whic'
-  if wait_log 'cache: hit' $cc_hit 5; then
-    ok "(cc-1a) second command-position query hits the empty-word cache"
-  else
-    ng "(cc-1a) cache hit not logged"
-  fi
-  drain 0.5
-  log_count 'request: collecting'; local -i cc_col2=$REPLY
-  if (( cc_col2 == cc_col )); then
-    ok "(cc-1b) no new fork is started on a cache hit ($cc_col -> $cc_col2)"
-  else
-    ng "(cc-1b) a fork ran despite the expected cache hit ($cc_col -> $cc_col2)"
-  fi
-  clear_line
-  drain 0.3
-}
-
-sec_tab() {
-  # ================================================================ (8) Tab pending
-  # Default [insert].tab=menu, so a Tab that lands before candidates arrive
-  # must, once they arrive, start selection -- not change the buffer.
-  log_count 'tab: pending'; local -i c_pend=$REPLY
-  log_count 'select: start'; local -i c_tstart=$REPLY
-  send_keys 'ls fx/basic/al'$'\t'   # Tab in the same burst, before debounce elapses
-  wait_log 'tab: pending' $c_pend 3 && ok "(tab-1a) Tab pressed before candidates arrive is recorded (pending)" || ng "(tab-1a) pending path not logged"
-  if wait_log 'select: start' $c_tstart 5; then
-    ok "(tab-1b) once candidates arrive, the pending Tab applies (menu -> selection starts)"
-  else
-    ng "(tab-1b) pending Tab was not applied on arrival"
-  fi
-  press $'\C-g'
-  clear_line
-  drain 0.3
-
-  # ---- (tab-2) [insert].tab=common-prefix over a leading dash run. The
-  # widening rule keeps the run in the collection string so compsys yields
-  # option candidates, and compsys returns those dash-included; the run must
-  # therefore stay in the query too, or the common-prefix insertion prepends a
-  # second dash (behavior.md "広げ規則"). A compdef fixture pins the candidate
-  # set: the real `ls -` option list differs per platform.
-  send_line '_zrushtestopt() { local -a m=(-alpha -alt); compadd -a m }'
-  sync_prompt
-  send_line 'compdef _zrushtestopt zrushtestopt'
-  sync_prompt
-  print -r -- $'[insert]\ntab = "common-prefix"' >| $XDG_CONFIG_HOME/zrush/config.toml
-  send_line ':'
-  sync_prompt
-  if send_keys_wait_plan nonempty 'zrushtestopt -'; then
-    log_count 'plan: applied'; local -i c_cp=$REPLY
-    press $'\t'
-    assert_buffer 'zrushtestopt -al' "(tab-2a) tab=common-prefix over a lone '-' inserts the common prefix without doubling the dash"
-    # The partial insertion is not a confirmation: it retriggers collection,
-    # and that second listing is what the Tab below acts on.
-    if wait_log 'plan: applied' $c_cp 5; then
-      press $'\t'
-      assert_buffer 'zrushtestopt -alpha ' "(tab-2b) a common-prefix that no longer grows falls back to confirming the top candidate"
-    else
-      ng "(tab-2b) the common-prefix insertion did not retrigger collection"
-    fi
-  fi
-  clear_line
-  rm -f $XDG_CONFIG_HOME/zrush/config.toml
-  send_line ':'
-  sync_prompt
-  drain 0.3
-}
-
-sec_sendbreak() {
-  # ================================================================ Regression: send-break leaves a clean new prompt (fix 3)
-  # An exit that bypasses _zrush_line_finish (send-break and similar) must
-  # not leak the previous session's plan state into the next one. A
-  # test-only widget dumps _zrush_plan_npos/_zrush_listing directly, since
-  # neither is observable through POSTDISPLAY/BUFFER alone once the new
-  # prompt's line-init has already cleared the display.
-  send_line '_zrt_dump_plan() { _zlog "TESTPLAN=npos=$_zrush_plan_npos listing=$_zrush_listing" }; zle -N _zrt-dump-plan _zrt_dump_plan; bindkey "^Xy" _zrt-dump-plan'
-  sync_prompt
-  send_keys_wait_plan nonempty 'ls fx/basic/al'   # real, non-empty _zrush_plan_* now populated
-  send_keys $'\C-c'                    # send-break: abandon the line, bypassing line-finish
-  if sync_prompt 15; then
-    ok "(sb-1a) a new prompt appears after send-break"
-    if dump_get $'\C-xy' TESTPLAN; then
-      if [[ $REPLY == *'npos=0'* && $REPLY == *'listing=0'* ]]; then
-        ok "(sb-1b) plan state is reset after send-break (npos=0, listing=0); no stale candidates leak into the new prompt"
-      else
-        ng "(sb-1b) stale plan state survived send-break: ${REPLY:-<none>}"
-      fi
-    else
-      ng "(sb-1b) plan-state dump did not run"
-    fi
-  else
-    skip "(sb-1) send-break did not produce a new prompt in this environment; skipping the plan-state check"
-  fi
-  clear_line
-  drain 0.3
-  send_line 'bindkey -r "^Xy"; zle -D _zrt-dump-plan; unfunction _zrt_dump_plan'
-  sync_prompt
 }
 
 sec_death() {


### PR DESCRIPTION
Closes #103. Milestone 2 of the driver migration decided in #76; stacked on the #101 PR.

Ports the seven small `driver.zsh` sections (`fifo`, `async`, `apply`, `dismiss`, `cache`, `tab`, `sendbreak`, 20 checks) to the Rust harness and deletes them from the zsh driver, together with the helpers they were the last consumers of (`HAVE_MEMO`, `is-at-least`, `skip()`).
Harness gains: the 7001-file overflow fixture at a cached deterministic path under `target/tmp/` (shared read-only, rebuilt only on entry-count mismatch), `send_line`/`clear_line`, per-test `config.toml`, and an in-order-substring matcher.
The `cli-protocol.md` verification pointer for POSTDISPLAY assembly now names `tests/driver/apply.rs`.

Verification: cargo fmt/clippy/build/test green; remaining zsh suites green (`driver.zsh` PASS=131 FAIL=0, keybinds, vectors, transport); 10/10 consecutive `cargo test --test driver` runs green (14 tests, ~3.9 s parallel); no files leaked into the system temp dir.

---

# M2 parity: retired `driver.zsh` checks to Rust tests

Seven sections were deleted from `tests/zsh/driver.zsh` and their `SECTIONS` entries removed: `fifo`, `async`, `apply`, `dismiss`, `cache`, `tab`, `sendbreak`.
`fx/overflow` stays in `driver.zsh` (the `inflight` section still uses it).
Three items did become dead once those seven sections were gone and were deleted in review round 2: the `HAVE_MEMO` block (`is-at-least 5.9 $ZSH_VERSION`, whose sole reader was `sec_apply`'s apl-1c), the `autoload -Uz is-at-least` that block needed, and the `skip()` function (whose sole caller was `sec_sendbreak`'s sb-1 SKIP path).
The `SKIP`/`OBSV` counters, `obsv()`, and the `SUMMARY` line stay, since they are still live for the remaining sections and are part of the evidence-retention contract.
Every check the seven sections contained is now an assertion in `tests/driver/`.
Test paths are relative to the `driver` integration-test target, so `cargo test --test driver <name>` selects them.

| retired case | Rust test | assertion label |
| --- | --- | --- |
| fifo-1a | `fifo::overflow_payload_delegates_in_one_frame_and_renders` | `(fifo-1a) list not displayed for an over-capacity payload` |
| fifo-1b | `fifo::overflow_payload_delegates_in_one_frame_and_renders` | `(fifo-1b) queued frame was not actually over-capacity (need > 65536)` |
| async-1a | `async_plumbing::slow_fork_does_not_block_input_and_still_completes` | `(async-1a) input blocked during slow collection` |
| async-1b | `async_plumbing::slow_fork_does_not_block_input_and_still_completes` | `(async-1b) slow-completion candidates never rendered` |
| apl-1a | `apply::postdisplay_and_region_highlight_after_a_listing_plan` | `(apl-1a) POSTDISPLAY malformed` |
| apl-1b | `apply::postdisplay_and_region_highlight_after_a_listing_plan` | `(apl-1b) no match-role highlight found` |
| apl-1c | `apply::postdisplay_and_region_highlight_after_a_listing_plan` | `(apl-1c) memo=zrush missing on zsh >=5.9` |
| dis-1a | `dismiss::dismiss_closes_the_list_without_changing_the_buffer` | `(dis-1a) dismiss did not work` |
| dis-1b | `dismiss::dismiss_closes_the_list_without_changing_the_buffer` | `(dis-1b) buffer is unchanged after dismiss` |
| dis-2 | `dismiss::dismiss_cancels_an_in_flight_collection` | `(dis-2) list reappeared after dismiss (stale collection not cancelled)` |
| acc-1a | `dismiss::accept_line_executes_and_resets_zrush_state` | `(acc-1a) command did not execute` |
| acc-1b | `dismiss::accept_line_executes_and_resets_zrush_state` | `(acc-1b) line-finish not logged after accept-line` |
| cc-1a | `cache::second_command_position_query_hits_the_cache_without_forking` | `(cc-1a) cache hit not logged` |
| cc-1b | `cache::second_command_position_query_hits_the_cache_without_forking` | `(cc-1b) a fork ran despite the expected cache hit` |
| tab-1a | `tab::pending_tab_starts_selection_once_candidates_arrive` | `(tab-1a) pending path not logged` |
| tab-1b | `tab::pending_tab_starts_selection_once_candidates_arrive` | `(tab-1b) pending Tab was not applied on arrival` |
| tab-2a | `tab::common_prefix_tab_over_a_leading_dash_run_does_not_double_the_dash` | `(tab-2a) tab=common-prefix over a lone '-' inserts the common prefix without doubling the dash` |
| tab-2b | `tab::common_prefix_tab_over_a_leading_dash_run_does_not_double_the_dash` | `(tab-2b) a common-prefix that no longer grows falls back to confirming the top candidate` (plus the retrigger wait) |
| sb-1a | `sendbreak::send_break_resets_plan_state_for_the_next_prompt` | `(sb-1a) no new prompt appeared after send-break` |
| sb-1b | `sendbreak::send_break_resets_plan_state_for_the_next_prompt` | `(sb-1b) stale plan state survived send-break` |

Grouping: each originating `sec_*` function became one file (`fifo.rs`, `async_plumbing.rs` — `async` is a Rust keyword, `apply.rs`, `dismiss.rs`, `cache.rs`, `tab.rs`, `sendbreak.rs`).
Within a file, a multi-step scenario that shares host state (fifo-1a/b; async-1a/b; apl-1a/b/c; cc-1a/b; tab-1a/b; tab-2a/b; sb-1a/b) is one `#[test]`.
`sec_dismiss` held three independent scenarios (dismiss, dis-2's race, accept-line) chained on one host only by `clear_line`.
Following the M1 precedent for `sec_select`/`sec_confirm`, they became three tests, each with its own host.

## Harness additions

- `Host::boot_with_overflow()` (`tests/driver/host.rs`, `tests/driver/fixtures.rs`): the 7001-file overflow tree (`0000-marker.txt` + `item-0001..7000.txt`) is symlinked into each host's `fx/overflow`, instead of the zsh driver's shared-playground copy.
  `Host::boot()` and `boot_with_overflow()` both go through a new private `boot_with(extra_fixtures)` so the two constructors don't duplicate the spawn sequence.
  The tree itself is built at a deterministic path under `target/tmp/zrush-overflow-fixture` (not a fresh `tempfile::TempDir`) and reused across `cargo test` invocations, rebuilding only when its entry count doesn't already match — the same caching idea as `ensure_many_dir` in `tests/zsh/driver-coexist.zsh`.
  A `OnceLock<PathBuf>` still gives at most one build check per process; the earlier `OnceLock<TempDir>` leaked a full 7001-file tree into the system temp dir on every `cargo test --test driver` run, since nothing ever dropped it (fixed in review round 2; 29 such leaked trees, ~29 x 7001 files, were found and removed from this machine's temp dir as part of that fix).
- `Host::send_line` (source + newline) and `Host::clear_line` (`^U` + 200 ms drain), matching the zsh driver's `send_line`/`clear_line`.
  `reset_line` was not added: grep confirms none of the seven ported sections call it (only the still-`zsh`-side `hist`/`jobtable`/`inflight` sections do).
- `Host::sync_prompt` now returns whether the prompt actually appeared (was `()`); existing callers that ignore the result are unaffected.
  `sendbreak` uses the return value directly instead of the zsh driver's `skip`.
- `Host::write_config` writes `$XDG_CONFIG_HOME/zrush/config.toml` directly (config path resolution itself is `tests/cli.rs`'s job, per cli-protocol.md's own verification pointer); `tab`'s `[insert].tab = "common-prefix"` fixture uses it.
  A paired `remove_config` plus a transliterated `send_line(":")`/`sync_prompt` teardown was removed in review round 2: with one host per test there is nothing to clean up for a later case, and that `send_line(":")` was additionally wrong as written (it ran with the buffer still holding `zrushtestopt -alpha `, so it would have executed `zrushtestopt -alpha :` instead of a no-op).
- `Host::last_log_line` (extracted out of `dump_get`, which now calls it) backs `fifo`'s `bytes=` extraction from `worker: queued request_id=...`.
- `Host::expect_in_order` (small in-order-substring matcher, not a glob/regex engine): `async-1a`'s zsh check used the glob `'*z*z*z*'` because a zle redraw between echoed keystrokes is not guaranteed to keep them byte-contiguous.
  The M1 handoff anticipated this ("a case needing real wildcards needs a small matcher"); `expect_in_order(&["z", "z", "z"], ...)` checks the three keystrokes were echoed in order without pulling in a pattern engine (rejected design).
  Its `in_order` helper gained the same empty-needle guard `contains` already has, in review round 2 (`[u8]::windows(0)` panics otherwise).
- `host::unquote` (the `${(qqqq)}` decoder used internally by `assert_buffer`) is now `pub(crate)` so `apply.rs` and `dismiss.rs` can decode raw `TESTPOST` dumps themselves, the same way `dis-2`/`apl-1a` need to inspect `POSTDISPLAY` text rather than just compare it.
- `keys::TAB`, `keys::DISMISS`, `keys::SEND_BREAK`, `keys::DUMP_POSTDISPLAY` added alongside the existing key constants.
- Review round 2 also corrected two wrong citations: `fixtures.rs`/`host.rs` no longer cite #63 (the expect/drain observation-window issue) for the overflow fixture, and instead say what's true (7001 entries sized to overflow both FIFO capacities; `0000-marker.txt` sorts first); the ARG_MAX rationale was dropped too, since it explained a zsh argv constraint the Rust builder (no argv, just `fs::File::create` calls) never had.
  `fifo.rs` no longer quotes behavior.md text that doesn't exist ("1 フレームの送信は... 委譲する", which greps to zero hits since behavior.md spells "frame" in Latin) and instead points at the real sentence, behavior.md:81's "writer は 1 回の `syswrite` で frame 全体を書き".
  `async_plumbing.rs`'s module doc now cites behavior.md:27's 「入力は決してブロックしない」 instead of AGENTS.md, which doesn't carry that principle.
- `sendbreak.rs`'s module doc no longer narrates migration history or cites `tmp/issue-76-rust-driver/m2-parity.md` (a file that never enters the repository); it now states only the live constraint (the 15s deadline's #47 sizing).
  Its trailing `bindkey -r`/`zle -D`/`unfunction` cleanup was also removed: a per-test host dies with the test, so unbinding a key on a host about to be torn down did nothing.

## Behavior differences and strengthenings from the retired checks

- **cc-1a/1b needed an extra warm-up round not in the zsh check.** Ported literally (two `whic` collections, second expected to hit the cache), it failed.
  A host's very first completion lazy-loads at least one compsys function, changing the function-count fingerprint the empty-word cache checks, which behavior.md's "空語収集キャッシュ" 「既知の癖」 already documents as a one-time extra miss.
  The zsh driver never hit this because `sec_cache` always ran after `sec_capture` and others had already exercised completion on the same host; each Rust test gets a fresh host, so it hits the quirk cold.
  The port adds one more `whic` round before the pair the assertions cover, absorbing the quirk, and comments the reason at the call site.
  This is a byproduct of per-test host isolation, not a change to what's being asserted.
- **sendbreak's SKIP became a hard assertion.** `sec_sendbreak`'s zsh check did `sync_prompt 15 || skip "..."`, but nothing in its comments or behavior.md gives a case where a post-send-break prompt legitimately never appears — the 15s deadline itself already accounts for the documented >5s pty-^C cost on a loaded host (#47).
  `sendbreak::send_break_resets_plan_state_for_the_next_prompt` asserts instead of tolerating a miss; see `tests/driver/sendbreak.rs`'s module doc for the same reasoning inline.
  No occurrence of this timing out has been observed in the runs recorded below.
- No vacuous checks (the M1-style always-true pattern) were found among the seven sections' ~20 checks; all were substantive baseline/growth or exact-value assertions already.

## Doc pointer fixed (was flagged, now resolved)

`docs/internal/contracts/cli-protocol.md`'s verification blockquote under "適用(zsh 側の規範)" named `tests/zsh/driver.zsh` for POSTDISPLAY assembly, which is now `tests/driver/apply.rs` (`apl-1a`).
This was originally flagged here as an open question because `docs/` looked out of this task's file scope, but the orchestrator confirmed the doc update was in scope and it has since been applied.
The blockquote now reads:

> 検証: いずれも実際の zle 配線に対するスモークテスト(`cargo test --test driver`)。
> `POSTDISPLAY` の組み立て — `tests/driver/apply.rs`。
> 補完一覧の確定時の `LBUFFER` 置換と `RBUFFER` 保持 — `tests/driver/confirm.rs`。

(The trailing `cargo test --test driver` line the first pass added separately was folded into the summary line in review round 2, since 「いずれも」 had ended up stated twice across the four lines.)

No other verification pointer in `cli-protocol.md`/`behavior.md` names any of the seven retired sections specifically (checked by grepping for `driver.zsh`, `検証:`, and each section's own log-message vocabulary).
The remaining three `cli-protocol.md` references to `tests/zsh/driver.zsh` (lines 591, 622, 701) describe sections/behavior that stay in `driver.zsh` (`death`'s discard/warn-once, generic keybind-smoke-testing, and the test launcher's `$ZRUSH_BIN` path) and are unaffected.

## Verification

```
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo build --release
cargo test
zsh -f tests/zsh/driver.zsh "$(mktemp -d)"      # SUMMARY: PASS=131 FAIL=0 SKIP=0 OBSV=1
zsh -f tests/zsh/keybinds.zsh "$(mktemp -d)"    # keybinds: 4 passed, 0 failed
zsh -f tests/zsh/vectors.zsh                    # SUMMARY: PASS=74 FAIL=0
zsh -f tests/zsh/transport.zsh                  # SUMMARY: PASS=18 FAIL=0
zsh -f tests/zsh/driver-coexist.zsh "$(mktemp -d)"  # SUMMARY: PASS=37 FAIL=0 SKIP=0 (local-only; run for thoroughness, not required by this milestone's file scope)
```

All green; `cargo test` runs the full workspace suite (205 lib tests + `cli.rs` + `driver` + `vectors.rs` + `worker_control.rs`) with no failures.

### `cargo test --test driver` repeat runs (10 consecutive, Apple M3)

Default parallelism (14 tests: 4 from M1 + 10 new):

```
run 1:  ok, 14 passed, 3.97s
run 2:  ok, 14 passed, 3.87s
run 3:  ok, 14 passed, 3.92s
run 4:  ok, 14 passed, 4.36s
run 5:  ok, 14 passed, 4.02s
run 6:  ok, 14 passed, 3.89s
run 7:  ok, 14 passed, 3.90s
run 8:  ok, 14 passed, 3.94s
run 9:  ok, 14 passed, 3.94s
run 10: ok, 14 passed, 3.98s
```

Serial (`--test-threads=1`):

```
run 1:  ok, 14 passed, 23.89s
run 2:  ok, 14 passed, 22.18s
run 3:  ok, 14 passed, 22.31s
run 4:  ok, 14 passed, 22.48s
run 5:  ok, 14 passed, 22.58s
run 6:  ok, 14 passed, 22.40s
run 7:  ok, 14 passed, 22.46s
run 8:  ok, 14 passed, 22.52s
run 9:  ok, 14 passed, 22.48s
run 10: ok, 14 passed, 22.72s
```

10/10 green in both modes, no flakes observed. (No full measurement report this milestone, per the instructions; these are the requested wall-clock numbers only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
