### PR TITLE
docs: add the _zrush_ namespace invariant to Core principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Templates under `.github/ISSUE_TEMPLATE/` mirror these rules; only the title and
 Details live in `docs/internal/specs/`; these are the invariants:
 
 - Never act on the user's behalf: don't rewrite input without an explicit action, and don't expand `~`.
+- Never pollute the user's shell namespace: every name zrush defines — functions, widgets, global variables — carries a `zrush` prefix; the only exception is zsh's conventional `REPLY*` return channels.
 - Never block input; collect candidates asynchronously.
 - Configuration lives solely in `~/.config/zrush/config.toml`; no zstyle-based settings.
 - Responsibilities: Rust = matching, ranking, history search, layout/render-plan computation, insertion-text construction, config interpretation; zsh = zle integration, compsys capture, applying the plan (rendering).


### PR DESCRIPTION
Closes #19.

Core principles に「ユーザーの shell の名前空間を汚さない」不変条件を1項目追加する。
定義するすべての名前(関数・ウィジェット・グローバル変数)に `zrush` プレフィックスを付ける。例外は zsh 慣習の `REPLY*` 戻り値チャネル(`_zrush_widen` などの戻り値)のみ。

#19 で検討したスタイルガイド(Coding style 節)は意図的に作らない。決定の経緯と理由は issue 本文に記録済み。

検証: `cargo fmt --check` / `clippy --all-targets -- -D warnings` / `cargo build --release` / `cargo test` すべて通過(docs のみの変更)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fep9wPHrXVufVGzHrSfw4