### PR TITLE
test(zle): re-press send-break when the host swallows the interrupt

### DIFF
--- a/tests/driver/hist_compsys.rs
+++ b/tests/driver/hist_compsys.rs
@@ -283,9 +283,9 @@ fn worker_death_on_the_synchronous_history_path_leaves_a_clean_line() {
         "(h26-setup) history menu did not open after worker cleanup={worker_clean}: {kind}"
     );
 
-    host.send_keys(keys::SEND_BREAK); // abandon the line, bypassing confirm/dismiss/line-finish
+    // abandon the line, bypassing confirm/dismiss/line-finish
     assert!(
-        host.sync_prompt(Duration::from_secs(15)),
+        host.send_break_and_sync(Duration::from_secs(15)),
         "(h26a) send-break did not produce a new prompt"
     );
     assert_eq!(
@@ -313,9 +313,8 @@ fn send_break_during_an_in_flight_collection_clears_the_collection_fds() {
         "(h26d-pre) no in-flight collection detected before send-break:"
     );
 
-    host.send_keys(keys::SEND_BREAK);
     assert!(
-        host.sync_prompt(Duration::from_secs(15)),
+        host.send_break_and_sync(Duration::from_secs(15)),
         "(h26d-a) send-break did not produce a new prompt"
     );
     assert_eq!(

--- a/tests/driver/hist_config.rs
+++ b/tests/driver/hist_config.rs
@@ -39,9 +39,8 @@ fn send_break_clears_a_merely_armed_debounce_timer() {
         "(h26c-pre) the debounce timer was not armed before send-break: {fds}"
     );
 
-    host.send_keys(keys::SEND_BREAK);
     assert!(
-        host.sync_prompt(Duration::from_secs(15)),
+        host.send_break_and_sync(Duration::from_secs(15)),
         "(h26c-a) send-break did not produce a new prompt during the debounce wait"
     );
     assert_eq!(

--- a/tests/driver/host.rs
+++ b/tests/driver/host.rs
@@ -313,6 +313,42 @@ impl Host {
         ok
     }
 
+    /// Send `keys::SEND_BREAK` and wait for the prompt it produces, re-sending
+    /// about once a second until `deadline` elapses. zsh 5.9 defers a SIGINT
+    /// that arrives while the host is inside a `zle -F` callback until the
+    /// next input byte, then swallows that byte -- so a press landing in that
+    /// window can vanish without ever reaching the line editor, and no single
+    /// deadline is long enough to wait it out (#116). This mirrors the
+    /// dump-widget re-press already used by [`Host::dump_get`] (#47).
+    ///
+    /// At a call site whose send-break targets an already-idle prompt
+    /// (sb-1a, h26a) a re-press is unconditionally harmless: landing twice on
+    /// a clean prompt is indistinguishable from landing once. At a call site
+    /// whose following assertion depends on a premise that decays on its own
+    /// -- an in-flight collection that finishes unprompted after ~0.5s
+    /// (h26d), or a debounce timer that fires unprompted at `delay-ms`
+    /// (h26c) -- a swallowed first press followed by a retry landing after
+    /// that premise has already decayed makes the cleanup assertion pass
+    /// vacuously instead of exercising send-break's own cleanup path. That is
+    /// the same trade `dump_get` already makes for its own re-press (#47): a
+    /// rare flake traded for a rarer vacuous pass, accepted because the
+    /// alternative -- a single, unrepeated press -- is the flake this method
+    /// exists to fix.
+    ///
+    /// Returns whether a prompt appeared within `deadline`.
+    pub fn send_break_and_sync(&mut self, deadline: Duration) -> bool {
+        let end = Instant::now() + deadline;
+        loop {
+            self.send_keys(keys::SEND_BREAK);
+            if self.sync_prompt(Duration::from_secs(1)) {
+                return true;
+            }
+            if Instant::now() >= end {
+                return false;
+            }
+        }
+    }
+
     pub fn press(&mut self, keys: &str) {
         self.send_keys(keys);
         self.drain(Duration::from_millis(300));

--- a/tests/driver/sendbreak.rs
+++ b/tests/driver/sendbreak.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use crate::host::{Host, PlanShape, keys};
+use crate::host::{Host, PlanShape};
 
 #[test]
 fn send_break_resets_plan_state_for_the_next_prompt() {
@@ -21,9 +21,9 @@ fn send_break_resets_plan_state_for_the_next_prompt() {
     host.sync_prompt(Duration::from_secs(5));
 
     host.send_keys_wait_plan(PlanShape::Nonempty, "ls fx/basic/al"); // real, non-empty _zrush_plan_* now populated
-    host.send_keys(keys::SEND_BREAK); // send-break: abandon the line, bypassing line-finish
+    // send-break: abandon the line, bypassing line-finish
     assert!(
-        host.sync_prompt(Duration::from_secs(15)),
+        host.send_break_and_sync(Duration::from_secs(15)),
         "(sb-1a) no new prompt appeared after send-break"
     );
 


### PR DESCRIPTION
Closes #116.

On slow macOS CI runners a `^C` can arrive while the host is inside a `zle -F` callback; zsh 5.9 defers such a SIGINT to the next input byte and then swallows it, so sb-1a's prompt wait timed out regardless of deadline (observed on the #112 run; the zsh driver used to tolerate exactly this with a SKIP).

Adds `Host::send_break_and_sync`, which re-sends `^C` in ~1 s slices up to the caller's deadline — the same idempotent re-press pattern the dump-widget reads already use (#47) — and converts all four send-break sites (sb-1a, h26a, h26d, h26c). Hard assertions and 15 s deadlines are unchanged; the accepted trade at the premise-decaying sites (h26d, h26c) is documented on the method.

Verification: fmt/clippy clean; `cargo test --test driver` 49 passed; the four affected tests 20/20 consecutive runs green, full target 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)