### PR TITLE
test(zle): write the fake control file atomically

### DIFF
--- a/tests/driver/bin/fake_worker.rs
+++ b/tests/driver/bin/fake_worker.rs
@@ -125,6 +125,16 @@ impl Fake {
     }
 }
 
+/// Every reader of `path` (the `hold`-loop poller, and the one-shot `proxy`,
+/// `mismatch`, and `drain` mode checks) must see a complete mode, so write a
+/// sibling temp file and `rename` it in.
+fn atomic_write(path: &Path, contents: &str) {
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    fs::write(&tmp, contents).unwrap_or_else(|e| panic!("write {}: {e}", tmp.display()));
+    fs::rename(&tmp, path)
+        .unwrap_or_else(|e| panic!("rename {} -> {}: {e}", tmp.display(), path.display()));
+}
+
 fn worker(fake: &Fake, control_fd: i32) {
     // cli-protocol.md 「abort control と worker 終了」: stdout is the response
     // stream and descendants must not inherit it.
@@ -149,8 +159,7 @@ fn worker(fake: &Fake, control_fd: i32) {
     }
 
     if fake.mode() == "mismatch" {
-        fs::write(&fake.control, "proxy")
-            .unwrap_or_else(|e| panic!("rewrite {}: {e}", fake.control.display()));
+        atomic_write(&fake.control, "proxy");
         write_message(&[b"incompatible", b"cafebabe"]);
         fake.note(&format!("mismatch {session}"));
         // Stay until the parent tears the transport down. A worker that

--- a/tests/driver/fake.rs
+++ b/tests/driver/fake.rs
@@ -55,7 +55,7 @@ impl Fake {
         let control = work.join("fake-control");
         let state = work.join("fake-state");
         let count = work.join("fake-state.count");
-        fs::write(&control, Mode::Proxy.as_str()).expect("write fake control file");
+        atomic_write(&control, Mode::Proxy.as_str());
         command
             .env("ZRUSH_BIN", env!("CARGO_BIN_EXE_zrush-fake-worker"))
             .env("ZRUSH_FAKE_CONTROL", &control)
@@ -68,7 +68,7 @@ impl Fake {
     }
 
     pub fn set_mode(&self, mode: Mode) {
-        fs::write(&self.control, mode.as_str()).expect("write fake control file");
+        atomic_write(&self.control, mode.as_str());
     }
 
     /// State lines containing `needle` (`grep -cF` semantics). Needles for a
@@ -134,4 +134,13 @@ impl Fake {
             Err(_) => Vec::new(),
         }
     }
+}
+
+/// Every reader of `path` (the fake's `hold`-loop poller, and its one-shot
+/// mode checks) must see a complete mode, so write a sibling temp file and
+/// `rename` it in.
+fn atomic_write(path: &Path, contents: &str) {
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    fs::write(&tmp, contents).expect("write fake control temp file");
+    fs::rename(&tmp, path).expect("rename fake control temp file");
 }


### PR DESCRIPTION
Closes #117.

Triage (recorded in the issue comments' investigation summary below) found the err-1e flake was harness-side, not a zrush bug: `Fake::set_mode` used `fs::write` — truncate then write, two syscalls — and the fake worker's 10 ms `hold`-mode poll could read the empty control file in that gap, hit the strict unknown-mode failure (exit 18), and vanish; the shell then correctly recorded a second session failure and opened the breaker. Deterministically reproduced by widening the gap (12 ms+ fails every time); the truncate-to-write gap was measured up to 66 ms under concurrent load on an M3, and CI runners are slower.

Fix: every write to a fake control file now goes through a write-sibling-temp-then-`rename` helper (in both the harness and the fake binary — separate compilation units), so a reader only ever sees a complete old or new value. The strict unknown-mode failure stays — it is what made this diagnosable.

Proof: with a 50 ms delay instrumented between temp-write and rename ON TOP of the fix, the death test passed 10/10 (readers see the complete old value); instrumentation removed from the final diff. An independent reviewer's hammer check: 61 100 concurrent reads, 0 empty, 0 torn, 0 ENOENT. Gates green; `cargo test --test driver death` 20/20; full driver 3/3 + review runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)