### PR TITLE
test(zle): port the history-menu delegation and config-variant checks

### DIFF
--- a/tests/driver/hist.rs
+++ b/tests/driver/hist.rs
@@ -1,8 +1,12 @@
-//! Helpers shared by the history-menu modules (`hist_lifecycle`, `hist_compsys`).
+//! Helpers shared by the history-menu modules (`hist_lifecycle`,
+//! `hist_compsys`, `hist_delegation`, `hist_config`).
 
 use std::time::Duration;
 
 use crate::host::{Host, keys};
+
+/// Nothing armed, nothing collecting: the `^Xt` dump of an idle line.
+pub const NO_COLLECTION: &str = "timer=-1 rfd=-1 wfd=-1 pty=<none>";
 
 /// A same-buffer recollection provoked by the step under test can legitimately
 /// have settled by the time the dump runs, so the assertion these cases can

--- a/tests/driver/hist_compsys.rs
+++ b/tests/driver/hist_compsys.rs
@@ -10,11 +10,8 @@
 use std::time::Duration;
 
 use crate::fake::Mode;
-use crate::hist::{assert_no_history_kind, open_menu};
+use crate::hist::{NO_COLLECTION, assert_no_history_kind, open_menu};
 use crate::host::{Host, keys};
-
-/// Nothing armed, nothing collecting: the `^Xt` dump of an idle line.
-const NO_COLLECTION: &str = "timer=-1 rfd=-1 wfd=-1 pty=<none>";
 
 /// Down at position 1 erases the whole menu, unlike a completion listing, where
 /// the analogous transition only deselects and keeps the text (see
@@ -224,7 +221,8 @@ fn the_fixtures_own_injection_commands_are_not_history_candidates() {
 /// disarms the timer and cancels any collection *before* it displays, so the
 /// fds are clear before ^C is even sent. That is what
 /// `send_break_during_an_in_flight_collection_clears_the_collection_fds` (and
-/// driver.zsh's (h26c), for the merely-armed timer) cover instead.
+/// `hist_config::send_break_clears_a_merely_armed_debounce_timer`, for the
+/// timer that is armed but has not started collecting) cover instead.
 #[test]
 fn worker_death_on_the_synchronous_history_path_leaves_a_clean_line() {
     let mut host = Host::boot_history_fake();

--- a/tests/driver/hist_config.rs
+++ b/tests/driver/hist_config.rs
@@ -1,0 +1,102 @@
+//! History-menu behavior that only a non-default `config.toml` can show:
+//! the `[history].limit` scan window, `[display].min-input` not gating the
+//! menu, and -- through a deliberately slow `[display].delay-ms` -- send-break
+//! against a debounce timer that is armed but has not started collecting
+//! (docs/internal/specs/behavior.md 「履歴メニュー」「候補収集」,
+//! docs/internal/contracts/config-schema.md).
+//!
+//! Each test writes its own config before its host boots, so the variant is in
+//! force from the moment the shell sources zrush.
+
+use std::time::Duration;
+
+use crate::hist::NO_COLLECTION;
+use crate::host::{Host, keys};
+
+/// Send-break while merely debounce-armed -- timer fd alive, no collection
+/// started yet -- must clear the timer too.
+///
+/// This is the third member of the send-break cleanup unit in `hist_compsys`:
+/// `worker_death_on_the_synchronous_history_path_leaves_a_clean_line` covers
+/// kind/listing across a send-break, and
+/// `send_break_during_an_in_flight_collection_clears_the_collection_fds`
+/// covers a *live* collection. Neither would catch a timer that is only armed,
+/// which is what a generous `delay-ms` makes observable: the round trip to dump
+/// and assert the armed timer through `^Xt` comfortably fits before the
+/// debounce would otherwise fire. (Disarming through the history-menu open path
+/// instead is `hist_compsys::an_up_inside_the_debounce_window_opens_the_menu_and_disarms_the_timer`.)
+#[test]
+fn send_break_clears_a_merely_armed_debounce_timer() {
+    let mut host = Host::boot_history_with_config("[display]\ndelay-ms = 2000\n");
+    host.send_keys("x");
+    host.drain(Duration::from_millis(300)); // comfortably within the 2s debounce window
+
+    // Without this the cleanup assertion below would pass for the wrong reason
+    // whenever the timer never armed.
+    let fds = host.collection_fds("(h26c-pre)");
+    assert!(
+        !fds.starts_with("timer=-1"),
+        "(h26c-pre) the debounce timer was not armed before send-break: {fds}"
+    );
+
+    host.send_keys(keys::SEND_BREAK);
+    assert!(
+        host.sync_prompt(Duration::from_secs(15)),
+        "(h26c-a) send-break did not produce a new prompt during the debounce wait"
+    );
+    assert_eq!(
+        host.collection_fds("(h26c)"),
+        NO_COLLECTION,
+        "(h26c) the disarmed debounce timer's fd survived the following line-init:"
+    );
+    assert_eq!(
+        host.listing_kind("(h26c-kind)"),
+        "kind=none sel=0 listing=0 npos=0",
+        "(h26c-kind) kind/listing is not clean:"
+    );
+}
+
+/// `[history].limit` bounds the RAW scan window: entries that do not survive
+/// the in-window dedup/exclusion are never backfilled from outside that window
+/// (cli-protocol.md 「history profile」, config-schema.md 「[history]」).
+///
+/// The rc file's fixture history is ordered so that the newest 5 raw entries
+/// are dupA, dupA, an excluded framing-byte line, keep3 and keep4, leaving
+/// three candidates; keep5-outside and oldest-outside sit just past the window
+/// and are disqualified by nothing but their position.
+#[test]
+fn the_history_limit_bounds_the_raw_scan_window() {
+    let mut host = Host::boot_history_limit_with_config("[history]\nlimit = 5\n");
+    host.press(keys::UP);
+
+    let post = host.postdisplay("(h8a)");
+    assert!(
+        post.contains("dupA")
+            && post.contains("keep3")
+            && post.contains("keep4")
+            && !post.contains("keep5-outside")
+            && !post.contains("oldest-outside"),
+        "(h8a) the newest-5 scan window did not yield exactly dupA/keep3/keep4: {post:?}"
+    );
+
+    let dupes = post.split('\n').filter(|row| row.contains("dupA")).count();
+    assert_eq!(
+        dupes, 1,
+        "(h8b) the duplicate within the scan window was not deduplicated to exactly one row: {post:?}"
+    );
+}
+
+/// `min-input` does not gate the history menu: even raised well above any
+/// possible word length, an empty-buffer Up still opens the full menu.
+/// behavior.md: min-input and the blank-buffer suppression rule apply only to
+/// the input-following auto display, not to the explicit history menu.
+#[test]
+fn min_input_does_not_gate_the_history_menu() {
+    let mut host = Host::boot_history_with_config("[display]\nmin-input = 50\n");
+    host.press(keys::UP);
+    let kind = host.listing_kind("(h19a)");
+    assert!(
+        kind.starts_with("kind=history sel=1 listing=1"),
+        "(h19a) empty-buffer Up did not open the history menu with min-input=50: {kind}"
+    );
+}

--- a/tests/driver/hist_delegation.rs
+++ b/tests/driver/hist_delegation.rs
@@ -1,0 +1,150 @@
+//! When select-prev/select-next do *not* open or move the history menu but
+//! fall through to what the key was bound to before zrush, or to plain cursor
+//! movement (docs/internal/specs/behavior.md 「選択・キーバインド」 priority
+//! rules, docs/internal/contracts/config-schema.md 「[keybind]」).
+//!
+//! Every test here runs on a host booted from `tests/zsh/rc/history.zshrc`.
+
+use std::time::Duration;
+
+use crate::hist::assert_no_history_kind;
+use crate::host::{Host, keys};
+
+/// While plain history is being browsed (`HISTNO != HISTCMD`, entered through
+/// the rc file's raw `^Xu` binding), select-prev and select-next both delegate
+/// to their predecessor instead of opening or moving a history menu.
+///
+/// Each raw history step changes BUFFER to a real history line, which -- like
+/// any buffer edit -- can arm and settle an ordinary recollection before the
+/// following dump runs, and that legitimately reports 'compsys'. So the kind
+/// assertions here are "never 'history'", not "always 'none'".
+///
+/// "kind != history" alone would also pass if the key were simply swallowed as
+/// a no-op rather than delegated, so the transition is additionally pinned down
+/// through BUFFER: Up must move one further step back in plain history (a
+/// different line), and Down must land back on exactly the line seen before Up
+/// (a round trip), which only up-line-or-history/down-line-or-history produce.
+#[test]
+fn browsing_plain_history_delegates_both_directions() {
+    let mut host = Host::boot_history();
+
+    host.press(keys::RAW_HISTORY_UP);
+    // A second raw step, so the round trip below has room: the delegated Up
+    // spends one more step backwards, and the delegated Down after it must
+    // still have a newer entry to return to.
+    host.press(keys::RAW_HISTORY_UP);
+
+    let kind = host.listing_kind("(h13-setup)");
+    assert_no_history_kind(
+        &kind,
+        "(h13-setup) unexpected history-menu kind after raw history browsing:",
+    );
+    let base = host.buffer("(h13-setup)");
+
+    host.press(keys::UP);
+    let kind = host.listing_kind("(h13a)");
+    assert_no_history_kind(
+        &kind,
+        "(h13a) Up while browsing plain history opened a history menu:",
+    );
+    let after_up = host.buffer("(h13a')");
+    assert_ne!(
+        after_up, base,
+        "(h13a') buffer did not change; Up may have been silently swallowed instead of delegated"
+    );
+
+    host.press(keys::DOWN);
+    let kind = host.listing_kind("(h13b)");
+    assert_no_history_kind(
+        &kind,
+        "(h13b) Down while browsing plain history opened a history menu:",
+    );
+    let after_down = host.buffer("(h13b')");
+    assert_eq!(
+        after_down, base,
+        "(h13b') the delegated Down did not move one step forward, back to the plain-history line seen before Up"
+    );
+}
+
+/// A multiline buffer with the cursor off the first line: Up is cursor
+/// movement, not a history-menu open (behavior.md priority rule 1, symmetric
+/// with select-next's own multiline rule).
+///
+/// "buffer unchanged" alone would also pass if Up were a pure no-op, so the
+/// cursor is read on both sides of the key: 'echo a' occupies positions 0..6
+/// (the newline sits at 6), so landing anywhere in 0..6 means "on line 1".
+#[test]
+fn a_cursor_below_the_first_line_makes_up_a_cursor_movement() {
+    let mut host = Host::boot_history();
+    host.send_keys("echo a");
+    host.send_keys(keys::QUOTED_NEWLINE);
+    host.send_keys("b");
+    host.drain(Duration::from_millis(500));
+
+    let before = host.cursor("(h14-setup)");
+    assert_eq!(
+        before, 8,
+        "(h14-setup) the cursor is not at the end of 'echo a\\nb':"
+    );
+
+    host.press(keys::UP);
+    let kind = host.listing_kind("(h14a)");
+    // A same-buffer recollection for the "b" argument word may already have
+    // settled (cli-protocol.md records it as 'compsys' either way); only a
+    // 'history' kind would mean the menu wrongly opened.
+    assert_no_history_kind(
+        &kind,
+        "(h14a) Up with a newline in LBUFFER opened a history menu:",
+    );
+    host.assert_buffer(
+        "echo a\nb",
+        "(h14b) buffer content changed, although only the cursor should have moved",
+    );
+
+    let after = host.cursor("(h14c)");
+    assert!(
+        after < 7 && after != before,
+        "(h14c) the cursor did not move onto the first line (before={before} after={after}; line 1 spans 0..6)"
+    );
+}
+
+/// Remapping select-prev to just `["up"]` leaves ctrl-p bound to its
+/// predecessor, i.e. plain history movement, while Up -- still in the remapped
+/// list -- keeps opening the history menu.
+///
+/// Up is exercised first, on the pristine just-started state: ctrl-p's own
+/// predecessor is real native history movement and would otherwise leave
+/// `HISTNO != HISTCMD` behind it, which changes what a *later* Up does
+/// (behavior.md priority rule 2) -- unrelated to what this remap is about.
+///
+/// "kind != history" alone would pass for ctrl-p being silently swallowed as a
+/// no-op, so the delegation is pinned down by requiring a real, nonempty buffer
+/// change out of its predecessor.
+#[test]
+fn dropping_ctrl_p_from_select_prev_leaves_it_on_native_history_movement() {
+    let mut host = Host::boot_history_with_config("[keybind]\nselect-prev = [\"up\"]\n");
+
+    host.press(keys::UP);
+    let kind = host.listing_kind("(h20b)");
+    assert!(
+        kind.starts_with("kind=history sel=1 listing=1"),
+        "(h20b) Up (still in the remapped select-prev list) did not open the history menu: {kind}"
+    );
+
+    host.press(keys::DISMISS); // back to an empty buffer, HISTNO still untouched
+    let before = host.buffer("(h20a')");
+
+    host.press(keys::CTRL_P);
+    let kind = host.listing_kind("(h20a)");
+    // ctrl-p's predecessor may move BUFFER to a real history line, which can
+    // arm and settle an ordinary recollection before this dump runs.
+    assert_no_history_kind(
+        &kind,
+        "(h20a) ctrl-p (excluded from select-prev) opened the history menu:",
+    );
+    let after = host.buffer("(h20a')");
+    assert!(
+        !after.is_empty() && after != before,
+        "(h20a') ctrl-p did not change the buffer; it may have been silently swallowed instead of delegated (before={before:?} after={after:?})"
+    );
+}

--- a/tests/driver/host.rs
+++ b/tests/driver/host.rs
@@ -22,6 +22,12 @@ pub mod keys {
     pub const TAB: &str = "\t";
     pub const DISMISS: &str = "\x07";
     pub const SEND_BREAK: &str = "\x03";
+    /// `ctrl-p`: a default select-prev key, and the one a `[keybind]` variant
+    /// can drop from the action's list.
+    pub const CTRL_P: &str = "\x10";
+    /// `quoted-insert` then LF: a literal newline in BUFFER, without the line
+    /// being accepted.
+    pub const QUOTED_NEWLINE: &str = "\x16\n";
     pub const DUMP_BUFFER: &str = "\x18b";
     pub const DUMP_POSTDISPLAY: &str = "\x18p";
     pub const DUMP_RH: &str = "\x18h";
@@ -32,9 +38,15 @@ pub mod keys {
     pub const DUMP_EVENT: &str = "\x18e";
     /// Debounce-timer and in-flight-collection fd state (history rc only).
     pub const DUMP_FDS: &str = "\x18t";
+    /// `CURSOR` position, for the cases that need a delegated widget to have
+    /// moved the cursor rather than merely left BUFFER alone (history rc only).
+    pub const DUMP_CURSOR: &str = "\x18z";
     /// `backward-char`: a cursor movement zrush never binds, i.e. an external
     /// CURSOR-only change (history rc only).
     pub const BACKWARD_CHAR: &str = "\x18l";
+    /// `up-line-or-history` bound raw: native history movement that bypasses
+    /// zrush, i.e. the way into `HISTNO != HISTCMD` (history rc only).
+    pub const RAW_HISTORY_UP: &str = "\x18u";
     pub const CURSOR_LEFT_THREE: &str = "\x18v";
     /// `_zrush_worker_shutdown` from a widget: an explicit healthy teardown.
     pub const WORKER_TEARDOWN: &str = "\x18q";
@@ -83,6 +95,9 @@ enum HostRc {
     /// Fixture history in memory (isolated HISTFILE, `SAVEHIST=0`) plus the
     /// history-menu dump widgets.
     History,
+    /// [`HostRc::History`]'s isolation with the small, deliberately ordered
+    /// fixture set the `[history].limit` scan window is read against.
+    HistoryLimit,
 }
 
 impl HostRc {
@@ -90,20 +105,21 @@ impl HostRc {
         match self {
             HostRc::Minimal => "tests/zsh/rc/minimal.zshrc",
             HostRc::History => "tests/zsh/rc/history.zshrc",
+            HostRc::HistoryLimit => "tests/zsh/rc/history-limit.zshrc",
         }
     }
 }
 
 impl Host {
     pub fn boot() -> Self {
-        Self::boot_with(HostRc::Minimal, |_home| {}, false)
+        Self::boot_with(HostRc::Minimal, |_home| {}, false, None)
     }
 
     /// Like [`Host::boot`], but symlinks the shared 7001-file overflow tree
     /// (built once per process, cached under `target/`) into `fx/overflow`
     /// under the host's home.
     pub fn boot_with_overflow() -> Self {
-        Self::boot_with(HostRc::Minimal, fixtures::link_overflow, false)
+        Self::boot_with(HostRc::Minimal, fixtures::link_overflow, false, None)
     }
 
     /// Like [`Host::boot`], but with `$ZRUSH_BIN` pointing at the failure-
@@ -111,21 +127,41 @@ impl Host {
     /// It starts in [`crate::fake::Mode::Proxy`], so the host behaves exactly
     /// as under the real binary until a test sets another mode.
     pub fn boot_fake() -> Self {
-        Self::boot_with(HostRc::Minimal, |_home| {}, true)
+        Self::boot_with(HostRc::Minimal, |_home| {}, true, None)
     }
 
     /// Like [`Host::boot`], but under `tests/zsh/rc/history.zshrc`.
     pub fn boot_history() -> Self {
-        Self::boot_with(HostRc::History, |_home| {}, false)
+        Self::boot_with(HostRc::History, |_home| {}, false, None)
     }
 
     /// [`Host::boot_history`] with [`Host::boot_fake`]'s launcher, for the
     /// history cases that inject a worker failure.
     pub fn boot_history_fake() -> Self {
-        Self::boot_with(HostRc::History, |_home| {}, true)
+        Self::boot_with(HostRc::History, |_home| {}, true, None)
     }
 
-    fn boot_with(rc: HostRc, extra_fixtures: impl FnOnce(&Path), fake: bool) -> Self {
+    /// [`Host::boot_history`] with `config` already at
+    /// `$XDG_CONFIG_HOME/zrush/config.toml` when the shell sources zrush, so
+    /// the variant is in force from the first keystroke instead of racing the
+    /// per-prompt config reload.
+    pub fn boot_history_with_config(config: &str) -> Self {
+        Self::boot_with(HostRc::History, |_home| {}, false, Some(config))
+    }
+
+    /// [`Host::boot_history_with_config`] under
+    /// `tests/zsh/rc/history-limit.zshrc`, whose fixture history is what a
+    /// `[history].limit` scan window is read against.
+    pub fn boot_history_limit_with_config(config: &str) -> Self {
+        Self::boot_with(HostRc::HistoryLimit, |_home| {}, false, Some(config))
+    }
+
+    fn boot_with(
+        rc: HostRc,
+        extra_fixtures: impl FnOnce(&Path),
+        fake: bool,
+        config: Option<&str>,
+    ) -> Self {
         let tmp = TempDir::new().expect("create work dir");
         let home = tmp.path().join("home");
         let work = tmp.path().join("work");
@@ -135,6 +171,9 @@ impl Host {
         fs::create_dir_all(&home).expect("create home");
         fs::create_dir_all(&zdot).expect("create zdotdir");
         fs::create_dir_all(xdg.join("zrush")).expect("create config dir");
+        if let Some(config) = config {
+            fs::write(xdg.join("zrush/config.toml"), config).expect("write config.toml");
+        }
         fixtures::build(&home);
         extra_fixtures(&home);
 
@@ -400,11 +439,26 @@ impl Host {
         None
     }
 
-    pub fn assert_buffer(&mut self, expected: &str, label: &str) {
+    /// The `^Xb` BUFFER dump, unquoted.
+    pub fn buffer(&mut self, label: &str) -> String {
         let dump = self
             .dump_get(keys::DUMP_BUFFER, "TESTBUF")
             .unwrap_or_else(|| panic!("{label}: BUFFER dump did not run"));
-        assert_eq!(unquote(&dump), expected, "{label}");
+        unquote(&dump)
+    }
+
+    pub fn assert_buffer(&mut self, expected: &str, label: &str) {
+        let buffer = self.buffer(label);
+        assert_eq!(buffer, expected, "{label}");
+    }
+
+    /// The `^Xz` CURSOR dump, as an offset into BUFFER.
+    pub fn cursor(&mut self, label: &str) -> usize {
+        let dump = self
+            .dump_get(keys::DUMP_CURSOR, "TESTCUR")
+            .unwrap_or_else(|| panic!("{label}: CURSOR dump did not run"));
+        dump.parse()
+            .unwrap_or_else(|e| panic!("{label}: CURSOR dump {dump:?} is not a position ({e})"))
     }
 
     /// The `^Xk` listing dump: `kind=<...> sel=<n> listing=<0|1> npos=<n>`.

--- a/tests/driver/main.rs
+++ b/tests/driver/main.rs
@@ -17,6 +17,8 @@ mod fifo;
 mod fixtures;
 mod hist;
 mod hist_compsys;
+mod hist_config;
+mod hist_delegation;
 mod hist_lifecycle;
 mod host;
 mod pty;

--- a/tests/zsh/driver.zsh
+++ b/tests/zsh/driver.zsh
@@ -4,10 +4,10 @@
 # Usage:
 #   zsh -f tests/zsh/driver.zsh <playground-dir> [section ...]
 #     The playground only needs to exist and be writable; it is used as an
-#     isolated $HOME. Every fixture this driver needs (small file/directory
-#     trees, a filename containing a space, a slow fake completion) is
-#     created under $PLAYGROUND/fx by this script -- no pre-populated docs
-#     tree or external "huge" directory is required.
+#     isolated $HOME. Every fixture this driver needs (a small file/directory
+#     tree and a large generated one) is created under $PLAYGROUND/fx by this
+#     script -- no pre-populated docs tree or external "huge" directory is
+#     required.
 #     With no section arguments every section runs. Naming sections runs just
 #     those, always in the canonical order of the SECTIONS array below (host
 #     startup and its baseline checks run regardless). Each section owns its
@@ -28,8 +28,8 @@
 #
 # Harness (shared with driver-coexist.zsh/driver-latency.zsh):
 #   - Start an interactive host zsh with nonblocking zpty -b, send keys, and inspect
-#     both pty output and the ZRUSH_LOG file (including the ^Xb/^Xp/^Xh test-only
-#     dump widgets registered by rc/minimal.zshrc).
+#     both pty output and the ZRUSH_LOG file (including the ^Xw/^Xj/^Xg/^Xf
+#     test-only dump widgets registered by rc/minimal.zshrc).
 #   - Always drain the pty in wait loops to prevent tcsetattr TCSADRAIN blocking.
 #     Draining never hides output from a later expect: EXPECT_BUF holds
 #     everything the host has emitted since the last input we sent it.
@@ -56,7 +56,7 @@ typeset -g PLAYGROUND=${1:?usage: driver.zsh <playground-dir> [section ...]}
 # Canonical execution order of the test sections. Any sections named on the
 # command line run in this order, never in argument order; an empty selection
 # means every section.
-typeset -ga SECTIONS=( hist jobtable inflight )
+typeset -ga SECTIONS=( jobtable inflight )
 typeset -gA PICKED=()
 for SECTION_ARG in "${@[2,-1]}"; do
   (( ${SECTIONS[(I)$SECTION_ARG]} )) || { print -u2 "FATAL: unknown section '$SECTION_ARG' (valid: $SECTIONS)"; exit 1 }
@@ -113,8 +113,6 @@ export ZRUSH_BIN=$WORK/bin/zrush
 export ZRUSH_REAL_BIN=$REPO/target/release/zrush
 export ZRUSH_FAKE_CONTROL=$WORK/fake-control
 export ZRUSH_FAKE_STATE=$WORK/fake-state
-# Test seam: 5000 ms matches the driver's other bounded waits.
-export ZRUSH_HISTORY_DEADLINE_MS=5000
 
 print "source $REPO/tests/zsh/rc/minimal.zshrc" > $ZDOTDIR/.zshrc
 
@@ -125,21 +123,6 @@ mkdir -p $PLAYGROUND/fx/basic/subdir
 : >| $PLAYGROUND/fx/basic/alpha.txt
 : >| $PLAYGROUND/fx/basic/alsoalpha.txt
 : >| $PLAYGROUND/fx/basic/subdir/inner.txt
-
-# fx/spacey: a filename whose quoted (w) and raw (m) forms differ.
-mkdir -p $PLAYGROUND/fx/spacey
-: >| $PLAYGROUND/fx/spacey/"has space.txt"
-
-# fx/hidden: dot-prefixed entries next to a visible one. The names share the
-# "dotted" stem so a dotless listing can be checked for their absence.
-mkdir -p $PLAYGROUND/fx/hidden
-: >| $PLAYGROUND/fx/hidden/.dotted-alpha.txt
-: >| $PLAYGROUND/fx/hidden/.dotted-beta.txt
-: >| $PLAYGROUND/fx/hidden/visible.txt
-
-# fx/headed: a plain file so _files' "file" tag heading appears in the plan.
-mkdir -p $PLAYGROUND/fx/headed
-: >| $PLAYGROUND/fx/headed/plainfile.txt
 
 # fx/overflow: enough entries that a single compsys capture's candidate_payload
 # comfortably exceeds the request-FIFO buffer on either platform this driver
@@ -207,7 +190,6 @@ sync_prompt() {  # $1=timeout(s); returns expect's status (drain still always ru
   drain 0.1
   return st
 }
-press() { send_keys $1; drain 0.3 }
 
 log_count() {  # $1=fixed string -> REPLY: occurrence count in ZRUSH_LOG
   typeset -g REPLY=0
@@ -286,23 +268,6 @@ wait_fake() {  # $1=fixed state line $2=baseline $3=timeout
   return 1
 }
 
-# Compare an exact ^Xb BUFFER dump against an expected string.
-assert_buffer() {  # $1=expected buffer $2=label
-  local expected=$1 want=${(qqqq)1}
-  send_keys $'\C-xb'
-  local -F dl=$(( SECONDS + 5 ))
-  local last=
-  local -a tl
-  while (( SECONDS < dl )); do
-    drain 0.15
-    tl=( ${(f)"$(grep -F 'TESTBUF=' $ZRUSH_LOG 2>/dev/null)"} )
-    (( $#tl )) && last=${tl[-1]#*TESTBUF=}
-    [[ ${(Q)last} == "$expected" ]] && { ok "$2"; return 0 }
-  done
-  ng "$2: buffer=${last:-?} want=$want"
-  return 1
-}
-
 # Trigger a ^X* dump widget and return the freshest matching ZRUSH_LOG line's
 # value (post-tag text) in REPLY. $1=dump key-sequence $2=log tag.
 # Waits for the tag's occurrence count to grow past its pre-press value, so a
@@ -353,25 +318,10 @@ assert_host_stdio() {  # $1=label; compare fd targets and stdout/stderr delivery
   return 1
 }
 
-# A send-break reset for scenarios that can leave a multiline BUFFER: ^U
-# (backward-kill-line) only clears the current physical line of a multiline
-# buffer, so those scenarios need a real line abandon + resync instead.
-# The generous bound matches the other send-break sites: a loaded host has
-# been observed to spend >5s inside pty-^C interrupt handling before the new
-# prompt appears (#47). A resync that never happens leaves every following
-# case running against a desynced host, so it is reported rather than dropped.
-reset_line() {
-  send_keys $'\C-c'
-  drain 0.3
-  sync_prompt 15 || ng "reset_line: no prompt after send-break"
-}
-
 # Stop whatever is running as the "host" pty and start a fresh one under a
-# given ZDOTDIR/XDG_CONFIG_HOME/log file. Used by the history-menu section
-# below, which needs several isolated hosts (a default-config one plus
-# config-variant ones for limit/min-input/keybind) beyond the single host the
-# rest of this driver uses.
-start_hist_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
+# given ZDOTDIR/XDG_CONFIG_HOME/log file. sec_jobtable and sec_inflight each
+# need a host of their own, because each lets its host exit for real.
+start_host() {  # $1=zdotdir $2=xdg-config-home $3=logfile
   zpty -d host 2>/dev/null
   export ZDOTDIR=$1 XDG_CONFIG_HOME=$2 ZRUSH_LOG=$3
   cd $PLAYGROUND || return 1
@@ -438,212 +388,13 @@ sec_boot() {
   assert_host_stdio "(fd-1d) generated callback dispatch preserves host fd 0/1/2"
 }
 
-sec_hist() {
-  # ================================================================ (10) History menu (issue #9)
-  # docs/internal/specs/behavior.md "履歴メニュー" and cli-protocol.md
-  # "history profile" are the source of truth. This section runs on its own
-  # host(s) with fixture history (tests/zsh/rc/history.zshrc and friends)
-  # instead of the "host" pty used above.
-  # The fixture history is isolated (HISTFILE under $WORK, SAVEHIST=0) and
-  # never touches the real ~/.zsh_history (AGENTS.md guardrail).
-  mkdir -p $WORK/zdot-hist $WORK/xdg-hist/zrush
-  print "source $REPO/tests/zsh/rc/history.zshrc" > $WORK/zdot-hist/.zshrc
-  start_hist_host $WORK/zdot-hist $WORK/xdg-hist $WORK/host-hist.log ||
-    ng "(hist-0) history-menu host failed to start"
-
-  # ---- (h13) while browsing plain history (HISTNO != HISTCMD, entered here
-  # via a raw ^Xu binding to up-line-or-history), select-prev/select-next
-  # both delegate to the predecessor instead of opening/moving a history menu.
-  # Each raw history step below changes BUFFER to a real history line, which
-  # (like any buffer edit) can arm and settle an ordinary recollection before
-  # the following dump runs; that legitimately shows up as 'compsys', so
-  # every check here is "never 'history'", not "always 'none'".
-  press $'\C-xu'
-  press $'\C-xu'   # two raw history-back steps, so there is room for a further Down below
-  dump_get $'\C-xk' TESTKIND
-  [[ $REPLY != 'kind=history'* ]] || ng "(h13-setup) unexpected history-menu kind after raw history browsing: $REPLY"
-  # audit A2: "kind != history" alone would also pass if the key were simply
-  # swallowed as a no-op instead of actually delegated, so additionally pin
-  # down the real transition via BUFFER content: Up must move one further
-  # step back in plain history (a different line), and Down must land back
-  # on exactly the line seen right before Up (a round trip), proving both
-  # keys actually reached up-line-or-history/down-line-or-history.
-  dump_get $'\C-xb' TESTBUF; local buf_base=${(Q)REPLY}
-  press $'\e[A'
-  if dump_get $'\C-xk' TESTKIND; then
-    [[ $REPLY != 'kind=history'* ]] && ok "(h13a) Up while browsing plain history delegates (no history menu opens)" || ng "(h13a) $REPLY"
-  fi
-  dump_get $'\C-xb' TESTBUF; local buf_after_up=${(Q)REPLY}
-  [[ $buf_after_up != "$buf_base" ]] \
-    && ok "(h13a') the delegated Up actually moved one step further back in plain history (buffer changed: ${(qqqq)buf_base} -> ${(qqqq)buf_after_up})" \
-    || ng "(h13a') buffer did not change; Up may have been silently swallowed instead of delegated"
-  press $'\e[B'
-  if dump_get $'\C-xk' TESTKIND; then
-    [[ $REPLY != 'kind=history'* ]] && ok "(h13b) Down while browsing plain history delegates (no history menu opens)" || ng "(h13b) $REPLY"
-  fi
-  dump_get $'\C-xb' TESTBUF; local buf_after_down=${(Q)REPLY}
-  [[ $buf_after_down == "$buf_base" ]] \
-    && ok "(h13b') the delegated Down actually moved one step forward, back to the same plain-history line as before Up" \
-    || ng "(h13b') buffer=${(qqqq)buf_after_down} want=${(qqqq)buf_base}"
-  reset_line
-
-  # ---- (h14) a multiline buffer with the cursor off the first line: Up is
-  # cursor movement, not a history-menu open (behavior.md priority rule 1,
-  # symmetric with select-next's own multiline rule).
-  send_keys 'echo a'
-  send_keys $'\C-v\C-j'
-  send_keys 'b'
-  drain 0.5
-  dump_get $'\C-xz' TESTCUR; local -i cur_before=$REPLY   # end of buffer: 8 ('echo a'=6 + \n + 'b')
-  press $'\e[A'
-  if dump_get $'\C-xk' TESTKIND; then
-    # A same-buffer recollection for the "b" argument word may have already
-    # settled (real or not, cli-protocol.md still records it as 'compsys');
-    # only a 'history' kind would mean the menu wrongly opened.
-    [[ $REPLY != 'kind=history'* ]] && ok "(h14a) Up with a newline in LBUFFER delegates (no history menu opens)" || ng "(h14a) $REPLY"
-  fi
-  assert_buffer $'echo a\nb' "(h14b) buffer content is unchanged (only the cursor moved)"
-  # audit A2: "buffer unchanged" alone would also pass if Up were a pure
-  # no-op, so additionally pin down that the cursor actually left line 2:
-  # 'echo a' occupies positions 0..6 (the newline sits at 6), so landing
-  # anywhere in 0..6 means "on line 1".
-  dump_get $'\C-xz' TESTCUR; local -i cur_after=$REPLY
-  [[ $cur_after -lt 7 && $cur_after -ne $cur_before ]] \
-    && ok "(h14c) the cursor actually moved onto the first line (was $cur_before, now $cur_after; line 1 spans 0..6)" \
-    || ng "(h14c) cursor did not move onto the first line (before=$cur_before after=$cur_after)"
-  reset_line
-
-  # ---- (h26c) audit A2: send-break while merely debounce-armed (timer fd
-  # alive, no collection started yet) must clear the timer too. A dedicated
-  # host with a generous delay-ms is used so the round trip to dump and
-  # assert the armed timer via ^Xt comfortably fits before the debounce
-  # would otherwise fire (disarming via the history-menu open path itself is
-  # covered by the Rust driver's debounce-window test; this covers disarming
-  # via send-break/line-init instead).
-  mkdir -p $WORK/xdg-hist-slowdebounce/zrush
-  print -r -- $'[display]\ndelay-ms = 2000' > $WORK/xdg-hist-slowdebounce/zrush/config.toml
-  if start_hist_host $WORK/zdot-hist $WORK/xdg-hist-slowdebounce $WORK/host-hist-slowdebounce.log; then
-    ok "(h26c-0) delay-ms=2000 host started"
-    send_keys 'x'
-    drain 0.3   # comfortably within the 2s debounce window
-    if dump_get $'\C-xt' TESTFDS; then
-      # Guard against a vacuous check: fail loudly here rather than silently
-      # passing (h26c) below for the wrong reason if the timer never armed.
-      [[ $REPLY != 'timer=-1'* ]] \
-        && ok "(h26c-pre) the debounce timer is armed (non -1) before send-break" \
-        || ng "(h26c-pre) timer was not armed as expected before send-break: $REPLY"
-    fi
-    send_keys $'\C-c'
-    if sync_prompt 15; then
-      ok "(h26c-a) a new prompt appears after send-break during the debounce wait"
-      if dump_get $'\C-xt' TESTFDS; then
-        [[ $REPLY == 'timer=-1 rfd=-1 wfd=-1 pty=<none>' ]] \
-          && ok "(h26c) the disarmed debounce timer's fd is cleared after the following line-init" \
-          || ng "(h26c) $REPLY"
-      fi
-      if dump_get $'\C-xk' TESTKIND; then
-        [[ $REPLY == 'kind=none sel=0 listing=0 npos=0' ]] && ok "(h26c-kind) kind/listing is also clean" || ng "(h26c-kind) $REPLY"
-      fi
-    else
-      ng "(h26c-a) send-break did not produce a new prompt in this environment"
-    fi
-  else
-    ng "(h26c-0) delay-ms=2000 host failed to start"
-  fi
-
-  # ---- (h8) [history].limit bounds the RAW scan window; entries that don't
-  # survive the in-window dedup/exclusion are never backfilled from outside
-  # that window (cli-protocol.md "history profile", config-schema.md "[history]").
-  mkdir -p $WORK/zdot-hist-lim $WORK/xdg-hist-lim/zrush
-  print "source $REPO/tests/zsh/rc/history-limit.zshrc" > $WORK/zdot-hist-lim/.zshrc
-  print -r -- $'[history]\nlimit = 5' > $WORK/xdg-hist-lim/zrush/config.toml
-  if start_hist_host $WORK/zdot-hist-lim $WORK/xdg-hist-lim $WORK/host-hist-limit.log; then
-    ok "(h8-0) limit=5 host started with its own fixture history"
-    press $'\e[A'
-    if dump_get $'\C-xp' TESTPOST; then
-      local post_lim=${(Q)REPLY}
-      if [[ $post_lim == *dupA* && $post_lim == *keep3* && $post_lim == *keep4* \
-            && $post_lim != *keep5-outside* && $post_lim != *oldest-outside* ]]; then
-        ok "(h8a) the newest-5 scan window yields dupA/keep3/keep4 and never backfills keep5-outside/oldest-outside from beyond it"
-      else
-        ng "(h8a) unexpected listing for limit=5: ${(qqqq)post_lim}"
-      fi
-      local -a lim_rows=( "${(f)post_lim}" )
-      local -i n_dupa=${#${(M)lim_rows:#*dupA*}}
-      (( n_dupa == 1 )) && ok "(h8b) the duplicate within the scan window is deduplicated to exactly one row" || ng "(h8b) dupA appeared in $n_dupa rows: ${(qqqq)post_lim}"
-    else
-      ng "(h8a) POSTDISPLAY dump did not run"
-    fi
-  else
-    ng "(h8-0) limit=5 host failed to start"
-  fi
-
-  # ---- (h19) min-input does not gate the history menu: even with min-input
-  # raised well above any possible word length, an empty-buffer Up still
-  # opens the full menu (behavior.md: min-input and the blank-buffer
-  # suppression rule apply only to the input-following auto display, not to
-  # the history menu).
-  mkdir -p $WORK/xdg-hist-mininput/zrush
-  print -r -- $'[display]\nmin-input = 50' > $WORK/xdg-hist-mininput/zrush/config.toml
-  if start_hist_host $WORK/zdot-hist $WORK/xdg-hist-mininput $WORK/host-hist-mininput.log; then
-    ok "(h19-0) min-input=50 host started"
-    press $'\e[A'
-    if dump_get $'\C-xk' TESTKIND; then
-      [[ $REPLY == 'kind=history sel=1 listing=1'* ]] \
-        && ok "(h19a) empty-buffer Up opens the history menu even with min-input=50" \
-        || ng "(h19a) $REPLY"
-    fi
-  else
-    ng "(h19-0) min-input=50 host failed to start"
-  fi
-
-  # ---- (h20) remapping select-prev to just ["up"] leaves ctrl-p bound to its
-  # predecessor (plain history movement, config-schema.md "[keybind]"); Up
-  # (still in the remapped list) still opens the history menu.
-  mkdir -p $WORK/xdg-hist-keybind/zrush
-  print -r -- $'[keybind]\nselect-prev = ["up"]' > $WORK/xdg-hist-keybind/zrush/config.toml
-  if start_hist_host $WORK/zdot-hist $WORK/xdg-hist-keybind $WORK/host-hist-keybind.log; then
-    ok "(h20-0) select-prev=[\"up\"] host started"
-    # Up first, on the pristine just-started state: ctrl-p's own predecessor
-    # (tested second, below) is real native history movement and would
-    # otherwise leave HISTNO != HISTCMD behind it, which changes what a
-    # *later* Up does (behavior.md priority rule 2) -- unrelated to what
-    # this remap is actually about.
-    press $'\e[A'
-    if dump_get $'\C-xk' TESTKIND; then
-      [[ $REPLY == 'kind=history sel=1 listing=1'* ]] \
-        && ok "(h20b) Up (still in the remapped select-prev list) still opens the history menu" \
-        || ng "(h20b) $REPLY"
-    fi
-    press $'\C-g'   # dismiss: back to an empty buffer, HISTNO still untouched
-    dump_get $'\C-xb' TESTBUF; local buf_before_ctrlp=${(Q)REPLY}
-    press $'\C-p'
-    if dump_get $'\C-xk' TESTKIND; then
-      # ctrl-p's predecessor may move BUFFER to a real history line, which
-      # (like any buffer edit) can arm and settle an ordinary recollection
-      # before this dump runs; only a 'history' kind would mean the menu
-      # wrongly opened.
-      [[ $REPLY != 'kind=history'* ]] && ok "(h20a) ctrl-p (excluded from select-prev) does not open the history menu" || ng "(h20a) $REPLY"
-    fi
-    # audit A2: "kind != history" alone would also pass if ctrl-p were
-    # silently swallowed as a no-op; pin down that its predecessor actually
-    # ran plain history movement by requiring a real, nonempty buffer change.
-    dump_get $'\C-xb' TESTBUF; local buf_after_ctrlp=${(Q)REPLY}
-    [[ -n $buf_after_ctrlp && $buf_after_ctrlp != "$buf_before_ctrlp" ]] \
-      && ok "(h20a') ctrl-p's predecessor actually performed native history movement (buffer: ${(qqqq)buf_before_ctrlp} -> ${(qqqq)buf_after_ctrlp})" \
-      || ng "(h20a') ctrl-p did not change the buffer; it may have been silently swallowed instead of delegated"
-  else
-    ng "(h20-0) select-prev=[\"up\"] host failed to start"
-  fi
-}
-
 sec_jobtable() {
   # ================================================================ Worker job-table isolation
   # This host must exit during the assertion, so give it dedicated rc/config/log
   # state rather than reusing any host needed by the preceding cases.
   mkdir -p $WORK/zdot-exit $WORK/xdg-exit/zrush
   print "source $REPO/tests/zsh/rc/minimal.zshrc" > $WORK/zdot-exit/.zshrc
-  if start_hist_host $WORK/zdot-exit $WORK/xdg-exit $WORK/host-exit.log; then
+  if start_host $WORK/zdot-exit $WORK/xdg-exit $WORK/host-exit.log; then
     send_line '[[ -o checkjobs && -o checkrunningjobs ]] && print CHECK-JOBS-ENABLED'
     if expect '*CHECK-JOBS-ENABLED*HP>*' 5; then
       fake_session_count; local -i exit_session=$(( REPLY + 1 ))
@@ -707,19 +458,19 @@ sec_inflight() {
   #
   # The previous case just let its own dedicated "host" pty session exit for
   # real (as opposed to every other transition in this driver, which deletes
-  # a still-live session via `zpty -d host`). start_hist_host always issues
+  # a still-live session via `zpty -d host`). start_host always issues
   # its own `zpty -d host 2>/dev/null` before spawning anew; issuing that
   # exact call -- with stderr redirected -- as the *first* deletion of an
   # already-dead real-worker session reproducibly kills this outer zsh
   # process outright (a zpty/job-control interaction, not a zrush bug).
   # Reaping it here first, without redirecting stderr, avoids the crash;
-  # start_hist_host's own redundant delete of the now-already-gone session
+  # start_host's own redundant delete of the now-already-gone session
   # is then a harmless no-op.
   print -r -- proxy > $ZRUSH_FAKE_CONTROL
   zpty -d host
   mkdir -p $WORK/zdot-inflight $WORK/xdg-inflight/zrush
   print "source $REPO/tests/zsh/rc/minimal.zshrc" > $WORK/zdot-inflight/.zshrc
-  if start_hist_host $WORK/zdot-inflight $WORK/xdg-inflight $WORK/host-inflight.log; then
+  if start_host $WORK/zdot-inflight $WORK/xdg-inflight $WORK/host-inflight.log; then
     send_line '[[ -o checkjobs && -o checkrunningjobs ]] && print CHECK-JOBS-ENABLED'
     if expect '*CHECK-JOBS-ENABLED*HP>*' 5; then
       # Warm the persistent worker up on a small request first so handshake/

--- a/tests/zsh/rc/history-limit.zshrc
+++ b/tests/zsh/rc/history-limit.zshrc
@@ -1,9 +1,9 @@
-# Host rc for the [history].limit boundary scenario in tests/zsh/driver.zsh
-# ("h8"). Same isolation as tests/zsh/rc/history.zshrc, but with its own
-# small, deliberately ordered fixture set so the newest-N-raw-entries scan
-# window (config's [history].limit, written to this host's own
-# XDG_CONFIG_HOME/zrush/config.toml by the driver) is easy to reason about
-# exactly. Required environment: ZRUSH_REAL_BIN, ZRUSH_TEST_TMP.
+# Host rc for the [history].limit boundary scenario in the Rust pty harness
+# (tests/driver/hist_config.rs). Same isolation as tests/zsh/rc/history.zshrc,
+# but with its own small, deliberately ordered fixture set so the
+# newest-N-raw-entries scan window (config's [history].limit, written to this
+# host's own XDG_CONFIG_HOME/zrush/config.toml before it boots) is easy to
+# reason about exactly. Required environment: ZRUSH_REAL_BIN, ZRUSH_TEST_TMP.
 PS1='HP> '
 HISTFILE=$ZRUSH_TEST_TMP/histfile-hist-limit
 HISTSIZE=1000
@@ -16,7 +16,7 @@ _zrt_dump_postdisplay() { _zlog "TESTPOST=${(qqqq)POSTDISPLAY}" }
 zle -N _zrt-dump-postdisplay _zrt_dump_postdisplay
 bindkey '^Xp' _zrt-dump-postdisplay
 
-# Oldest to newest. With [history].limit=5 (the driver writes that to this
+# Oldest to newest. With [history].limit=5 (the test writes that to this
 # host's config.toml) the scan window is exactly the newest 5 RAW entries
 # below: dupA (x2) + ctrlone (SOH, excluded) + keep3 + keep4. Within that
 # window, dedup and exclusion leave only 3 candidates (dupA once, keep3,

--- a/tests/zsh/rc/history.zshrc
+++ b/tests/zsh/rc/history.zshrc
@@ -1,6 +1,6 @@
 # Host rc for the headless history-menu regression scenarios, loaded through
-# ZDOTDIR by the Rust pty harness (tests/driver/) and by tests/zsh/driver.zsh
-# (issue #9: docs/internal/specs/behavior.md "履歴メニュー",
+# ZDOTDIR by the Rust pty harness (tests/driver/) (issue #9:
+# docs/internal/specs/behavior.md "履歴メニュー",
 # docs/internal/contracts/cli-protocol.md "history profile").
 # Required environment: ZRUSH_REAL_BIN, ZRUSH_TEST_TMP (see tests/zsh/rc/minimal.zshrc).
 # Isolated HISTFILE + SAVEHIST=0: the fixture history below lives only in this
@@ -43,8 +43,7 @@ bindkey '^Xu' up-line-or-history
 bindkey '^Xl' backward-char
 
 # ^Xz: CURSOR position, for scenarios that need to confirm a delegated widget
-# actually moved the cursor (driver.zsh's (h14c)), not just that BUFFER text
-# was left alone.
+# actually moved the cursor, not just that BUFFER text was left alone.
 _zrt_dump_cursor() { _zlog "TESTCUR=$CURSOR" }
 zle -N _zrt-dump-cursor _zrt_dump_cursor
 bindkey '^Xz' _zrt-dump-cursor


### PR DESCRIPTION
Closes #110. Re-lands the content of #114, which was merged while its base still pointed at the #113 branch — the squash landed on that side branch instead of main, so main never received this change (#110 stayed open as a result).

The commit is identical in content to what #114's review approved, rebased onto the merged #113. See #114 for the full parity table and verification record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)