### PR TITLE
fix(worker): drain requests after an incompatible reply until stdin EOF

### DIFF
--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -63,7 +63,7 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 | コード | 意味 |
 |---|---|
-| 0 | 成功。worker は frame 境界での stdin EOF、`zrush config` は設定ファイルの問題があっても既定値と警告を出力して成功する。`zrush init` は自身の絶対パス解決とスクリプト出力に成功する |
+| 0 | 成功。worker は frame 境界での stdin EOF、または `incompatible` 応答後の discard 状態での stdin EOF・read error で終了する。`zrush config` は設定ファイルの問題があっても既定値と警告を出力して成功する。`zrush init` は自身の絶対パス解決とスクリプト出力に成功する |
 | 1 | worker の session-fatal framing/I/O/内部エラー、control-fd の setup failure、watchdog による abort、`zrush config` の内部エラー、または `zrush init` の自身のパス解決失敗を含む内部エラー |
 | 2 | usage エラー(未知・不足・不正な引数、未知または未指定のサブコマンド) |
 
@@ -108,6 +108,8 @@ worker は通常の request 処理を始める前に watchdog thread を起動�
 - abort は小さな Unix 専用 wrapper から process 全体へ `_exit(1)` を実行する。
   main worker thread が request 処理で停止していても watchdog 単独で終了させる。
 - watchdog は detached であり、frame 境界の stdin EOF による main thread の正常 exit 0 を妨げない。
+  `incompatible` 応答後の discard 状態も同じく stdin EOF で exit 0 し、request write end を閉じないシェルに対しては
+  watchdog がその上限を与える。
   zsh は正常 shutdown の response EOF まで control write fd を open に保ち、先に閉じて abort と競合させない。
 
 stdout(fd 1)は response stream 専用で、worker は起動時に cloexec を付ける。
@@ -147,9 +149,13 @@ incompatible: ["incompatible", worker_build_stamp]
 ```
 
 worker は `hello` の build stamp が自身の値と一致しなければ、自身の stamp を
-`worker_build_stamp` に入れた `incompatible` を 1 個返して終了する。zsh は、正しい形の `incompatible` または
-stamp の異なる `ready` を stale build として扱い、自動 re-source を 1 回試みる。握手での別 kind・別フィールド数・
-不正な stamp は protocol failure、EOF・I/O エラー・非 canonical framing は worker session failure である。
+`worker_build_stamp` に入れた `incompatible` を 1 個返し、以後は request bytes を解釈しない discard 状態に入る。
+discard 状態の worker は stdin を読み捨てるだけで、frame として解釈も応答もせず、stdin EOF、または
+読み捨て中の read error で exit 0 する。zsh は hello の後ろに frame を queue していることがある。
+worker が読み捨てて request stream を書き込み可能に保つため、その write は失敗せず、`incompatible` が失われない。
+zsh は、正しい形の `incompatible` または stamp の異なる `ready` を stale build として扱い、自動 re-source を 1 回試みる。
+握手での別 kind・別フィールド数・不正な stamp は protocol failure、
+EOF・I/O エラー・非 canonical framing は worker session failure である。
 worker が受ける `hello` の kind・フィールド数・stamp 表記自体が不正な場合は、応答せず終了する。
 
 ### 要求と応答
@@ -196,7 +202,8 @@ error: ["error", request_id, code]
 外側または nested netstring framing の破損、あるいは request_id の欠落・非 canonical 表記・範囲外によって
 安全に対応付けられない場合は応答せずセッションを終了する。
 
-相関可能な各 request は `ok` または `error` の**終端応答をちょうど 1 個**受ける。
+`ready` を返したセッションでは、相関可能な各 request は `ok` または `error` の**終端応答をちょうど 1 個**受ける。
+`incompatible` を返したセッションでその後に届くバイトは request ではなく、この規範の対象外である。
 worker は要求を受信順に処理し、応答を黙って省略しない。`error` も正常に形成された終端応答であり、
 worker セッション失敗には数えない。`ok` の `render_plan` は後述の描画プランストリームそのものを格納する。
 

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -140,7 +140,10 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 - 正しい形の `incompatible`、stamp の異なる `ready`、source/config の build-stamp 不一致は stale build として
   失敗回数を介さず `$ZRUSH_BIN init zsh` の自動 re-source を 1 回だけ試みる。成功時は警告せず診断ログだけを残し、
   検出時点の未完了 request はすべて破棄して replay しない。re-source の失敗または re-source 中の再不一致だけが
-  警告 1 回と無効化へ落ちる。旧 generation に worker がいた場合は replacement worker を直ちに起動して握手を検証し、
+  警告 1 回と無効化へ落ちる。正しい形の `incompatible` は worker session failure に数えず、連続失敗回数も進めない。
+  worker は `incompatible` の後も request stream を読み捨てるため、hello の後ろに queue されていた frame は
+  通常どおり書き込まれて破棄され、stale worker は re-source の正常 shutdown で停止する。
+  旧 generation に worker がいた場合は replacement worker を直ちに起動して握手を検証し、
   worker が未起動なら lazy 状態を保つ。認識済み `incompatible` や local request_id 枯渇のように
   transport が健全なら正常 shutdown、壊れた handshake/session なら異常 abort を使う。
   stopping/quarantine 中の re-source・config reload・build-stamp 照合は fail fast し、新しい deadline や stop を

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -173,6 +173,7 @@ pub(crate) fn run<R: Read, W: Write>(mut input: R, mut output: W) -> Result<End,
                     if process_message(&message, &mut handshake, &mut output)?
                         == MessageResult::Incompatible
                     {
+                        discard_requests(&mut input);
                         return Ok(End::Incompatible);
                     }
                 }
@@ -182,6 +183,7 @@ pub(crate) fn run<R: Read, W: Write>(mut input: R, mut output: W) -> Result<End,
                     if process_message(&message, &mut handshake, &mut output)?
                         == MessageResult::Incompatible
                     {
+                        discard_requests(&mut input);
                         return Ok(End::Incompatible);
                     }
                 }
@@ -189,6 +191,12 @@ pub(crate) fn run<R: Read, W: Write>(mut input: R, mut output: W) -> Result<End,
             }
         }
     }
+}
+
+/// The post-`incompatible` discard state of cli-protocol.md
+/// 「セッションフレーミングと握手」.
+fn discard_requests<R: Read>(input: &mut R) {
+    std::io::copy(input, &mut std::io::sink()).ok();
 }
 
 fn process_message<W: Write>(
@@ -448,10 +456,16 @@ mod tests {
     }
 
     #[test]
-    fn mismatch_replies_once_and_exits() {
+    fn mismatch_replies_once_and_discards_the_rest_of_stdin() {
+        let input = [
+            message(&[b"hello", b"deadbeef"]),
+            message(&request(b"1", b"/", b"")),
+            b"1:x!".to_vec(),
+        ]
+        .concat();
         let mut output = Vec::new();
         assert_eq!(
-            run(Cursor::new(message(&[b"hello", b"deadbeef"])), &mut output).unwrap(),
+            run(Cursor::new(input), &mut output).unwrap(),
             End::Incompatible
         );
         assert_eq!(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -410,7 +410,7 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
 }
 
 #[test]
-fn worker_protocol_mismatch_exits_after_incompatible_response() {
+fn worker_protocol_mismatch_replies_then_discards_until_stdin_eof() {
     let (mut command, control_read, _control_write) = worker_command();
     let mut child = command
         .stdin(Stdio::piped())
@@ -418,16 +418,15 @@ fn worker_protocol_mismatch_exits_after_incompatible_response() {
         .spawn()
         .unwrap();
     drop(control_read);
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(&msg(&[b"hello", b"deadbeef"]))
-        .unwrap();
+    let mut input = msg(&[b"hello", b"deadbeef"]);
+    input.extend_from_slice(b"1:x!not-a-frame");
+    child.stdin.take().unwrap().write_all(&input).unwrap();
     let out = child.wait_with_output().unwrap();
     assert_eq!(out.status.code(), Some(0));
+    let frames = decode_frames(&out.stdout);
+    assert_eq!(frames.len(), 1, "one terminal response, nothing after it");
     assert_eq!(
-        fields(&decode_frames(&out.stdout)[0]),
+        fields(&frames[0]),
         vec![b"incompatible".to_vec(), BUILD_STAMP.to_vec()]
     );
 }

--- a/tests/driver/bin/fake_worker.rs
+++ b/tests/driver/bin/fake_worker.rs
@@ -162,13 +162,8 @@ fn worker(fake: &Fake, control_fd: i32) {
         atomic_write(&fake.control, "proxy");
         write_message(&[b"incompatible", b"cafebabe"]);
         fake.note(&format!("mismatch {session}"));
-        // Stay until the parent tears the transport down. A worker that
-        // vanishes the instant it answers `incompatible` races the first plan
-        // frame the same lazy start queued behind the handshake: whichever of
-        // the two the shell reaches first decides whether the stale build is
-        // followed or the write is reported as a session failure. Holding the
-        // request end open makes the stale-build path the only outcome; the
-        // watchdog still ends this process the moment the control fd speaks.
+        // cli-protocol.md 「セッションフレーミングと握手」: the post-`incompatible`
+        // discard state.
         io::copy(&mut input, &mut io::sink()).ok();
         return;
     }

--- a/tests/worker_control.rs
+++ b/tests/worker_control.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, Instant};
 
 const BUILD_STAMP: &[u8] = env!("ZRUSH_BUILD_STAMP").as_bytes();
 
+const DRAIN_PROBE_BYTES: usize = 8 * 1024 * 1024;
+
 fn netstring(payload: &[u8]) -> Vec<u8> {
     let mut out = payload.len().to_string().into_bytes();
     out.push(b':');
@@ -75,6 +77,25 @@ fn complete_handshake(child: &mut Child) {
     assert_eq!(ready, expected);
 }
 
+fn reach_incompatible(child: &mut Child) {
+    let hello = message(&[b"hello", b"deadbeef"]);
+    child
+        .stdin
+        .as_mut()
+        .expect("request stdin")
+        .write_all(&hello)
+        .expect("write hello");
+    let expected = message(&[b"incompatible", BUILD_STAMP]);
+    let mut reply = vec![0_u8; expected.len()];
+    child
+        .stdout
+        .as_mut()
+        .expect("response stdout")
+        .read_exact(&mut reply)
+        .expect("read incompatible");
+    assert_eq!(reply, expected);
+}
+
 fn wait_bounded(child: &mut Child) -> ExitStatus {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
@@ -106,6 +127,37 @@ fn control_eof_exits_while_request_stdin_is_blocked() {
     complete_handshake(&mut child);
 
     drop(control);
+
+    assert_eq!(wait_bounded(&mut child).code(), Some(1));
+}
+
+#[test]
+fn incompatible_worker_absorbs_a_request_larger_than_the_pipe_buffer_then_exits_at_eof() {
+    let (mut child, control) = spawn_worker();
+    reach_incompatible(&mut child);
+
+    // Well above the largest default pipe capacity in the supported
+    // macOS/Linux matrix (including Linux systems with 64 KiB pages), so the
+    // write cannot finish unless the worker actively drains stdin.
+    let bulk = vec![b'x'; DRAIN_PROBE_BYTES];
+    child
+        .stdin
+        .as_mut()
+        .expect("request stdin")
+        .write_all(&bulk)
+        .expect("write past the pipe buffer");
+    drop(child.stdin.take());
+
+    assert_eq!(wait_bounded(&mut child).code(), Some(0));
+    drop(control);
+}
+
+#[test]
+fn abort_byte_exits_while_an_incompatible_worker_discards_requests() {
+    let (mut child, mut control) = spawn_worker();
+    reach_incompatible(&mut child);
+
+    control.write_all(&[0]).expect("send abort byte");
 
     assert_eq!(wait_bounded(&mut child).code(), Some(1));
 }


### PR DESCRIPTION
Closes #111.

After a rebuild, a lazily started stale-stamp worker replied `incompatible` and exited immediately; the shell's plan frame — queued behind the hello — could then hit EPIPE before the reply was read, get recorded as `session failure: frame write failed`, and two retries against the same stale binary opened the breaker, demanding the manual re-source the automatic path exists to avoid.

Fix (option A of the recorded design; contract updated in the same change): after writing `incompatible`, the worker enters a discard state — it reads and sinks request bytes without interpreting them, and exits 0 at stdin EOF (or a read error while discarding; the shell never observes the exit status). The queued frame's write now always succeeds, so the reply cannot be lost to a failed write, and the stale worker stops through the re-source's normal shutdown. Worker-side on purpose: the fix ships in the freshly built binary, so it protects the very first mismatch in an already-running shell — a zsh-side fix would only guard the second.

Docs: cli-protocol.md (handshake discard state + rationale, exit-code row 0, terminal-response scoping, watchdog bound) and behavior.md (a well-formed `incompatible` never counts as a session failure). The driver fake's mismatch-mode hold, previously documented as a test-only divergence, is now conformance.

Tests: post-`incompatible` 8 MiB write completes and EOF exits 0 (draining, not merely holding the fd open — it would EPIPE against the old worker); an abort byte during discard still exits 1; cli.rs pins exactly one response frame with garbage after the reply; unit test extended. Full gates green after rebasing onto #120, including 3x driver runs and the zsh suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)