### PR TITLE
feat: move the candidate payload cache into the worker

### DIFF
--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -652,10 +652,16 @@ zsh は一覧を消す。
 - `unknown-generation` は、`plan` が参照した generation を worker が保持していないことを表す。
   他の `error` と同じく正常な終端応答であり、worker セッション失敗にも連続失敗回数にも数えない。
   zsh はその要求も先行する `store` も replay しない。
-  latch を参照して送った `plan` であれば、その candidate store latch を無効化する
-  (latch の所在と無効化点は behavior.md「worker ライフサイクル」節が定める)。
-  非同期の補完経路では、入力がまだ current なら新しい収集を開始して新しい generation を作る。
-  履歴メニューの同期交換では他の `error` と同じく交換の失敗として扱う(behavior.md「履歴メニュー」節)。
+  非同期の補完経路でのその後の扱いは、その `plan` が latch を参照して送ったものかどうかで決まる。
+  - latch を参照して送った `plan`: その candidate store latch を無効化し
+    (latch の所在と無効化点は behavior.md「worker ライフサイクル」節が定める)、
+    入力がまだ current なら新しい収集を開始して新しい generation を作る。
+  - それ以外の `plan`: 同じ収集で直前に送った `store` が `error` で終端した場合に限られる
+    (受信順処理により、成功した `store` の直後へ連送した `plan` が `unknown-generation` を受けることはない)。
+    失敗した要求として捨てるだけで、再収集はせず次の実入力を待つ。
+    決定的な `store` の失敗が再収集を無限に呼び戻さないための限定である。
+  履歴メニューの同期交換では、どちらの場合も他の `error` と同じく交換の失敗として扱う
+  (behavior.md「履歴メニュー」節)。
 - `store` の `ok` は body が空バイト列であることを検証する。
   空でなければ仕様を満たさない応答として扱い、プランを破棄する場合と同じく worker セッションを終了する。
 - `plan` の `ok` body が仕様を満たさない場合

--- a/docs/internal/contracts/cli-protocol.md
+++ b/docs/internal/contracts/cli-protocol.md
@@ -39,7 +39,7 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 > 検証: 制御バイトを含む候補・値の除外(送信側の保証)のうち「compsys 捕獲 profile」の分 —
 > `tests/vectors/encode/`(`zsh -f tests/zsh/vectors.zsh`)。他の profile の分を固定するテストは無い。
 
-- 対話シェルごとに `zrush worker` を最大 1 プロセス常駐させ、複数のプラン要求を同じ
+- 対話シェルごとに `zrush worker` を最大 1 プロセス常駐させ、複数の要求を同じ
   stdin/stdout セッションで処理する。ワーカーは最初の実要求まで起動しない。
   `zrush config` は設定の読み込みごとに、`zrush init` はシェル起動(source)時に、
   それぞれ one-shot で起動する。
@@ -69,12 +69,12 @@ zrush.zsh(zsh 側)と `zrush` バイナリ(Rust 側)の入出力仕様。
 
 `--help` / `-h`、および `help` サブコマンドは使用方法を表示して exit 0 する。
 これは人間向けの補助機能であり、zsh がこれらを起動することはない。
-完全で相関可能な plan 要求のエラーは exit code を変えず、`error` 応答で通知する。
+完全で相関可能な要求のエラーは exit code を変えず、`error` 応答で通知する。
 
 ## `zrush worker`
 
-候補列とクエリを受け取り、マッチング・ランキング・グループ分割・グリッドレイアウト・
-ハイライト計算・ナビゲーション表構築・挿入テキスト構築までを行い、
+候補列を受け取って解析済みのまま保持し、クエリと組み合わせてマッチング・ランキング・
+グループ分割・グリッドレイアウト・ハイライト計算・ナビゲーション表構築・挿入テキスト構築までを行い、
 zsh がそのまま適用できる描画プランを返す。
 
 ### 起動と責務
@@ -89,12 +89,13 @@ option の欠落、数字でない/2 以下の値、未知または余分な引�
 fd が closed / write-only である場合、または watchdog setup に失敗した場合は、`hello` / `ready` や
 request 処理を始める前に startup 診断を stderr へ 1 行書いて exit 1 する。
 起動後は stdin から要求を読み、
-要求ごとにマッチング・ランキング・グループ分割・グリッドレイアウト・ハイライト計算・
+`store` 要求では候補レコードストリームを解析してスロットへ格納し、
+`plan` 要求ごとにマッチング・ランキング・グループ分割・グリッドレイアウト・ハイライト計算・
 ナビゲーション表構築・挿入テキスト構築を行って stdout へ応答する。
 one-shot の `zrush plan` サブコマンドは存在しない。
 
 ワーカーは **config.toml を読まない**。設定スナップショットは要求フィールドで受け取る
-(設定の取得・mtime 監視は zsh 側の責務)。`HISTFILE` も読まず、候補 payload 全体を要求ごとに受け取る。
+(設定の取得・mtime 監視は zsh 側の責務)。`HISTFILE` も読まず、候補は `store` 要求で受け取る。
 ただしファイルシステムに対しては純粋でない: `f = 1` 候補の `/` 合成判定だけは要求の `cwd` を基準に stat する。
 
 ### abort control と worker 終了
@@ -133,8 +134,8 @@ message   = netstring(netstring(field-1) ... netstring(field-N))
   宣言長未満の EOF、外側 payload 内の不完全または余分なフィールドバイトは framing error である。
 - 読み取りの分割位置に意味はない。1 回の read に複数メッセージが含まれる場合、壊れた後続メッセージより前に
   完成していたメッセージは先に処理し、OS の read 境界によって配送結果を変えない。
-- 候補レコードストリームと描画プランストリームは、それぞれ 1 個の opaque field として入れ子にする。
-  その内側の NUL フレーミングは後述の規範を保つ。
+- 候補レコードストリームは `store` 要求の、描画プランストリームは `plan` の成功応答の、
+  それぞれ 1 個の opaque field として入れ子にする。その内側の NUL フレーミングは後述の規範を保つ。
 - kind・build stamp・request_id・列挙値・真偽値・数値・error code は、以下に示す ASCII バイト列と
   完全一致しなければならない。前後空白、符号、別の大小文字表記を許さない。
 
@@ -167,16 +168,34 @@ worker が受ける `hello` の kind・フィールド数・stamp 表記自体�
 角括弧内は外側 message payload に固定順で並ぶ netstring field を表す。
 
 ```
-plan:  ["plan", request_id, cwd, producer, query, mode, smart_case,
-        rows, width, trailing_space, candidate_payload]
-ok:    ["ok", request_id, render_plan]
+store: ["store", request_id, slot, candidate_generation, candidate_payload]
+plan:  ["plan", request_id, candidate_generation, cwd, producer, query, mode, smart_case,
+        rows, width, trailing_space]
+ok:    ["ok", request_id, body]
 error: ["error", request_id, code]
 ```
+
+要求は 2 種類ある。
+`store` は候補レコードストリームを worker へ渡して解析済みの candidate store に格納し、
+`plan` はその store を `candidate_generation` で参照して描画プランを得る。
+候補 payload は `plan` に載せない。
 
 - `request_id`: zsh が所有する `1..=9223372036854775807`(`i64::MAX`)の canonical ASCII 10 進識別子。
   先頭ゼロを付けない。
   シェルセッション内で単調増加し、worker の終了・再起動でもリセットまたは再利用しない。
   候補集合や履歴の revision を表す値ではない。
+- `slot`: `live` または `cache`。
+  zsh が所有する列挙であり、worker はスロットの意味を解釈しない。
+  worker はスロットごとに最大 1 generation の解析済み candidate store を保持し、
+  新しい `store` の受理は**同一スロットの**前 generation だけを破棄する(他スロットの generation は残る)。
+  candidate store は worker セッションに属し、worker の終了とともに失われる。
+- `candidate_generation`: zsh が所有する `1..=9223372036854775807`(`i64::MAX`)の canonical ASCII 10 進識別子。
+  先頭ゼロを付けない。
+  `request_id` とは独立の値である。
+  シェルセッション内で単調増加し、再利用せず、worker の終了・再起動でもリセットしない。
+  `store` では格納先の generation を、`plan` では参照する generation を表す。
+  `plan` の generation 検索はスロット横断で行い、ヒットしたスロットの解析結果から描画プランを計算する。
+- `candidate_payload`: 後述の候補レコードストリーム全体をそのまま格納する opaque bytes。
 - `producer`: `compsys` または `history`。
   結果順に加えてレイアウト方針を選ぶ: `compsys` は最大 8 列・上から下、
   `history` は 1 列・下から上。レコード解釈・ハイライト・挿入テキスト構築は共通である
@@ -197,21 +216,39 @@ error: ["error", request_id, code]
   基準に解決する。worker 自身の起動時 cwd は判定に使わない。絶対 stat パスはそのまま使い、
   シンボリックリンクは追跡する。`~` は展開しない。cwd または対象パスを stat できない場合は
   「ディレクトリでない」と扱い、`/` を合成しない。
-- `candidate_payload`: 後述の候補レコードストリーム全体をそのまま格納する opaque bytes。
 
-完全な message から canonical な `request_id` を回収できた後に、kind・フィールド数・列挙値・数値の
-不正を検出した場合、worker は同じ `request_id` の `error` を返してセッションを継続する。
-`code` は `invalid-request`(plan 要求の kind・固定フィールド・scalar 不正)または
-`invalid-payload`(候補レコードストリームの framing error)のいずれかである。
+完全な message から canonical な `request_id` を回収できた後に要求を遂行できない場合、
+worker は同じ `request_id` の `error` を返してセッションを継続する。
+終端 `error` の `code` は要求の kind ごとに次のいずれかである。
+
+| kind | code | 意味 |
+|---|---|---|
+| `store` | `invalid-request` | kind・固定フィールド・scalar・`slot` 列挙の不正 |
+| `store` | `invalid-payload` | 候補レコードストリームの framing error |
+| `plan` | `invalid-request` | kind・固定フィールド・scalar の不正 |
+| `plan` | `unknown-generation` | どのスロットにも存在しない `candidate_generation` の参照 |
+
+`invalid-request` と `invalid-payload` は要求自体の不正を、
+`unknown-generation` は整形としては正しい要求が参照先を持たないことを表す。
+`plan` は候補 payload を運ばないため、`invalid-payload` は `plan` の code 集合に現れない。
+`store` の検証順は、`request_id` の回収 → kind・フィールド数・scalar(`slot` 列挙を含む)→
+`candidate_payload` の framing である。
+scalar と payload の双方に不正がある要求では、先に検出される `invalid-request` を返す。
+`error` で終わる `store` は既存のスロットをいっさい変更しない(全スロット無変更のまま終端 error を返す)。
 外側または nested netstring framing の破損、あるいは request_id の欠落・非 canonical 表記・範囲外によって
 安全に対応付けられない場合は応答せずセッションを終了する。
 
 `ready` を返したセッションでは、相関可能な各 request は `ok` または `error` の**終端応答をちょうど 1 個**受ける。
+`store` もこの規範に従う 1 個の request である。
 `incompatible` を返したセッションでその後に届くバイトは request ではなく、この規範の対象外である。
 worker は要求を受信順に処理し、応答を黙って省略しない。`error` も正常に形成された終端応答であり、
-worker セッション失敗には数えない。`ok` の `render_plan` は後述の描画プランストリームそのものを格納する。
+worker セッション失敗には数えない。
+zsh は `store` の終端応答を待たずに、同じ generation を参照する `plan` をその後ろへ pipeline してよい
+(pipeline の許容範囲は握手の規範と同じ)。
+`ok` の `body` は kind で決まる: `store` の成功では空バイト列、
+`plan` の成功では後述の描画プランストリームそのものである。
 
-### `candidate_payload`(候補レコードストリーム)
+### `store` の `candidate_payload`(候補レコードストリーム)
 
 > 検証(この節と以下の小節): 送信側(zsh のエンコーダ)の発行規範 — `tests/vectors/encode/`(`zsh -f tests/zsh/vectors.zsh`)。
 > worker セッションを通した受信側(Rust のパーサ)の解釈規範と、候補ストリーム framing error の
@@ -219,8 +256,7 @@ worker セッション失敗には数えない。`ok` の `render_plan` は後�
 > パーサの全域性 — `src/record.rs` の proptest。
 > 「history profile」の送信側規範(イベント番号との対応、重複・制御バイト除外) —
 > `tests/zsh/vectors.zsh`。受信側の解釈は上記のベクタが覆う。
-> 「compsys 捕獲 profile」の transport 側の規範(pid レコードの除去、
-> 空語収集キャッシュに保存する payload の形)も上記の検証の範囲外。
+> 「compsys 捕獲 profile」の transport 側の規範(pid レコードの除去)も上記の検証の範囲外。
 
 フレーミングは NUL(`\0`)終端のレコードが連続する形式。
 レコード内は `\2` で連結した `<tag>\1<value>` 形式のフィールドの並び。
@@ -253,7 +289,7 @@ worker セッション失敗には数えない。`ok` の `render_plan` は後�
   - `f`(値 `1`): ファイル候補であることを示す。
   - `rd`: チルダ・パラメータ展開済みの実ディレクトリ(ファイル候補の合成 `/` 判定に使う)。
   - `X`: グループ見出し文字列。`J`: グループ名。
-    グループキーの決定規則は `render_plan`「表示行の中身」節。
+    グループキーの決定規則は「描画プランストリーム」の「表示行の中身」節。
 - 共有フィールドが全て空でも、ヘッダレコードは必ず発行する
   (バッチ境界を一意に識別するため)。
 - 候補レコードを 1 件も発行しないバッチについては、
@@ -303,10 +339,11 @@ zpty 内で compsys を駆動して得る payload(behavior.md「候補収集」�
 - 重複候補(同一の match-text/display-text 組)は除去せずそのまま送ってよい。
 - 制御バイト(`\0` `\1` `\2`)を含む候補・値の除外は fork 内の compadd フックが保証する。
 - ワーカーの pid レコード(`pid\1<pid>\0` としてストリーム先頭に流れる)は、
-  zsh が受信中に取り除いてから plan 要求の `candidate_payload` へ入れる。
-  空語収集キャッシュ(behavior.md)に保存する payload も pid を取り除いた形が契約である。
+  zsh が受信中に取り除いてから `store` 要求の `candidate_payload` へ入れる。
   Rust 側でのスキップは保険であり、通常の入力では発生しない。
-- plan 要求のフィールド値: `producer` は `compsys`、`query` は広げ規則が定めるクエリ
+- `store` 要求のフィールド値: `slot` は空語収集キャッシュの対象となる収集なら `cache`、それ以外の収集なら `live`。
+  どの収集がキャッシュの対象かは behavior.md「空語収集キャッシュ」節が定める。
+- `plan` 要求のフィールド値: `producer` は `compsys`、`query` は広げ規則が定めるクエリ
   (behavior.md「候補収集」節)、`trailing_space` は `[insert].trailing-space` の設定値。
 
 #### history profile
@@ -321,7 +358,7 @@ zsh が履歴から合成する payload。
   欠番を詰めず、キーをそのまま使う。`m` / `d` は発行しない
   (match-text も番号接頭辞を付ける前のセル表示テキストも `w` そのもの)。
 - 候補レコードは新しい順(最新の履歴行が先頭)。
-  `producer = history` は `candidate_payload` の出現順を保つため(「マッチング・ランキングの意味論」節)、
+  `producer = history` は格納された候補レコードストリームの出現順を保つため(「マッチング・ランキングの意味論」節)、
   この順序がそのまま位置番号順になり、位置 1 は**マッチした候補のうち最も新しい履歴行**になる
   (クエリにマッチしない履歴行は位置を持たないため、位置 1 が payload の先頭レコードとは限らない。
   クエリが非空でもマッチ品質で並べ替わらない)。
@@ -342,10 +379,11 @@ zsh が履歴から合成する payload。
 - payload の合成は、全履歴の値の一括展開 1 回(履歴の総件数に線形)と、
   走査範囲の処理(打ち切りまでに読んだ行数と行長に線形)からなる
   (この payload は同期経路で合成される。behavior.md「履歴メニュー」節)。
-- plan 要求のフィールド値: `producer` は `history`、`query` はバッファ全体(as-typed)、
+- `store` 要求のフィールド値: `slot` は `live`。
+- `plan` 要求のフィールド値: `producer` は `history`、`query` はバッファ全体(as-typed)、
   `trailing_space` は常に `false`(挿入テキストを履歴行の原文と一致させるため)。
 
-### `ok` の `render_plan`(描画プランストリーム)
+### `plan` の `ok` body(描画プランストリーム)
 
 > 検証(この節と以下の小節。ただし「適用(zsh 側の規範)」を除く):
 > ワイヤ形式とプランの中身 — `tests/vectors/plan/` を、Rust のシリアライザと参照パーサ `src/wire.rs`(`tests/vectors.rs`)、
@@ -416,7 +454,7 @@ NUL(`\0`)終端フィールドの平坦列。数値は ASCII 10 進表記。順�
   受け取ったプランからエントリを再構築することで実現する:
   `pos == 選択位置` の match / history-number エントリをスキップし、
   代わりに選択エントリ(その位置のセル実テキスト範囲 + `selected` スペック)を追加する。
-  プランの再取得・plan 要求の再送は伴わない。
+  プランの再取得・`plan` 要求の再送は伴わない。
 - match 装飾は match-text をそのまま表示しているセルにのみ発行される
   (display-text 表示セルには発行されない)。
   切り詰め済みセルへのクリップも Rust 側で計算済み。
@@ -498,7 +536,7 @@ NUL(`\0`)終端フィールドの平坦列。数値は ASCII 10 進表記。順�
   (バッチヘッダの共有フィールド + その候補固有の `w`)。
 - `f = 1` かつ連結結果の末尾が `/` でない候補は、`rd` と match-text
   (`m` があれば `m`、なければ `w`)の生バイト列を連結したパスを、
-  plan 要求の `cwd` を基準に、シンボリックリンクを追跡して stat する。
+  `plan` 要求の `cwd` を基準に、シンボリックリンクを追跡して stat する。
   stat が失敗する場合・対象がディレクトリでない場合は `/` を合成しない。
   この判定はプラン計算時点のスナップショットであり、zsh は確定時に再検証しない
   (該当ディレクトリがプラン計算後に削除・変更されていても、返された挿入テキストをそのまま使う)。
@@ -607,9 +645,20 @@ zsh は一覧を消す。
 
 - zsh は応答の外側/nested netstring、固定フィールド数、kind、canonical な request_id、
   および request_id が未完了要求の 1 つに対応することを検証する。不正なら worker セッションを壊れたものとして終了する。
+- `error` の `code` は `invalid-request` / `invalid-payload` / `unknown-generation` のいずれかでなければならない。
+  それ以外の値は不正な応答であり、worker セッションを壊れたものとして終了する。
 - `error` は相関する要求の正常な終端応答である。その要求の結果を破棄し、それが現在の最新要求なら
   既存一覧も消す。stale 要求なら UI 状態を変えない。どちらの場合も worker は継続利用する。
-- `ok` の `render_plan` が仕様を満たさない場合
+- `unknown-generation` は、`plan` が参照した generation を worker が保持していないことを表す。
+  他の `error` と同じく正常な終端応答であり、worker セッション失敗にも連続失敗回数にも数えない。
+  zsh はその要求も先行する `store` も replay しない。
+  latch を参照して送った `plan` であれば、その candidate store latch を無効化する
+  (latch の所在と無効化点は behavior.md「worker ライフサイクル」節が定める)。
+  非同期の補完経路では、入力がまだ current なら新しい収集を開始して新しい generation を作る。
+  履歴メニューの同期交換では他の `error` と同じく交換の失敗として扱う(behavior.md「履歴メニュー」節)。
+- `store` の `ok` は body が空バイト列であることを検証する。
+  空でなければ仕様を満たさない応答として扱い、プランを破棄する場合と同じく worker セッションを終了する。
+- `plan` の `ok` body が仕様を満たさない場合
   (最終フィールドの NUL 終端欠落、`L` / `P` / `H` が非負の数字列でない、
   総フィールド数が `4 + L + H + 3P` と一致しない、ハイライト・セル範囲・ナビゲーションの
   各タプルの要素数が不正、`role` が `match` / `heading` / `history-number` 以外、
@@ -764,11 +813,14 @@ typeset -g _ZRUSH_EXPECTED_BUILD_STAMP='<build-stamp>'
    最初の要求は `ready` を待たずに `hello` の後ろへ pipeline する(「セッションフレーミングと握手」節)。
    遅延起動時に runtime directory/FIFO を作成してはならない。spawn 後の parent endpoint/watcher failure と
    writer notification/watcher failure の fail-closed quarantine・runtime taint は behavior.md が定める。
-4. 入力変化 → デバウンス → zpty 収集完了後: zsh が pid レコードを取り除いた
-   捕獲 payload を `producer = compsys` の plan 要求で worker に送る。
-   対応する `ok` の描画プランを POSTDISPLAY / region_highlight に適用する。
+4. 入力変化 → デバウンス → zpty 収集完了後: zsh が pid レコードを取り除いた捕獲 payload を、
+   新しい `candidate_generation` の `store` 要求(空語収集キャッシュの対象なら `cache`、それ以外は `live`)で送り、
+   続けて同じ generation を参照する `producer = compsys` の `plan` 要求を連送する。
+   `plan` に対応する `ok` の描画プランを POSTDISPLAY / region_highlight に適用する。
    以降の選択移動・確定は、プラン内のナビゲーション表・セル範囲・挿入テキストの配列引きだけで完結する
-   (plan 要求の再送はしない)。
+   (要求の再送はしない)。
+   空語収集キャッシュがヒットした場合は収集も `store` も行わず、
+   worker が保持している generation を参照する `plan` 要求だけを送る(behavior.md「空語収集キャッシュ」節)。
 5. 非選択での select-prev(既定 ↑): zsh がメモリ上の履歴から payload を合成し、
-   `producer = history` の plan 要求と応答を同期交換して、返ったプランを同じように適用する
+   `store`(`live`)と `producer = history` の `plan` を同期交換で連送して、返ったプランを同じように適用する
    (fork も compsys も介さない。behavior.md「履歴メニュー」節)。

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -118,7 +118,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   `unknown-generation` を受けたときに無効化する。
   latch を無効化した generation を payload の再送で復元することはせず、
   失敗した `store` / `plan` も replay しない。
-  次の実入力による新しい収集だけが新しい generation を作る。
+  新しい generation を作るのは新しい収集だけである。
 - 正常 shutdown は unhanded frame を破棄し、unacked writer があれば full-frame ack を待つ。
   ack を受けると writer が既に自身の request fd を閉じているため、対話シェルの request write fd を閉じて
   frame 境界の EOF を作る。その後も abort-control write fd は閉じず、response FIFO を bytes のまま EOF まで
@@ -150,7 +150,8 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   worker が健全に finalization された後、ユーザーが明示的に re-source した場合だけ、この reason と
   failure counter を 0 に戻して新しい worker 起動を許可する。request_id、callback generation、warning latch は
   戻さず、未完了 request の replay もしない。自動 build-stamp re-source はこの解除を行わない。
-  invalid handshake、request_id 枯渇、runtime setup failure など別の disable reason はこの操作で解除しない。
+  invalid handshake、request_id または candidate_generation の枯渇、runtime setup failure など
+  別の disable reason はこの操作で解除しない。
 - 正しい形の `incompatible`、stamp の異なる `ready`、source/config の build-stamp 不一致は stale build として
   失敗回数を介さず `$ZRUSH_BIN init zsh` の自動 re-source を 1 回だけ試みる。成功時は警告せず診断ログだけを残し、
   検出時点の未完了 request はすべて破棄して replay しない。re-source の失敗または re-source 中の再不一致だけが
@@ -244,8 +245,9 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 結果をプロンプトを跨いでキャッシュする。
 
 - 対象は広げ結果が空文字列の収集のみ。
-  `sudo ` 後などのコマンド位置は、広げ結果が空文字列でも対象外とする。
-  ここで対象とした収集だけが `cache` スロットを使い、対象外の収集は `live` スロットを使う
+  `sudo ` 後などのコマンド位置は広げ結果が非空になるため対象外である。
+  広げ結果が空文字列でも、捕獲した payload が空の収集は対象外とする。
+  ここで対象とした収集だけが `cache` スロットを使い、それ以外の収集は `live` スロットを使う
   (cli-protocol.md「要求と応答」節)。
 - 解析済みの候補を保持するのは worker の `cache` スロットである(cli-protocol.md「要求と応答」節)。
   zsh が保持するのは**フィンガープリント・保存時刻・`cache` スロットの candidate store latch**

--- a/docs/internal/specs/behavior.md
+++ b/docs/internal/specs/behavior.md
@@ -60,7 +60,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   まで保持し、response EOF まで上記の rollback quarantine を続ける。readiness cleanup を保証できない場合は
   fail-closed のまま direct な明示 cleanup または shell exit に委ねてよい。EOF finalization 後も taint は残り、
   同じ source generation で worker を交換しない。
-- worker は最初の実 plan 要求で遅延起動し、対話シェルごとに高々 1 個とする。
+- worker は最初の実要求で遅延起動し、対話シェルごとに高々 1 個とする。
   stdin/stdout は request/response FIFO に接続し、abort-control FIFO の read fd を
   `zrush worker --control-fd N` で渡す(詳細は `../contracts/cli-protocol.md`)。
   worker と短命な writer child は対話シェルの job table に登録せず、zsh は両者の numeric PID を
@@ -74,8 +74,9 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   control channel や request FIFO の EOF、job/exit status から完了を推測しない。
 - request/response の nested-netstring と `hello` / `ready` は
   `../contracts/cli-protocol.md` が定める。通常の補完経路は cold start・握手・応答を同期的に待たず、
-  response fd の `zle -F` callback で進める。同期的に起動/plan 応答を待てるのは履歴メニューだけで、
-  その 1 本の絶対 100ms deadline に起動・握手・先行 request・対象応答をすべて含める。
+  response fd の `zle -F` callback で進める。同期的に起動と応答を待てるのは履歴メニューだけで、
+  その 1 本の絶対 100ms deadline に起動・握手・先行 request・`store` と `plan` の連送・
+  `plan` の終端応答をすべて含める。
 - worker stdin への送信単位は完成済み frame 1 個で、outbound queue に send offset を持たない。
   対話シェル自身は request FIFO へ blocking write せず、cloexec 付き request write fd を fork した
   短命な writer child に渡す。fork した child は request と通知以外の transport fd copy を直ちに閉じ、
@@ -106,6 +107,18 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   **異常 abort** がある。どちらも最初に stopping gate を立て、normal callback と新しい enqueue/send/start を止め、
   unhanded frame と session の未完了 request をすべて破棄し、一覧を消して replay しない。
   zrush の disable policy は stop mode と別に決める。
+- 解析済みの候補は worker がスロット(`live` / `cache`)ごとに candidate generation 単位で保持する
+  (`../contracts/cli-protocol.md`「要求と応答」節)。
+  zsh が要求を跨いで参照するのは `cache` スロットだけであり、
+  「現 worker session が `cache` スロットにどの generation を保持しているか」を
+  **candidate store latch** として持つ。
+  `live` スロットの store は直後に連送する `plan` からしか参照しないため、latch を持たない。
+  candidate store は worker session に属するため、latch は worker の起動・正常 shutdown・異常 abort・
+  session failure・worker の交換・re-source のたび、および latch を参照して送った `plan` が
+  `unknown-generation` を受けたときに無効化する。
+  latch を無効化した generation を payload の再送で復元することはせず、
+  失敗した `store` / `plan` も replay しない。
+  次の実入力による新しい収集だけが新しい generation を作る。
 - 正常 shutdown は unhanded frame を破棄し、unacked writer があれば full-frame ack を待つ。
   ack を受けると writer が既に自身の request fd を閉じているため、対話シェルの request write fd を閉じて
   frame 境界の EOF を作る。その後も abort-control write fd は閉じず、response FIFO を bytes のまま EOF まで
@@ -197,8 +210,14 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   候補レコードを継承 pipe fd へ NUL 区切りで搬出する(終端 = EOF)。
   フレーミングに使う制御バイト(NUL、`\1`、`\2`)を含む候補は一覧に載らない。
   レコードのタグ構成(バッチヘッダ・`m` タグを含む)は
-  `../contracts/cli-protocol.md`(plan 要求の `candidate_payload`)の契約に従う。
+  `../contracts/cli-protocol.md`(`store` 要求の `candidate_payload`)の契約に従う。
   キャンセルは worker 自己申告 pid のプロセスグループへの SIGINT → `zpty -d`。
+- 収集が完走したら、その payload を新しい candidate generation の `store` 要求で worker へ渡し、
+  続けて同じ generation を参照する `plan` 要求を連送する
+  (`../contracts/cli-protocol.md`「要求と応答」節)。
+  スロットは空語収集キャッシュの対象となる収集が `cache`、それ以外の収集が `live`。
+  どの収集がキャッシュの対象かは「空語収集キャッシュ」節が定める。
+  payload を zsh 側に保持することはせず、後続の要求は generation 参照だけで済ませる。
 - 新しいリクエストの開始時に進行中の収集をキャンセルする。
   **キャンセルされたリクエストの結果は、その後に到着しても表示に使わない**
   (`zpty -d` 後に届く残留データは捨てる)。
@@ -224,21 +243,30 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 行頭のコマンド位置(広げ結果が空文字列)の収集は最重量ケース(全コマンド名)のため、
 結果をプロンプトを跨いでキャッシュする。
 
-- 対象は広げ結果が空文字列の収集のみ。`sudo ` 後などのコマンド位置は対象外。
-- キャッシュが保持するのは**生の捕獲 payload(ワーカーの pid レコードを取り除いた形。
-  cli-protocol.md)・フィンガープリント・保存時刻**の 3 つ。
-  解析・マッチング結果そのものはキャッシュしない(解析は Rust worker の責務のため)。
-- 検証は使用時に行う: **フィンガープリント**(`$PATH` 文字列 + PATH 各ディレクトリの
+- 対象は広げ結果が空文字列の収集のみ。
+  `sudo ` 後などのコマンド位置は、広げ結果が空文字列でも対象外とする。
+  ここで対象とした収集だけが `cache` スロットを使い、対象外の収集は `live` スロットを使う
+  (cli-protocol.md「要求と応答」節)。
+- 解析済みの候補を保持するのは worker の `cache` スロットである(cli-protocol.md「要求と応答」節)。
+  zsh が保持するのは**フィンガープリント・保存時刻・`cache` スロットの candidate store latch**
+  (現 worker session が保持している generation)の 3 つだけで、生の捕獲 payload は保持しない。
+- 検証は使用時に行う。
+  ヒットの条件は次の 3 つがすべて成り立つこと:
+  **フィンガープリント**(`$PATH` 文字列 + PATH 各ディレクトリの
   mtime + 関数・エイリアス・ビルトインの個数。`autocd` 有効または PATH に相対要素が
-  ある場合のみ `$PWD` を含める)の一致と、**TTL 300 秒**(固定値)。
-- ヒット時は compsys の fork をせず、キャッシュした payload をそのまま plan 要求の
-  `candidate_payload` に入れて結果を得る。ミス時は通常どおり収集し、成功時に payload とフィンガープリントを保存する。
+  ある場合のみ `$PWD` を含める)の一致、**TTL 300 秒**(固定値)以内、latch が有効であること。
+- ヒット時は compsys の fork も `store` も行わず、latch が指す generation を参照する `plan` 要求だけを送る
+  (payload の転送も再解析も起こらない)。
+- ミス時は通常どおり収集し、成功時に新しい generation を `cache` スロットへ `store` してから
+  フィンガープリント・保存時刻・latch を更新する。
+  worker session を失った後は latch が無効なため、フィンガープリントと TTL が有効でもミスとして再収集する
+  (latch の無効化点は「worker ライフサイクル」節)。
 - 既知の癖: compsys が補完関数を遅延ロードすると関数個数が増え、直後の 1 回だけ
   余計にミスする。これは正しい無効化であり一度きりで収束する。
 
 ## マッチング
 
-- 常駐 Rust worker の plan 要求処理が担う。ティア序列は
+- 常駐 Rust worker の `plan` 要求処理が担う。ティア序列は
   **prefix > substring > edit(誤字許容)> fuzzy(部分列)** で、`mode` が
   どのティアまで拾うかの上限を決める。prefix / substring は literal、edit / fuzzy は
   approximate とする。`mode` が許す literal マッチが 1 件以上あれば approximate マッチを
@@ -262,7 +290,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   worker が補完一覧ではランキング上位 `rows × 8` 件、履歴一覧では先頭 `rows` 件
   (それぞれのレイアウトが取り得る最大容量)までをレイアウト対象に取る
   (Rust 内部の上限。プロトコルには現れない)。
-- 補完一覧の plan 要求は、収集完了後の非同期結果経路から worker へ送る。
+- 補完一覧の要求(`store` と `plan`)は、収集完了後の非同期結果経路から worker へ送る。
   応答は worker stdout の `zle -F` コールバックで受け、キー入力を同期的に待たせない
   (「入力は決してブロックしない」原則)。
   例外は履歴メニューで、こちらは select-prev の押下時に同期実行する(「履歴メニュー」節)。
@@ -275,7 +303,7 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   挿入テキストは原文のまま返る。
 - 端末リサイズ時: 描画プランは要求時点の `rows` / `width` に基づくスナップショットであり、
   リサイズ直後に自動で再計算されることはない。
-  次の plan 要求までのレイアウトのズレは仕様外として許容する。
+  次の `plan` 要求までのレイアウトのズレは仕様外として許容する。
 - 装飾は `[display.highlight]` の 4 種(selected / match / heading / history-number)。
   match と history-number の装飾は選択中セルには適用しない
   (実現方法は cli-protocol.md「ハイライト」節: 選択変更のたびに
@@ -330,7 +358,9 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   遅れて到着した補完結果が履歴メニューを置き換えることはない。
 - payload は zsh がメモリ上の履歴から合成する(fork も compsys も介さない。
   合成規則は cli-protocol.md「history profile」)。
-  worker との plan 要求/応答を同期的に待つのはこの経路だけである。
+  合成した payload は新しい candidate generation の `store` 要求(`live` スロット)で送り、
+  続けて同じ generation を参照する `plan` 要求を連送する。
+  worker との要求/応答を同期的に待つのはこの経路だけである。
 - 合成する payload の総バイト数には**固定の上限 262144 バイト(256 KiB)**を置く。
   新しい方から走査し、次の候補レコードを加えると上限を超える時点で走査を打ち切る。
   そのレコードとそれより古い履歴行は送らず、レコードの途中で切ることもしない。
@@ -339,15 +369,17 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
   1 行の長さには上限を設けないため、`[history].limit` 件に達するより先にバイト上限へ達することがあり、
   その場合に履歴一覧が対象にするのは走査範囲のうち新しい側の一部だけになる。
   最も新しい候補レコード 1 件だけで上限を超える場合は候補が 0 件になり、後述の「マッチ 0 件」に従う。
-- 履歴 payload の合成が完了した直後から、対象 request_id の完全な終端応答を受け取るまでを
+- 履歴 payload の合成が完了した直後から、`plan` 要求の完全な終端応答を受け取るまでを
   **1 本の絶対 100ms deadline**で制限する。worker が未起動なら、その起動・`hello` / `ready` 握手・
-  要求送信・完全な応答受信をすべて同じ 100ms に含める。deadline は固定方針であり設定項目にしない。
+  `store` と `plan` の送信・`store` の終端応答の消費・完全な `plan` 応答の受信をすべて同じ 100ms に含める。
+  deadline は固定方針であり設定項目にしない。
   環境変数 `ZRUSH_HISTORY_DEADLINE_MS`(ミリ秒、未設定時は 100)で deadline を上書きできるが、これは `zsh/zrush.zsh` の `ZRUSH_BIN` と `ZRUSH_NO_INIT` に倣ったテストドライバ専用の seam である。
   payload 合成に費やす時間はこの deadline に含めない。
-- 対象 request_id の完全な終端応答を受信した時点で同期待ちは終了する。
+- `plan` 要求の完全な終端応答を受信した時点で同期待ちは終了する
+  (先行する `store` の終端応答はその途中で消費する)。
   受信済みで未処理の後続応答は同期待ちの中では処理せず、非同期経路が引き取る。
 - 同期待ちの間に先行する非同期要求の応答を受けた場合も通常どおり終端まで読み、stale なら破棄して
-  対象 request_id を待ち続ける。先行要求の outbound queue 送信と直列処理に費やす時間も同じ deadline を消費する。
+  `plan` 要求の request_id を待ち続ける。先行要求の outbound queue 送信と直列処理に費やす時間も同じ deadline を消費する。
   deadline を要求ごと・write/read ごとに延長しない。超過時は worker プロセスを終了させて消滅を確認し、
   watcher を解除して pipe fd を閉じてから、その session の未完了要求をすべて破棄する。自動 replay しない
   (連続失敗の扱いは「worker ライフサイクル」)。
@@ -377,9 +409,9 @@ zsh は zle 統合・compsys 呼び出しによる捕獲・プランの適用
 - 履歴メニューを消して通常状態へ戻る条件:
   - **マッチ 0 件**(履歴が 0 件の場合を含む)→ メニューは開かず(既存の一覧があれば消し)、
     キーは消費してバッファは変えない。素の履歴移動へのフォールバックはしない。
-  - **同期 worker 交換の失敗**(`error` 応答、worker セッション失敗、deadline 超過、
-    または仕様を満たさない `ok`)→ 一覧と種別を破棄し、
-    バッファは変えない(cli-protocol.md「エラー時の zsh 側挙動」)。
+  - **同期 worker 交換の失敗**(`store` または `plan` の `error` 応答、worker セッション失敗、
+    deadline 超過、または仕様を満たさない `ok`)→ 一覧と種別を破棄し、
+    バッファは変えない(cli-protocol.md「応答の検証と zsh 側の適用(規範)」)。
   - **zrush のアクション以外の要因による `BUFFER` / `CURSOR` の変化**
     (文字入力・編集・カーソル移動・他ウィジェット)→ 履歴メニューを全消去して通常フローへ戻る。
     補完一覧のように一覧テキストを残すことはしない。

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,6 @@
 //! Grid layout, highlight, and navigation engine for worker plan requests.
 //!
-//! Semantics: docs/internal/contracts/cli-protocol.md "render_plan",
+//! Semantics: docs/internal/contracts/cli-protocol.md 「`plan` の `ok` body」,
 //! specifically "表示行の中身" (grouping/grid), "オフセット規律"
 //! (char-count vs display-width split), "ハイライト", and "ナビ". This
 //! module owns grouping, the column-major grid, cell truncation/padding,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,6 +1,6 @@
 //! Orchestration for worker plan requests (cli-protocol.md "`zrush worker`").
 //!
-//! Pipeline: record::parse -> hidden-file exclusion -> matching::QueryMatcher
+//! Pipeline: hidden-file exclusion -> matching::QueryMatcher
 //! (score every remaining candidate + common-prefix over the *untruncated*
 //! prefix-tier matches)
 //! -> ranking::rank (suppress approximate tiers when a literal exists,
@@ -13,10 +13,10 @@
 //! (this is where `-f` directory-synthesis stat happens, and only for
 //! positions layout actually kept) -> wire::serialize.
 //!
-//! `run` takes one complete candidate payload and an injected
-//! `is_dir` predicate, so it stays free of I/O and is directly testable.
-//! The only error this pipeline itself can produce is candidate framing
-//! violation (record.rs); session I/O belongs to worker.rs.
+//! `compute` reads an already-parsed candidate payload (record::Stored) and
+//! takes an injected `is_dir` predicate, so it stays free of I/O and is
+//! directly testable. It cannot fail: the payload was validated when the
+//! `store` request parsed it, and session I/O belongs to worker.rs.
 
 use crate::matching::{Mode, QueryMatcher, Tier};
 use crate::span::CharSpan;
@@ -57,13 +57,14 @@ impl Producer {
     }
 }
 
-/// Run the full pipeline and return the serialized render plan.
-pub(crate) fn run(
+/// Run the full pipeline over a stored candidate payload and return the
+/// serialized render plan.
+pub(crate) fn compute(
     params: &Params,
-    payload: &[u8],
+    stored: &record::Stored,
     is_dir: &dyn Fn(&[u8]) -> bool,
-) -> Result<Vec<u8>, record::FramingError> {
-    let parsed = record::parse(payload)?;
+) -> Vec<u8> {
+    let batches = stored.batches();
 
     let mut qm = QueryMatcher::new(&params.query, params.mode, params.smart_case);
     let mut matched: Vec<(usize, crate::matching::TierHit)> = Vec::new();
@@ -74,9 +75,9 @@ pub(crate) fn run(
     // cli-protocol.md "隠し候補の除外": excluded before tier classification, so
     // hidden files reach neither the listing nor common-prefix.
     let hidden_opt_in = params.query.first() == Some(&b'.');
-    for (idx, cand) in parsed.candidates.iter().enumerate() {
+    for (idx, cand) in stored.candidates().enumerate() {
         let text = cand.match_text();
-        if !hidden_opt_in && text.starts_with(b".") && parsed.batches[cand.batch].f == b"1" {
+        if !hidden_opt_in && text.starts_with(b".") && batches[cand.batch].f == b"1" {
             continue;
         }
         if let Some(hit) = qm.classify(text) {
@@ -96,7 +97,7 @@ pub(crate) fn run(
     let ranked = ranking::rank(&matched, cap, params.producer.order());
     let candidates: Vec<record::Candidate<'_>> = ranked
         .iter()
-        .map(|&(idx, _)| parsed.candidates[idx])
+        .map(|&(idx, _)| stored.candidate(idx))
         .collect();
     // spans() is a second pass by design (matching.rs docs): only run it
     // on the ranked subset that actually reaches layout, and derive it
@@ -115,7 +116,7 @@ pub(crate) fn run(
 
     let built = layout::build(
         &candidates,
-        &parsed.batches,
+        &batches,
         &sources,
         &spans,
         params.rows,
@@ -130,12 +131,12 @@ pub(crate) fn run(
         .iter()
         .map(|&i| {
             let cand = &candidates[i];
-            let batch = &parsed.batches[cand.batch];
+            let batch = &batches[cand.batch];
             insert::build(batch, cand, params.trailing_space, is_dir)
         })
         .collect();
 
-    Ok(wire::serialize(common_prefix, &built, &insert_texts))
+    wire::serialize(common_prefix, &built, &insert_texts)
 }
 
 /// Compose the display source for every candidate before the layout phase.
@@ -331,6 +332,17 @@ mod tests {
         false
     }
 
+    /// The store-then-plan pair the worker performs, as one call: parse a
+    /// payload and compute a plan from the result.
+    fn run(
+        params: &Params,
+        payload: &[u8],
+        is_dir: &dyn Fn(&[u8]) -> bool,
+    ) -> Result<Vec<u8>, record::FramingError> {
+        let stored = record::parse(payload.to_vec())?;
+        Ok(compute(params, &stored, is_dir))
+    }
+
     fn parse_wire(out: &[u8]) -> wire::Plan {
         wire::parse(out).expect("valid plan")
     }
@@ -378,13 +390,6 @@ mod tests {
     fn empty_stdin_is_the_four_field_zero_match_form() {
         let out = run(&params("abc", Mode::Typo, 10, 40, true), b"", &no_dir).unwrap();
         assert_eq!(out, b"\x000\x000\x000\x00");
-    }
-
-    #[test]
-    fn framing_error_is_reported() {
-        // no trailing NUL: framing violation (record.rs).
-        let err = run(&params("a", Mode::Typo, 10, 40, true), b"b", &no_dir).unwrap_err();
-        assert_eq!(err, crate::record::FramingError);
     }
 
     #[test]

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,18 +1,34 @@
-//! Candidate-payload record parser for worker plan requests.
+//! Candidate-payload record parser and the parsed form the worker retains.
 //!
 //! Format and semantics: docs/internal/contracts/cli-protocol.md
-//! ("`zrush worker`" -> "candidate_payload", source of truth). NUL-terminated
-//! records; fields within a record are `\2`-joined `<tag>\1<value>` pairs.
-//! Batch header records (first field tag `b`) carry shared fields that
-//! apply to every candidate record up to the next header; candidate
-//! records (first field tag `w`) carry per-candidate `w`/`m`/`d`/`n`.
+//! ("`zrush worker`" -> 「`store` の `candidate_payload`」, source of truth).
+//! NUL-terminated records; fields within a record are `\2`-joined
+//! `<tag>\1<value>` pairs. Batch header records (first field tag `b`) carry
+//! shared fields that apply to every candidate record up to the next header;
+//! candidate records (first field tag `w`) carry per-candidate `w`/`m`/`d`/`n`.
 //!
-//! Zero-copy: every value here borrows from the request payload.
+//! [`parse`] takes ownership of one payload and returns a [`Stored`] that
+//! keeps those bytes: a `store` request parses once, and each later `plan`
+//! reads [`Batch`] / [`Candidate`] views borrowing from the retained buffer.
 //! plan.rs is the consumer.
 
 const REC_SEP: u8 = 0; // \0: terminates a record
 const FIELD_SEP: u8 = 2; // \2: joins fields within a record
 const TAG_SEP: u8 = 1; // \1: separates a field's tag from its value
+
+/// Byte range into a [`Stored`] buffer. Empty stands for "absent", matching
+/// the contract's equivalence of an absent field and an empty value.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ByteSpan {
+    start: usize,
+    end: usize,
+}
+
+impl ByteSpan {
+    fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+}
 
 /// Shared fields from a batch header record, inherited by every candidate
 /// up to the next header (cli-protocol.md "バッチヘッダレコード").
@@ -68,36 +84,111 @@ impl<'a> Candidate<'a> {
     }
 }
 
-/// Parsed candidate payload: batch headers and candidates in stream order.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct Parsed<'a> {
-    pub batches: Vec<Batch<'a>>,
-    pub candidates: Vec<Candidate<'a>>,
+/// A batch header's shared fields as ranges into the owning [`Stored`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct BatchSpans {
+    p_vis: ByteSpan,
+    p_hidden: ByteSpan,
+    s_vis: ByteSpan,
+    s_hidden: ByteSpan,
+    i_vis: ByteSpan,
+    i_hidden: ByteSpan,
+    ip: ByteSpan,
+    f: ByteSpan,
+    rd: ByteSpan,
+    x: ByteSpan,
+    j: ByteSpan,
+}
+
+/// A candidate record's fields as ranges into the owning [`Stored`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CandidateSpans {
+    w: ByteSpan,
+    m: Option<ByteSpan>,
+    d: Option<ByteSpan>,
+    n: Option<ByteSpan>,
+    batch: usize,
+}
+
+/// One parsed candidate payload, owning the bytes its views borrow: batch
+/// headers and candidates in stream order.
+#[derive(Debug)]
+pub(crate) struct Stored {
+    bytes: Vec<u8>,
+    batches: Vec<BatchSpans>,
+    candidates: Vec<CandidateSpans>,
+}
+
+impl Stored {
+    fn slice(&self, span: ByteSpan) -> &[u8] {
+        &self.bytes[span.start..span.end]
+    }
+
+    /// Batch headers in stream order; a [`Candidate`]'s `batch` indexes this.
+    pub(crate) fn batches(&self) -> Vec<Batch<'_>> {
+        self.batches
+            .iter()
+            .map(|spans| Batch {
+                p_vis: self.slice(spans.p_vis),
+                p_hidden: self.slice(spans.p_hidden),
+                s_vis: self.slice(spans.s_vis),
+                s_hidden: self.slice(spans.s_hidden),
+                i_vis: self.slice(spans.i_vis),
+                i_hidden: self.slice(spans.i_hidden),
+                ip: self.slice(spans.ip),
+                f: self.slice(spans.f),
+                rd: self.slice(spans.rd),
+                x: self.slice(spans.x),
+                j: self.slice(spans.j),
+            })
+            .collect()
+    }
+
+    pub(crate) fn candidate_count(&self) -> usize {
+        self.candidates.len()
+    }
+
+    pub(crate) fn candidate(&self, index: usize) -> Candidate<'_> {
+        let spans = self.candidates[index];
+        Candidate {
+            w: self.slice(spans.w),
+            m: spans.m.map(|span| self.slice(span)),
+            d: spans.d.map(|span| self.slice(span)),
+            n: spans.n.map(|span| self.slice(span)),
+            batch: spans.batch,
+        }
+    }
+
+    pub(crate) fn candidates(&self) -> impl ExactSizeIterator<Item = Candidate<'_>> {
+        (0..self.candidate_count()).map(|index| self.candidate(index))
+    }
 }
 
 /// The only parse error: a non-empty stream whose last byte is not NUL.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct FramingError;
 
-/// Parse one complete candidate payload per cli-protocol.md.
-/// Mapping a `FramingError` to the worker response belongs to worker.rs.
-pub(crate) fn parse(input: &[u8]) -> Result<Parsed<'_>, FramingError> {
+/// Parse one complete candidate payload per cli-protocol.md, taking
+/// ownership of it. Mapping a `FramingError` to the worker response, and
+/// retaining the result per slot, belong to worker.rs.
+pub(crate) fn parse(bytes: Vec<u8>) -> Result<Stored, FramingError> {
     // NUL-terminated records: a non-empty stream must end with NUL, and
     // stripping it yields exactly the record list.
-    let body = match input.last() {
-        None => return Ok(Parsed::default()),
-        Some(&REC_SEP) => &input[..input.len() - 1],
+    let body_len = match bytes.last() {
+        None => 0,
+        Some(&REC_SEP) => bytes.len() - 1,
         Some(_) => return Err(FramingError),
     };
 
-    let mut batches: Vec<Batch<'_>> = Vec::new();
-    let mut candidates: Vec<Candidate<'_>> = Vec::new();
+    let mut batches: Vec<BatchSpans> = Vec::new();
+    let mut candidates: Vec<CandidateSpans> = Vec::new();
     // None until the first header is seen; candidate records before that
     // point are skipped (cli-protocol.md "スキップ規律").
     let mut current_batch: Option<usize> = None;
 
-    for record in body.split(|&b| b == REC_SEP) {
-        let mut fields = record.split(|&b| b == FIELD_SEP).map(split_field);
+    for (at, record) in split_spans(&bytes[..body_len], REC_SEP, 0) {
+        let mut fields =
+            split_spans(record, FIELD_SEP, at).map(|(at, field)| split_field(field, at));
         // Splitting even an empty slice yields one (empty) element, so a
         // record always has a first field.
         let (tag0, val0) = fields.next().expect("record has >= 1 field");
@@ -118,25 +209,46 @@ pub(crate) fn parse(input: &[u8]) -> Result<Parsed<'_>, FramingError> {
             _ => {}
         }
     }
-    Ok(Parsed {
+    Ok(Stored {
+        bytes,
         batches,
         candidates,
     })
 }
 
-/// Split a `<tag>\1<value>` field. A field without the separator cannot
-/// occur under the contract (framing-byte exclusion is the sender's
-/// guarantee); read it as an empty-value tag rather than panicking.
-fn split_field(field: &[u8]) -> (&[u8], &[u8]) {
+/// Split `input` on `separator`, pairing every piece with its own offset in
+/// the payload buffer; `base` is `input`'s offset there.
+fn split_spans(input: &[u8], separator: u8, base: usize) -> impl Iterator<Item = (usize, &[u8])> {
+    let mut at = base;
+    input
+        .split(move |&byte| byte == separator)
+        .map(move |piece| {
+            let start = at;
+            at += piece.len() + 1; // the separator the split consumed
+            (start, piece)
+        })
+}
+
+/// Split a `<tag>\1<value>` field at offset `at`. A field without the
+/// separator cannot occur under the contract (framing-byte exclusion is the
+/// sender's guarantee); read it as an empty-value tag rather than panicking.
+fn split_field(field: &[u8], at: usize) -> (&[u8], ByteSpan) {
+    let end = at + field.len();
     match field.iter().position(|&b| b == TAG_SEP) {
-        Some(i) => (&field[..i], &field[i + 1..]),
-        None => (field, b""),
+        Some(i) => (
+            &field[..i],
+            ByteSpan {
+                start: at + i + 1,
+                end,
+            },
+        ),
+        None => (field, ByteSpan { start: end, end }),
     }
 }
 
-/// Fold a header record's remaining fields into a `Batch`: unknown tags
+/// Fold a header record's remaining fields into a `BatchSpans`: unknown tags
 /// ignored, duplicate tags first-wins, empty value == absent.
-fn parse_batch_fields<'a>(fields: impl Iterator<Item = (&'a [u8], &'a [u8])>) -> Batch<'a> {
+fn parse_batch_fields<'a>(fields: impl Iterator<Item = (&'a [u8], ByteSpan)>) -> BatchSpans {
     let mut p_vis = None;
     let mut p_hidden = None;
     let mut s_vis = None;
@@ -167,19 +279,19 @@ fn parse_batch_fields<'a>(fields: impl Iterator<Item = (&'a [u8], &'a [u8])>) ->
             *slot = Some(val); // first occurrence wins
         }
     }
-    let present = |v: Option<&'a [u8]>| v.filter(|s| !s.is_empty()).unwrap_or(b"");
-    Batch {
-        p_vis: present(p_vis),
-        p_hidden: present(p_hidden),
-        s_vis: present(s_vis),
-        s_hidden: present(s_hidden),
-        i_vis: present(i_vis),
-        i_hidden: present(i_hidden),
-        ip: present(ip),
-        f: present(f),
-        rd: present(rd),
-        x: present(x),
-        j: present(j),
+    // An absent tag and an empty value both read as the empty span.
+    BatchSpans {
+        p_vis: p_vis.unwrap_or_default(),
+        p_hidden: p_hidden.unwrap_or_default(),
+        s_vis: s_vis.unwrap_or_default(),
+        s_hidden: s_hidden.unwrap_or_default(),
+        i_vis: i_vis.unwrap_or_default(),
+        i_hidden: i_hidden.unwrap_or_default(),
+        ip: ip.unwrap_or_default(),
+        f: f.unwrap_or_default(),
+        rd: rd.unwrap_or_default(),
+        x: x.unwrap_or_default(),
+        j: j.unwrap_or_default(),
     }
 }
 
@@ -187,10 +299,10 @@ fn parse_batch_fields<'a>(fields: impl Iterator<Item = (&'a [u8], &'a [u8])>) ->
 /// unknown tags (including a duplicate `w`) ignored, duplicate `m`/`d`/`n`
 /// first-wins, empty value == absent.
 fn parse_candidate_fields<'a>(
-    w: &'a [u8],
-    fields: impl Iterator<Item = (&'a [u8], &'a [u8])>,
+    w: ByteSpan,
+    fields: impl Iterator<Item = (&'a [u8], ByteSpan)>,
     batch: usize,
-) -> Candidate<'a> {
+) -> CandidateSpans {
     let mut m_raw = None;
     let mut d_raw = None;
     let mut n_raw = None;
@@ -202,11 +314,11 @@ fn parse_candidate_fields<'a>(
             _ => {} // unknown tag, or a later duplicate `w`/`m`/`d`/`n`
         }
     }
-    Candidate {
+    CandidateSpans {
         w,
-        m: m_raw.filter(|v| !v.is_empty()),
-        d: d_raw.filter(|v| !v.is_empty()),
-        n: n_raw.filter(|v| !v.is_empty()),
+        m: m_raw.filter(|span| !span.is_empty()),
+        d: d_raw.filter(|span| !span.is_empty()),
+        n: n_raw.filter(|span| !span.is_empty()),
         batch,
     }
 }
@@ -241,14 +353,132 @@ mod tests {
     proptest! {
         #[test]
         fn parse_is_total(input in arbitrary_parser_input()) {
-            let Ok(parsed) = parse(&input) else { return Ok(()) };
-            for cand in &parsed.candidates {
+            let Ok(parsed) = parse(input) else { return Ok(()) };
+            let batches = parsed.batches().len();
+            for cand in parsed.candidates() {
                 prop_assert!(!cand.w.is_empty(), "candidate with empty w: {cand:?}");
                 prop_assert!(
-                    cand.batch < parsed.batches.len(),
+                    cand.batch < batches,
                     "candidate batch index out of range: {cand:?}"
                 );
             }
+        }
+    }
+
+    /// Tag order of `BatchSpans` / [`Batch`], for indexing a generated
+    /// header's shared values against the parsed views.
+    const SHARED_TAGS: [&[u8]; 11] = [
+        b"P", b"p", b"S", b"s", b"i", b"I", b"ip", b"f", b"rd", b"X", b"J",
+    ];
+
+    #[derive(Debug)]
+    struct GeneratedCandidate {
+        w: Vec<u8>,
+        m: Option<Vec<u8>>,
+        d: Option<Vec<u8>>,
+        n: Option<Vec<u8>>,
+    }
+
+    #[derive(Debug)]
+    struct GeneratedBatch {
+        shared: Vec<Option<Vec<u8>>>,
+        candidates: Vec<GeneratedCandidate>,
+    }
+
+    /// A value a conforming sender can emit: non-empty and free of the
+    /// three framing bytes.
+    fn generated_value() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(3u8..=u8::MAX, 1..=8)
+    }
+
+    fn generated_batches() -> impl Strategy<Value = Vec<GeneratedBatch>> {
+        let candidate = (
+            generated_value(),
+            prop::option::of(generated_value()),
+            prop::option::of(generated_value()),
+            prop::option::of(generated_value()),
+        )
+            .prop_map(|(w, m, d, n)| GeneratedCandidate { w, m, d, n });
+        let batch = (
+            prop::collection::vec(prop::option::of(generated_value()), SHARED_TAGS.len()),
+            prop::collection::vec(candidate, 0..=4),
+        )
+            .prop_map(|(shared, candidates)| GeneratedBatch { shared, candidates });
+        prop::collection::vec(batch, 0..=3)
+    }
+
+    fn generated_payload(batches: &[GeneratedBatch]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for batch in batches {
+            out.extend_from_slice(b"b");
+            out.push(TAG_SEP);
+            for (tag, value) in SHARED_TAGS.iter().zip(&batch.shared) {
+                if let Some(value) = value {
+                    push_field(&mut out, tag, value);
+                }
+            }
+            out.push(REC_SEP);
+            for candidate in &batch.candidates {
+                out.extend_from_slice(b"w");
+                out.push(TAG_SEP);
+                out.extend_from_slice(&candidate.w);
+                for (tag, value) in [
+                    (b"m".as_slice(), &candidate.m),
+                    (b"d".as_slice(), &candidate.d),
+                    (b"n".as_slice(), &candidate.n),
+                ] {
+                    if let Some(value) = value {
+                        push_field(&mut out, tag, value);
+                    }
+                }
+                out.push(REC_SEP);
+            }
+        }
+        out
+    }
+
+    fn push_field(out: &mut Vec<u8>, tag: &[u8], value: &[u8]) {
+        out.push(FIELD_SEP);
+        out.extend_from_slice(tag);
+        out.push(TAG_SEP);
+        out.extend_from_slice(value);
+    }
+
+    // Every view is a range into the retained buffer, so a span that drifts
+    // still yields *some* byte string. Only comparing against the values the
+    // payload was built from ties a span to the field it claims to be.
+    proptest! {
+        #[test]
+        fn spans_recover_the_values_the_payload_was_built_from(
+            batches in generated_batches(),
+        ) {
+            let parsed = parse(generated_payload(&batches)).unwrap();
+            let views = parsed.batches();
+            prop_assert_eq!(views.len(), batches.len());
+
+            let mut index = 0;
+            for (batch_index, (spec, view)) in batches.iter().zip(&views).enumerate() {
+                let shared: [&[u8]; SHARED_TAGS.len()] = [
+                    view.p_vis, view.p_hidden, view.s_vis, view.s_hidden,
+                    view.i_vis, view.i_hidden, view.ip, view.f,
+                    view.rd, view.x, view.j,
+                ];
+                for ((tag, expected), actual) in SHARED_TAGS.iter().zip(&spec.shared).zip(shared) {
+                    let expected: &[u8] = expected.as_deref().unwrap_or(b"");
+                    prop_assert_eq!(actual, expected, "batch {} tag {:?}", batch_index, tag);
+                }
+
+                for expected in &spec.candidates {
+                    let candidate = parsed.candidate(index);
+                    prop_assert_eq!(candidate.w, &expected.w[..]);
+                    prop_assert_eq!(candidate.m, expected.m.as_deref());
+                    prop_assert_eq!(candidate.d, expected.d.as_deref());
+                    prop_assert_eq!(candidate.n, expected.n.as_deref());
+                    prop_assert_eq!(candidate.batch, batch_index);
+                    index += 1;
+                }
+            }
+            prop_assert_eq!(parsed.candidate_count(), index);
         }
     }
 
@@ -288,14 +518,14 @@ mod tests {
         let c2 = record(&[field("w", "grep")]);
         let refs: [&[u8]; 3] = [&header, &c1, &c2];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.batches.len(), 1);
-        assert_eq!(parsed.batches[0].j, b"cmds");
-        assert_eq!(parsed.candidates.len(), 2);
-        assert_eq!(parsed.candidates[0].w, b"git");
-        assert_eq!(parsed.candidates[0].batch, 0);
-        assert_eq!(parsed.candidates[1].w, b"grep");
-        assert_eq!(parsed.candidates[1].batch, 0);
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.batches().len(), 1);
+        assert_eq!(parsed.batches()[0].j, b"cmds");
+        assert_eq!(parsed.candidate_count(), 2);
+        assert_eq!(parsed.candidate(0).w, b"git");
+        assert_eq!(parsed.candidate(0).batch, 0);
+        assert_eq!(parsed.candidate(1).w, b"grep");
+        assert_eq!(parsed.candidate(1).batch, 0);
     }
 
     #[test]
@@ -305,11 +535,11 @@ mod tests {
         let without_m = record(&[field("w", "plain.txt")]);
         let refs: [&[u8]; 3] = [&header, &with_m, &without_m];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates[0].m, Some(&b"space name.txt"[..]));
-        assert_eq!(parsed.candidates[0].match_text(), b"space name.txt");
-        assert_eq!(parsed.candidates[1].m, None);
-        assert_eq!(parsed.candidates[1].match_text(), b"plain.txt");
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate(0).m, Some(&b"space name.txt"[..]));
+        assert_eq!(parsed.candidate(0).match_text(), b"space name.txt");
+        assert_eq!(parsed.candidate(1).m, None);
+        assert_eq!(parsed.candidate(1).match_text(), b"plain.txt");
     }
 
     #[test]
@@ -330,8 +560,8 @@ mod tests {
         ]);
         let refs: [&[u8]; 1] = [&header];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        let b = &parsed.batches[0];
+        let parsed = parse(input).unwrap();
+        let b = parsed.batches()[0];
         assert_eq!(b.p_vis, b"p1");
         assert_eq!(b.p_hidden, b"p2");
         assert_eq!(b.s_vis, b"s1");
@@ -350,9 +580,9 @@ mod tests {
         let header = record(&[field("b", "")]);
         let refs: [&[u8]; 1] = [&header];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.batches.len(), 1);
-        assert_eq!(parsed.batches[0], Batch::default());
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.batches().len(), 1);
+        assert_eq!(parsed.batches()[0], Batch::default());
     }
 
     #[test]
@@ -363,14 +593,14 @@ mod tests {
         let c2 = record(&[field("w", "b")]);
         let refs: [&[u8]; 4] = [&h1, &c1, &h2, &c2];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.batches.len(), 2);
-        assert_eq!(parsed.batches[0].j, b"g1");
-        assert_eq!(parsed.batches[0].x, b"Group 1");
-        assert_eq!(parsed.batches[1].j, b"g2");
-        assert_eq!(parsed.batches[1].x, b"Group 2");
-        assert_eq!(parsed.candidates[0].batch, 0);
-        assert_eq!(parsed.candidates[1].batch, 1);
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.batches().len(), 2);
+        assert_eq!(parsed.batches()[0].j, b"g1");
+        assert_eq!(parsed.batches()[0].x, b"Group 1");
+        assert_eq!(parsed.batches()[1].j, b"g2");
+        assert_eq!(parsed.batches()[1].x, b"Group 2");
+        assert_eq!(parsed.candidate(0).batch, 0);
+        assert_eq!(parsed.candidate(1).batch, 1);
     }
 
     #[test]
@@ -380,9 +610,9 @@ mod tests {
         let ok = record(&[field("w", "on-time")]);
         let refs: [&[u8]; 3] = [&stray, &header, &ok];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates.len(), 1);
-        assert_eq!(parsed.candidates[0].w, b"on-time");
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate_count(), 1);
+        assert_eq!(parsed.candidate(0).w, b"on-time");
     }
 
     #[test]
@@ -392,9 +622,9 @@ mod tests {
         let ok = record(&[field("w", "cand")]);
         let refs: [&[u8]; 3] = [&header, &pid, &ok];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.batches.len(), 1);
-        assert_eq!(parsed.candidates.len(), 1);
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.batches().len(), 1);
+        assert_eq!(parsed.candidate_count(), 1);
     }
 
     #[test]
@@ -405,9 +635,9 @@ mod tests {
         let ok = record(&[field("w", "good")]);
         let refs: [&[u8]; 3] = [&header, &bad, &ok];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates.len(), 1);
-        assert_eq!(parsed.candidates[0].w, b"good");
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate_count(), 1);
+        assert_eq!(parsed.candidate(0).w, b"good");
     }
 
     #[test]
@@ -417,9 +647,9 @@ mod tests {
         let ok = record(&[field("w", "ok")]);
         let refs: [&[u8]; 3] = [&header, &empty_w, &ok];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates.len(), 1);
-        assert_eq!(parsed.candidates[0].w, b"ok");
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate_count(), 1);
+        assert_eq!(parsed.candidate(0).w, b"ok");
     }
 
     #[test]
@@ -428,8 +658,8 @@ mod tests {
         let c = record(&[field("w", "word"), field("d", "display text")]);
         let refs: [&[u8]; 2] = [&header, &c];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates[0].d, Some(&b"display text"[..]));
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate(0).d, Some(&b"display text"[..]));
     }
 
     #[test]
@@ -438,8 +668,8 @@ mod tests {
         let c = record(&[field("w", "echo hi"), field("n", "12345")]);
         let refs: [&[u8]; 2] = [&header, &c];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates[0].n, Some(&b"12345"[..]));
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate(0).n, Some(&b"12345"[..]));
     }
 
     #[test]
@@ -453,11 +683,11 @@ mod tests {
         ]);
         let refs: [&[u8]; 2] = [&header, &c];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.candidates[0].m, None);
-        assert_eq!(parsed.candidates[0].d, None);
-        assert_eq!(parsed.candidates[0].n, None);
-        assert_eq!(parsed.candidates[0].match_text(), b"word");
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.candidate(0).m, None);
+        assert_eq!(parsed.candidate(0).d, None);
+        assert_eq!(parsed.candidate(0).n, None);
+        assert_eq!(parsed.candidate(0).match_text(), b"word");
     }
 
     #[test]
@@ -472,17 +702,17 @@ mod tests {
         ]);
         let refs: [&[u8]; 2] = [&header, &c];
         let input = payload(&refs);
-        let parsed = parse(&input).unwrap();
-        assert_eq!(parsed.batches[0].j, b"first");
-        assert_eq!(parsed.candidates[0].m, Some(&b"m1"[..]));
-        assert_eq!(parsed.candidates[0].n, Some(&b"10"[..]));
+        let parsed = parse(input).unwrap();
+        assert_eq!(parsed.batches()[0].j, b"first");
+        assert_eq!(parsed.candidate(0).m, Some(&b"m1"[..]));
+        assert_eq!(parsed.candidate(0).n, Some(&b"10"[..]));
     }
 
     #[test]
     fn empty_payload_is_zero_batches_and_candidates() {
-        let parsed = parse(&[]).unwrap();
-        assert_eq!(parsed.batches.len(), 0);
-        assert_eq!(parsed.candidates.len(), 0);
+        let parsed = parse(Vec::new()).unwrap();
+        assert_eq!(parsed.batches().len(), 0);
+        assert_eq!(parsed.candidate_count(), 0);
     }
 
     #[test]
@@ -490,9 +720,9 @@ mod tests {
         let header = record(&[field("b", "")]);
         let mut input = header;
         // No trailing NUL appended (unlike `payload`).
-        assert_eq!(parse(&input), Err(FramingError));
+        assert_eq!(parse(input.clone()).err(), Some(FramingError));
         // Sanity: same bytes plus a NUL do parse.
         input.push(0);
-        assert!(parse(&input).is_ok());
+        assert!(parse(input).is_ok());
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,4 @@
-//! Persistent worker session for plan requests.
+//! Persistent worker session for `store` and `plan` requests.
 
 use std::ffi::OsStr;
 use std::fmt;
@@ -143,21 +143,56 @@ enum MessageResult {
     Incompatible,
 }
 
-enum Request<'a> {
-    Valid {
-        request_id: &'a [u8],
-        cwd: &'a [u8],
+enum Request {
+    Store {
+        slot: Slot,
+        generation: i64,
+        payload: Vec<u8>,
+    },
+    Plan {
+        generation: i64,
+        cwd: Vec<u8>,
         params: plan::Params,
-        payload: &'a [u8],
     },
-    Invalid {
-        request_id: &'a [u8],
-    },
+    Invalid,
+}
+
+/// The slots zsh addresses; the worker never interprets what they mean.
+#[derive(Clone, Copy)]
+enum Slot {
+    Live,
+    Cache,
+}
+
+const SLOT_COUNT: usize = 2;
+
+/// At most one parsed candidate generation per slot, for the lifetime of
+/// this session (cli-protocol.md 「要求と応答」).
+#[derive(Default)]
+struct CandidateStore {
+    slots: [Option<(i64, record::Stored)>; SLOT_COUNT],
+}
+
+impl CandidateStore {
+    /// Replace this slot's generation, leaving every other slot untouched.
+    fn insert(&mut self, slot: Slot, generation: i64, stored: record::Stored) {
+        self.slots[slot as usize] = Some((generation, stored));
+    }
+
+    /// Look a generation up across every slot.
+    fn find(&self, generation: i64) -> Option<&record::Stored> {
+        self.slots
+            .iter()
+            .flatten()
+            .find(|(stored_generation, _)| *stored_generation == generation)
+            .map(|(_, stored)| stored)
+    }
 }
 
 pub(crate) fn run<R: Read, W: Write>(mut input: R, mut output: W) -> Result<End, Error> {
     let mut decoder = Decoder::new();
     let mut handshake = Handshake::Awaiting;
+    let mut store = CandidateStore::default();
     let mut buffer = [0; READ_BUFFER_SIZE];
 
     loop {
@@ -170,7 +205,7 @@ pub(crate) fn run<R: Read, W: Write>(mut input: R, mut output: W) -> Result<End,
         match decoder.feed(&buffer[..read]) {
             Ok(messages) => {
                 for message in messages {
-                    if process_message(&message, &mut handshake, &mut output)?
+                    if process_message(&message, &mut handshake, &mut store, &mut output)?
                         == MessageResult::Incompatible
                     {
                         discard_requests(&mut input);
@@ -180,7 +215,7 @@ pub(crate) fn run<R: Read, W: Write>(mut input: R, mut output: W) -> Result<End,
             }
             Err(feed_error) => {
                 for message in feed_error.completed {
-                    if process_message(&message, &mut handshake, &mut output)?
+                    if process_message(&message, &mut handshake, &mut store, &mut output)?
                         == MessageResult::Incompatible
                     {
                         discard_requests(&mut input);
@@ -202,13 +237,14 @@ fn discard_requests<R: Read>(input: &mut R) {
 fn process_message<W: Write>(
     message: &[u8],
     handshake: &mut Handshake,
+    store: &mut CandidateStore,
     output: &mut W,
 ) -> Result<MessageResult, Error> {
     let fields = decode_fields(message)?;
     match handshake {
         Handshake::Awaiting => process_hello(&fields, handshake, output),
         Handshake::Ready => {
-            process_request(&fields, output)?;
+            process_request(fields, store, output)?;
             Ok(MessageResult::Continue)
         }
     }
@@ -233,86 +269,134 @@ fn process_hello<W: Write>(
     Ok(MessageResult::Continue)
 }
 
-fn process_request<W: Write>(fields: &[Vec<u8>], output: &mut W) -> Result<(), Error> {
+fn process_request<W: Write>(
+    fields: Vec<Vec<u8>>,
+    store: &mut CandidateStore,
+    output: &mut W,
+) -> Result<(), Error> {
     let request_id = fields
         .get(1)
-        .filter(|value| parse_request_id(value).is_some())
-        .ok_or(Error::Protocol)?;
+        .filter(|value| parse_identifier(value).is_some())
+        .ok_or(Error::Protocol)?
+        .clone();
 
-    match parse_request(fields, request_id) {
-        Request::Invalid { request_id } => {
-            write_message(output, &[b"error", request_id, b"invalid-request"])
-        }
-        Request::Valid {
-            request_id,
+    match parse_request(fields) {
+        Request::Invalid => write_message(output, &[b"error", &request_id, b"invalid-request"]),
+        Request::Store {
+            slot,
+            generation,
+            payload,
+        } => match record::parse(payload) {
+            Ok(stored) => {
+                store.insert(slot, generation, stored);
+                write_message(output, &[b"ok", &request_id, b""])
+            }
+            Err(record::FramingError) => {
+                write_message(output, &[b"error", &request_id, b"invalid-payload"])
+            }
+        },
+        Request::Plan {
+            generation,
             cwd,
             params,
-            payload,
-        } => {
-            let is_dir = |path: &[u8]| is_dir_from(cwd, path);
-            match plan::run(&params, payload, &is_dir) {
-                Ok(render_plan) => write_message(output, &[b"ok", request_id, &render_plan]),
-                Err(record::FramingError) => {
-                    write_message(output, &[b"error", request_id, b"invalid-payload"])
-                }
+        } => match store.find(generation) {
+            Some(stored) => {
+                let is_dir = |path: &[u8]| is_dir_from(&cwd, path);
+                let body = plan::compute(&params, stored, &is_dir);
+                write_message(output, &[b"ok", &request_id, &body])
             }
-        }
+            None => write_message(output, &[b"error", &request_id, b"unknown-generation"]),
+        },
     }
 }
 
-fn parse_request<'a>(fields: &'a [Vec<u8>], request_id: &'a [u8]) -> Request<'a> {
-    let [
-        cmd,
-        _id,
-        cwd,
-        producer,
-        query,
-        mode,
-        smart_case,
-        rows,
-        width,
-        trailing_space,
-        payload,
-    ] = fields
-    else {
-        return Request::Invalid { request_id };
-    };
-    if cmd != b"plan" {
-        return Request::Invalid { request_id };
+fn parse_request(fields: Vec<Vec<u8>>) -> Request {
+    match fields.first().map(Vec::as_slice) {
+        Some(b"store") => parse_store(fields),
+        Some(b"plan") => parse_plan(fields),
+        _ => Request::Invalid,
     }
+}
 
-    let Some(producer) = parse_producer(producer) else {
-        return Request::Invalid { request_id };
+fn parse_store(fields: Vec<Vec<u8>>) -> Request {
+    let Ok([_kind, _id, slot, generation, payload]) = <[Vec<u8>; 5]>::try_from(fields) else {
+        return Request::Invalid;
     };
-    let Some(mode) = Mode::parse(std::str::from_utf8(mode).unwrap_or("")) else {
-        return Request::Invalid { request_id };
+    let Some(slot) = parse_slot(&slot) else {
+        return Request::Invalid;
     };
-    let Some(smart_case) = parse_bool(smart_case) else {
-        return Request::Invalid { request_id };
+    let Some(generation) = parse_identifier(&generation) else {
+        return Request::Invalid;
     };
-    let Some(rows) = parse_positive_usize(rows) else {
-        return Request::Invalid { request_id };
-    };
-    let Some(width) = parse_positive_usize(width) else {
-        return Request::Invalid { request_id };
-    };
-    let Some(trailing_space) = parse_bool(trailing_space) else {
-        return Request::Invalid { request_id };
+    Request::Store {
+        slot,
+        generation,
+        payload,
+    }
+}
+
+fn parse_plan(fields: Vec<Vec<u8>>) -> Request {
+    let Ok(
+        [
+            _kind,
+            _id,
+            generation,
+            cwd,
+            producer,
+            query,
+            mode,
+            smart_case,
+            rows,
+            width,
+            trailing_space,
+        ],
+    ) = <[Vec<u8>; 11]>::try_from(fields)
+    else {
+        return Request::Invalid;
     };
 
-    Request::Valid {
-        request_id,
+    let Some(generation) = parse_identifier(&generation) else {
+        return Request::Invalid;
+    };
+    let Some(producer) = parse_producer(&producer) else {
+        return Request::Invalid;
+    };
+    let Some(mode) = Mode::parse(std::str::from_utf8(&mode).unwrap_or("")) else {
+        return Request::Invalid;
+    };
+    let Some(smart_case) = parse_bool(&smart_case) else {
+        return Request::Invalid;
+    };
+    let Some(rows) = parse_positive_usize(&rows) else {
+        return Request::Invalid;
+    };
+    let Some(width) = parse_positive_usize(&width) else {
+        return Request::Invalid;
+    };
+    let Some(trailing_space) = parse_bool(&trailing_space) else {
+        return Request::Invalid;
+    };
+
+    Request::Plan {
+        generation,
         cwd,
         params: plan::Params {
             producer,
-            query: query.clone(),
+            query,
             mode,
             smart_case,
             rows,
             width,
             trailing_space,
         },
-        payload,
+    }
+}
+
+fn parse_slot(value: &[u8]) -> Option<Slot> {
+    match value {
+        b"live" => Some(Slot::Live),
+        b"cache" => Some(Slot::Cache),
+        _ => None,
     }
 }
 
@@ -332,7 +416,9 @@ fn parse_bool(value: &[u8]) -> Option<bool> {
     }
 }
 
-fn parse_request_id(value: &[u8]) -> Option<i64> {
+/// `request_id` and `candidate_generation` share one grammar: canonical
+/// ASCII decimal in `1..=i64::MAX`.
+fn parse_identifier(value: &[u8]) -> Option<i64> {
     let parsed = parse_canonical_u64(value)?;
     i64::try_from(parsed).ok().filter(|id| *id > 0)
 }
@@ -430,36 +516,173 @@ mod tests {
         }
     }
 
-    fn request<'a>(id: &'a [u8], cwd: &'a [u8], payload: &'a [u8]) -> Vec<&'a [u8]> {
+    /// One batch header plus one candidate record.
+    fn payload(word: &[u8]) -> Vec<u8> {
+        [b"b\x01\0w\x01", word, b"\0"].concat()
+    }
+
+    fn store_request<'a>(
+        id: &'a [u8],
+        slot: &'a [u8],
+        generation: &'a [u8],
+        payload: &'a [u8],
+    ) -> Vec<&'a [u8]> {
+        vec![b"store", id, slot, generation, payload]
+    }
+
+    fn plan_request<'a>(id: &'a [u8], generation: &'a [u8]) -> Vec<&'a [u8]> {
         vec![
-            b"plan", id, cwd, b"compsys", b"", b"typo", b"true", b"10", b"40", b"true", payload,
+            b"plan", id, generation, b"/", b"compsys", b"", b"typo", b"true", b"10", b"40", b"true",
         ]
     }
 
-    #[test]
-    fn handshake_and_multiple_requests_share_one_session() {
-        let hello = message(&[b"hello", BUILD_STAMP.as_bytes()]);
-        let first = request(b"1", b"/", b"");
-        let second = request(b"2", b"/", b"");
-        let input = [hello, message(&first), message(&second)].concat();
-        let mut output = Vec::new();
+    /// Field 3 of a terminal response: an `ok` body or an error `code`.
+    fn body(response: &[Vec<u8>]) -> &[u8] {
+        &response[2]
+    }
 
+    fn session(requests: &[Vec<u8>]) -> Vec<Vec<Vec<u8>>> {
+        let mut input = message(&[b"hello", BUILD_STAMP.as_bytes()]);
+        for fields in requests {
+            input.extend_from_slice(fields);
+        }
+        let mut output = Vec::new();
         assert_eq!(run(Cursor::new(input), &mut output).unwrap(), End::Eof);
         let decoded = messages(&output);
         assert_eq!(
             decoded[0],
             [b"ready".to_vec(), BUILD_STAMP.as_bytes().to_vec()]
         );
-        assert_eq!(&decoded[1][..2], [b"ok".as_slice(), b"1".as_slice()]);
+        decoded
+    }
+
+    #[test]
+    fn handshake_and_multiple_requests_share_one_session() {
+        let decoded = session(&[
+            message(&store_request(b"1", b"live", b"5", b"")),
+            message(&plan_request(b"2", b"5")),
+            message(&plan_request(b"3", b"5")),
+        ]);
+
+        assert_eq!(decoded[1], [b"ok".to_vec(), b"1".to_vec(), Vec::new()]);
         assert_eq!(&decoded[2][..2], [b"ok".as_slice(), b"2".as_slice()]);
-        assert_eq!(decoded[1][2], b"\0\x30\0\x30\0\x30\0");
+        assert_eq!(&decoded[3][..2], [b"ok".as_slice(), b"3".as_slice()]);
+        assert_eq!(body(&decoded[2]), b"\0\x30\0\x30\0\x30\0");
+    }
+
+    #[test]
+    fn one_store_serves_every_later_plan() {
+        let payload = payload(b"git");
+        let decoded = session(&[
+            message(&store_request(b"1", b"live", b"5", &payload)),
+            message(&plan_request(b"2", b"5")),
+            message(&plan_request(b"3", b"5")),
+        ]);
+
+        assert!(
+            body(&decoded[2]).windows(3).any(|bytes| bytes == b"git"),
+            "plan does not list the stored candidate: {:?}",
+            body(&decoded[2])
+        );
+        assert_eq!(body(&decoded[2]), body(&decoded[3]));
+    }
+
+    #[test]
+    fn a_new_generation_replaces_only_its_own_slot() {
+        let cached = payload(b"git");
+        let live = payload(b"grep");
+        let recached = payload(b"gzip");
+        let decoded = session(&[
+            message(&store_request(b"1", b"cache", b"5", &cached)),
+            message(&store_request(b"2", b"live", b"6", &live)),
+            message(&store_request(b"3", b"cache", b"7", &recached)),
+            message(&plan_request(b"4", b"7")),
+            message(&plan_request(b"5", b"6")),
+            message(&plan_request(b"6", b"5")),
+        ]);
+
+        assert!(body(&decoded[4]).windows(4).any(|b| b == b"gzip"));
+        assert!(body(&decoded[5]).windows(4).any(|b| b == b"grep"));
+        assert_eq!(
+            decoded[6],
+            [
+                b"error".to_vec(),
+                b"6".to_vec(),
+                b"unknown-generation".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_plan_for_a_generation_no_slot_holds_is_a_terminal_error() {
+        let decoded = session(&[message(&plan_request(b"1", b"9"))]);
+
+        assert_eq!(
+            decoded[1],
+            [
+                b"error".to_vec(),
+                b"1".to_vec(),
+                b"unknown-generation".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_store_that_fails_framing_leaves_every_slot_unchanged() {
+        let live = payload(b"git");
+        let cached = payload(b"grep");
+        let decoded = session(&[
+            message(&store_request(b"1", b"live", b"5", &live)),
+            message(&store_request(b"2", b"cache", b"6", &cached)),
+            message(&store_request(b"3", b"live", b"7", b"unterminated")),
+            message(&plan_request(b"4", b"5")),
+            message(&plan_request(b"5", b"6")),
+            message(&plan_request(b"6", b"7")),
+        ]);
+
+        assert_eq!(
+            decoded[3],
+            [
+                b"error".to_vec(),
+                b"3".to_vec(),
+                b"invalid-payload".to_vec()
+            ]
+        );
+        // Neither the slot the failed store addressed nor the other one moved.
+        assert!(body(&decoded[4]).windows(3).any(|b| b == b"git"));
+        assert!(body(&decoded[5]).windows(4).any(|b| b == b"grep"));
+        assert_eq!(
+            decoded[6],
+            [
+                b"error".to_vec(),
+                b"6".to_vec(),
+                b"unknown-generation".to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_new_session_starts_with_an_empty_store() {
+        let stored = payload(b"git");
+        session(&[message(&store_request(b"1", b"live", b"5", &stored))]);
+
+        let decoded = session(&[message(&plan_request(b"2", b"5"))]);
+
+        assert_eq!(
+            decoded[1],
+            [
+                b"error".to_vec(),
+                b"2".to_vec(),
+                b"unknown-generation".to_vec()
+            ]
+        );
     }
 
     #[test]
     fn mismatch_replies_once_and_discards_the_rest_of_stdin() {
         let input = [
             message(&[b"hello", b"deadbeef"]),
-            message(&request(b"1", b"/", b"")),
+            message(&plan_request(b"1", b"5")),
             b"1:x!".to_vec(),
         ]
         .concat();
@@ -479,20 +702,17 @@ mod tests {
 
     #[test]
     fn correlatable_shape_and_payload_errors_are_in_band() {
-        let hello = message(&[b"hello", BUILD_STAMP.as_bytes()]);
-        let bad_shape = message(&[b"other", b"7"]);
-        let bad_payload = message(&request(b"8", b"/", b"unterminated"));
-        let mut output = Vec::new();
+        let decoded = session(&[
+            message(&[b"other", b"7"]),
+            message(&store_request(b"8", b"live", b"5", b"unterminated")),
+            message(&store_request(b"9", b"elsewhere", b"5", b"")),
+            message(&store_request(b"10", b"live", b"05", b"")),
+            message(&plan_request(b"11", b"0")),
+        ]);
 
-        run(
-            Cursor::new([hello, bad_shape, bad_payload].concat()),
-            &mut output,
-        )
-        .unwrap();
         assert_eq!(
-            messages(&output),
+            decoded[1..],
             [
-                vec![b"ready".to_vec(), BUILD_STAMP.as_bytes().to_vec()],
                 vec![
                     b"error".to_vec(),
                     b"7".to_vec(),
@@ -503,6 +723,42 @@ mod tests {
                     b"8".to_vec(),
                     b"invalid-payload".to_vec()
                 ],
+                vec![
+                    b"error".to_vec(),
+                    b"9".to_vec(),
+                    b"invalid-request".to_vec()
+                ],
+                vec![
+                    b"error".to_vec(),
+                    b"10".to_vec(),
+                    b"invalid-request".to_vec()
+                ],
+                vec![
+                    b"error".to_vec(),
+                    b"11".to_vec(),
+                    b"invalid-request".to_vec()
+                ],
+            ]
+        );
+    }
+
+    /// cli-protocol.md 「要求と応答」: a `store` whose scalars *and* payload
+    /// are both invalid answers with the error detected first.
+    #[test]
+    fn store_scalar_validation_precedes_payload_framing() {
+        let decoded = session(&[message(&store_request(
+            b"1",
+            b"elsewhere",
+            b"5",
+            b"unterminated",
+        ))]);
+
+        assert_eq!(
+            decoded[1],
+            [
+                b"error".to_vec(),
+                b"1".to_vec(),
+                b"invalid-request".to_vec()
             ]
         );
     }
@@ -532,7 +788,7 @@ mod tests {
     fn completed_prefix_is_written_before_later_outer_corruption() {
         let input = [
             message(&[b"hello", BUILD_STAMP.as_bytes()]),
-            message(&request(b"1", b"/", b"")),
+            message(&store_request(b"1", b"live", b"5", b"")),
             b"1:x!".to_vec(),
         ]
         .concat();
@@ -578,8 +834,8 @@ mod tests {
 
     #[test]
     fn scalar_parsers_require_canonical_positive_ascii() {
-        assert_eq!(parse_request_id(b"1"), Some(1));
-        assert_eq!(parse_request_id(b"9223372036854775807"), Some(i64::MAX));
+        assert_eq!(parse_identifier(b"1"), Some(1));
+        assert_eq!(parse_identifier(b"9223372036854775807"), Some(i64::MAX));
         for value in [
             b"".as_slice(),
             b"0",
@@ -589,7 +845,7 @@ mod tests {
             b" 1",
             b"9223372036854775808",
         ] {
-            assert_eq!(parse_request_id(value), None, "{value:?}");
+            assert_eq!(parse_identifier(value), None, "{value:?}");
         }
         for value in [b"1".as_slice(), b"42", usize::MAX.to_string().as_bytes()] {
             assert!(parse_positive_usize(value).is_some(), "{value:?}");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -41,7 +41,7 @@ fn worker_command() -> (Command, UnixStream, UnixStream) {
 
 // ---- zrush worker ----
 
-/// Run one `plan` request through a fresh `zrush worker` session.
+/// Run one `store`/`plan` pair through a fresh `zrush worker` session.
 fn ns(payload: &[u8]) -> Vec<u8> {
     let mut out = payload.len().to_string().into_bytes();
     out.push(b':');
@@ -84,19 +84,25 @@ fn run_plan(extra: &[&str], stdin: &[u8]) -> (i32, Vec<u8>) {
             .map(|w| w[1])
             .unwrap_or("")
     };
-    let req = msg(&[
-        b"plan",
-        b"1",
-        std::env::current_dir().unwrap().as_os_str().as_bytes(),
-        value("--producer").as_bytes(),
-        value("--query").as_bytes(),
-        value("--mode").as_bytes(),
-        b"true",
-        value("--rows").as_bytes(),
-        value("--width").as_bytes(),
-        value("--trailing-space").as_bytes(),
-        stdin,
-    ]);
+    // `stdin` is the candidate payload: it reaches the worker as a `store`
+    // (generation 1) that the `plan` then references.
+    let req = [
+        msg(&[b"store", b"1", b"live", b"1", stdin]),
+        msg(&[
+            b"plan",
+            b"2",
+            b"1",
+            std::env::current_dir().unwrap().as_os_str().as_bytes(),
+            value("--producer").as_bytes(),
+            value("--query").as_bytes(),
+            value("--mode").as_bytes(),
+            b"true",
+            value("--rows").as_bytes(),
+            value("--width").as_bytes(),
+            value("--trailing-space").as_bytes(),
+        ]),
+    ]
+    .concat();
     let (mut command, control_read, _control_write) = worker_command();
     let mut child = command
         .stdin(Stdio::piped())
@@ -368,10 +374,11 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
         p.extend(word("git"));
         p
     };
-    let request = |id: &[u8]| {
+    let plan = |id: &[u8]| {
         msg(&[
             b"plan",
             id,
+            b"1",
             cwd.as_os_str().as_bytes(),
             b"compsys",
             b"",
@@ -380,7 +387,6 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
             b"10",
             b"40",
             b"true",
-            &payload,
         ])
     };
     let (mut command, control_read, _control_write) = worker_command();
@@ -392,8 +398,9 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
     drop(control_read);
     let mut input = Vec::new();
     input.extend(msg(&[b"hello", BUILD_STAMP]));
-    input.extend(request(b"1"));
-    input.extend(request(b"2"));
+    input.extend(msg(&[b"store", b"1", b"live", b"1", &payload]));
+    input.extend(plan(b"2"));
+    input.extend(plan(b"3"));
     let mut stdin = child.stdin.take().unwrap();
     for chunk in input.chunks(3) {
         stdin.write_all(chunk).unwrap();
@@ -401,12 +408,19 @@ fn worker_handshake_and_multiple_requests_share_one_process() {
     drop(stdin);
     let out = child.wait_with_output().unwrap();
     let frames = decode_frames(&out.stdout);
-    assert_eq!(frames.len(), 3, "ready plus two terminal responses");
+    assert_eq!(frames.len(), 4, "ready plus three terminal responses");
     assert_eq!(
         fields(&frames[0]),
         vec![b"ready".to_vec(), BUILD_STAMP.to_vec()]
     );
-    assert!(fields(&frames[1])[0] == b"ok" && fields(&frames[2])[0] == b"ok");
+    assert_eq!(
+        fields(&frames[1]),
+        vec![b"ok".to_vec(), b"1".to_vec(), Vec::new()],
+        "the store body is empty"
+    );
+    // Both plans read the one stored generation.
+    assert!(fields(&frames[2])[0] == b"ok" && fields(&frames[3])[0] == b"ok");
+    assert_eq!(fields(&frames[2])[2], fields(&frames[3])[2]);
 }
 
 #[test]

--- a/tests/driver/bin/fake_worker.rs
+++ b/tests/driver/bin/fake_worker.rs
@@ -181,13 +181,20 @@ fn worker(fake: &Fake, control_fd: i32) {
             return;
         };
         let request = fields(&payload, fake);
+        // The kind is folded onto the contract's two request kinds so a state
+        // line always splits into four fields (`tests/driver/fake.rs`).
+        let kind = match request.first().map(Vec::as_slice) {
+            Some(b"store") => "store",
+            Some(b"plan") => "plan",
+            _ => "other",
+        };
         let request_id = match request.get(1) {
             Some(field) => str::from_utf8(field)
                 .unwrap_or_else(|e| panic!("request_id is not UTF-8: {field:?} ({e})"))
                 .to_string(),
             None => "missing".to_string(),
         };
-        fake.note(&format!("request {session} {request_id}"));
+        fake.note(&format!("request {session} {kind} {request_id}"));
 
         let mut action = fake.mode();
         if action == "hold" {
@@ -203,8 +210,16 @@ fn worker(fake: &Fake, control_fd: i32) {
             // is the point: no terminal response ever reaches the parent.
             unsafe { libc::_exit(DIE_STATUS) };
         }
-        if action == "error" || action == "drain" {
-            write_message(&[b"error", request_id.as_bytes(), b"invalid-request"]);
+        if action == "error" || action == "drain" || action == "unknown-generation" {
+            // A `store` always succeeds with the contract's empty body; the
+            // mode decides only what the `plan` referencing it gets back.
+            if kind == "store" {
+                write_message(&[b"ok", request_id.as_bytes(), b""]);
+            } else if action == "unknown-generation" {
+                write_message(&[b"error", request_id.as_bytes(), b"unknown-generation"]);
+            } else {
+                write_message(&[b"error", request_id.as_bytes(), b"invalid-request"]);
+            }
             fake.note(&format!("{action} {session} {request_id}"));
             continue;
         }

--- a/tests/driver/cache.rs
+++ b/tests/driver/cache.rs
@@ -1,38 +1,460 @@
-//! Empty-word collection cache: a second command-position query hits the
-//! cache and forks nothing (docs/internal/specs/behavior.md "空語収集キャッシュ").
+//! Empty-word collection cache: what a hit skips, what forces a miss, and how
+//! the candidate store latch dies with the worker session it belongs to
+//! (docs/internal/specs/behavior.md 「空語収集キャッシュ」「worker ライフ
+//! サイクル」, docs/internal/contracts/cli-protocol.md 「要求と応答」
+//! 「応答の検証と zsh 側の適用」).
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use crate::host::{Host, PlanShape};
+use crate::fake::Mode;
+use crate::host::{Host, PlanShape, SHUTDOWN_SEAM, dump_field, keys, state_has};
 
-#[test]
-fn second_command_position_query_hits_the_cache_without_forking() {
-    let mut host = Host::boot();
-    // Warm-up: a host's very first completion commonly lazy-loads at least one
-    // compsys function, which changes the fingerprint (function count) the
-    // empty-word cache checks and costs exactly one extra miss (behavior.md
-    // "空語収集キャッシュ" 「既知の癖」). Absorb it here so the pair below
-    // observes the steady-state fingerprint.
-    host.send_keys_wait_plan(PlanShape::Nonempty, "whic");
+/// A command-position word: the widening rule empties it, so the collection it
+/// provokes is the cache's subject (behavior.md 「候補収集」「空語収集キャッシュ」).
+const QUERY: &str = "whic";
+
+/// The frame that carries a candidate record stream; a hit sends none.
+const STORE: &str = "worker: queued store request_id=";
+/// The frame a hit does send.
+const PLAN: &str = "worker: queued request_id=";
+const COLLECTING: &str = "request: collecting";
+const HIT: &str = "cache: hit (generation=";
+const LATCHED: &str = "cache: latched";
+
+/// Type [`QUERY`] and wait until the cache has decided that request: either it
+/// answered from the latch, or it collected and the worker's `ok` turned the
+/// staged entry into the new latch. Returns whether it was a hit. The line is
+/// left as typed -- clearing it would make the input no longer current, which
+/// is itself one of the conditions under test.
+fn query(host: &mut Host, label: &str) -> bool {
+    let hits = host.log_count(HIT);
+    let latched = host.log_count(LATCHED);
+    host.send_keys(QUERY);
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        host.drain(Duration::from_millis(150));
+        if host.log_count(HIT) > hits {
+            return true;
+        }
+        if host.log_count(LATCHED) > latched {
+            return false;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{label}: the command-position query was neither served from nor written to the cache"
+        );
+    }
+}
+
+/// Repeat the query until one of them is answered from the latch. A host's
+/// first completions lazy-load compsys functions, and every load changes the
+/// function count the fingerprint covers, so the steady state is reached by
+/// repeating rather than by a fixed number of rounds
+/// (behavior.md 「空語収集キャッシュ」 「既知の癖」).
+fn warm_to_a_hit(host: &mut Host, label: &str) {
+    for _ in 0..5 {
+        let hit = query(host, label);
+        host.clear_line();
+        host.drain(Duration::from_millis(300));
+        if hit {
+            return;
+        }
+    }
+    panic!("{label}: the empty-word cache never reached a steady-state hit");
+}
+
+/// The generation of the freshest logged hit -- the one the latch pointed at.
+fn hit_generation(host: &Host, label: &str) -> i64 {
+    let line = host
+        .last_log_line(HIT)
+        .unwrap_or_else(|| panic!("{label}: no cache hit has been logged"));
+    line.rsplit_once("generation=")
+        .and_then(|(_, rest)| rest.trim_end_matches(')').parse().ok())
+        .unwrap_or_else(|| panic!("{label}: no generation in {line:?}"))
+}
+
+/// Slot and generation of the freshest queued `store`.
+fn last_store(host: &Host, label: &str) -> (String, i64) {
+    let line = host
+        .last_log_line(STORE)
+        .unwrap_or_else(|| panic!("{label}: no store has been queued"));
+    let generation = dump_field(&line, "generation")
+        .parse()
+        .unwrap_or_else(|e| panic!("{label}: non-numeric generation in {line:?} ({e})"));
+    (dump_field(&line, "slot").to_string(), generation)
+}
+
+/// An argument-position completion: widening leaves a non-empty word, so this
+/// collection is not the cache's subject and stores into `live`.
+fn argument_completion(host: &mut Host) {
+    host.send_keys_wait_plan(PlanShape::Nonempty, "ls fx/basic/al");
     host.clear_line();
-    host.drain(Duration::from_millis(500));
+    host.drain(Duration::from_millis(300));
+}
 
-    host.send_keys_wait_plan(PlanShape::Nonempty, "whic");
-    host.clear_line();
-    host.drain(Duration::from_millis(500));
-
-    let hit_baseline = host.log_count("cache: hit");
-    let collecting_baseline = host.log_count("request: collecting");
-    host.send_keys("whic");
+/// Open the history menu on an empty buffer and dismiss it again. An empty
+/// buffer collects nothing (behavior.md 「候補収集」), so the only thing this
+/// adds is the menu's own synchronous `live` store and `history` plan.
+fn history_menu(host: &mut Host, label: &str) {
+    let opened = host.log_count("producer=history");
+    host.press(keys::UP);
     assert!(
-        host.wait_log("cache: hit", hit_baseline, Duration::from_secs(5)),
-        "(cc-1a) cache hit not logged"
+        host.wait_log("producer=history", opened, Duration::from_secs(10)),
+        "{label}: the history menu never reached the worker"
+    );
+    host.press(keys::DISMISS);
+    host.drain(Duration::from_millis(300));
+}
+
+/// The first command-position query has nothing to reuse: it collects, hands
+/// the records to the `cache` slot and latches the generation the worker took.
+/// A later one plans straight from that latch -- no fork, and no second store.
+#[test]
+fn a_command_position_query_latches_and_the_next_one_plans_from_the_latch() {
+    let mut host = Host::boot();
+
+    let empty0 = host.log_count("cache: miss (empty)");
+    let hit = query(&mut host, "(cc-1a)");
+    let (slot, _) = last_store(&host, "(cc-1a)");
+    assert!(
+        !hit && host.log_count("cache: miss (empty)") > empty0 && slot == "cache",
+        "(cc-1a) the first command-position query did not miss into the cache slot: slot={slot}"
+    );
+    host.clear_line();
+    host.drain(Duration::from_millis(300));
+
+    warm_to_a_hit(&mut host, "(cc-1b)");
+
+    let collecting = host.log_count(COLLECTING);
+    let stores = host.log_count(STORE);
+    let plans = host.log_count(PLAN);
+    assert!(
+        query(&mut host, "(cc-1c)"),
+        "(cc-1c) the steady-state query was not served from the latch"
+    );
+    host.drain(Duration::from_millis(500));
+    assert_eq!(
+        host.log_count(COLLECTING),
+        collecting,
+        "(cc-1d) a fork ran despite the cache hit"
+    );
+    assert_eq!(
+        host.log_count(STORE),
+        stores,
+        "(cc-1e) a store went out despite the cache hit"
+    );
+    assert_eq!(
+        host.log_count(PLAN),
+        plans + 1,
+        "(cc-1f) the hit did not send exactly one plan"
+    );
+}
+
+/// The 300 s TTL is a fixed constant, so the saved timestamp is aged rather
+/// than waited out. The fingerprint still matches and the latch is still
+/// valid: the TTL alone is what forces the recollection.
+#[test]
+fn an_expired_ttl_recollects_although_the_fingerprint_still_matches() {
+    let mut host = Host::boot();
+    warm_to_a_hit(&mut host, "(cc-2 setup)");
+
+    host.press(keys::AGE_CACHE);
+    let aged = host.cache_state();
+    let age: i64 = dump_field(&aged, "age")
+        .parse()
+        .unwrap_or_else(|e| panic!("(cc-2a) non-numeric age in {aged:?} ({e})"));
+    assert!(
+        state_has(&aged, &["fpmatch=1"]) && age > 300,
+        "(cc-2a) the aged entry is not a TTL-only miss: {aged}"
     );
 
+    let expired = host.log_count("cache: miss (ttl)");
+    let collecting = host.log_count(COLLECTING);
+    assert!(
+        !query(&mut host, "(cc-2b)"),
+        "(cc-2b) an entry past its TTL was still served from the latch"
+    );
+    assert!(
+        host.log_count("cache: miss (ttl)") == expired + 1
+            && host.log_count(COLLECTING) > collecting,
+        "(cc-2c) the expired entry did not recollect"
+    );
+}
+
+/// A new alias is a new command-position candidate, and the alias count the
+/// fingerprint covers is what notices it. TTL and latch stay valid, so the
+/// fingerprint alone forces the recollection -- and the recollection is what
+/// puts the new command in the listing.
+#[test]
+fn a_changed_environment_expires_the_fingerprint() {
+    let mut host = Host::boot();
+    warm_to_a_hit(&mut host, "(cc-3 setup)");
+
+    host.send_line("alias whic-zrt-fresh=:");
+    host.sync_prompt(Duration::from_secs(5));
     host.drain(Duration::from_millis(500));
-    let collecting_after = host.log_count("request: collecting");
-    assert_eq!(
-        collecting_after, collecting_baseline,
-        "(cc-1b) a fork ran despite the expected cache hit ({collecting_baseline} -> {collecting_after})"
+    let changed = host.cache_state();
+    assert!(
+        state_has(&changed, &["fpmatch=0"]),
+        "(cc-3a) a new alias did not change the fingerprint: {changed}"
+    );
+
+    let stale = host.log_count("cache: miss (fingerprint)");
+    let collecting = host.log_count(COLLECTING);
+    let applied = host.log_count("plan: applied");
+    assert!(
+        !query(&mut host, "(cc-3b)"),
+        "(cc-3b) a stale fingerprint was still served from the latch"
+    );
+    assert!(
+        host.log_count("cache: miss (fingerprint)") == stale + 1
+            && host.log_count(COLLECTING) > collecting,
+        "(cc-3c) the stale entry did not recollect"
+    );
+    assert!(
+        host.wait_log("plan: applied", applied, Duration::from_secs(10)),
+        "(cc-3d) the recollection never rendered"
+    );
+    let post = host.postdisplay("(cc-3d)");
+    assert!(
+        post.contains("whic-zrt-fresh"),
+        "(cc-3d) the recollected listing is missing the new command: {post:?}"
+    );
+}
+
+/// The latch belongs to the worker session. A session failure drops it and so
+/// does a re-source, both while the fingerprint matches and the entry is well
+/// inside its TTL, and recollection is the only way back. The candidate
+/// generation counter is what neither of them may rewind
+/// (cli-protocol.md 「要求と応答」 candidate_generation).
+#[test]
+fn the_latch_dies_with_the_worker_session_and_with_a_re_source() {
+    let mut host = Host::boot_fake();
+    // The fake has to be the worker before the latch is taken, or the death
+    // below would kill a session the latch never came from. Its `store` always
+    // succeeds, so the latch is taken exactly as under the real binary; only
+    // the `plan` comes back as an in-band error, which is not a session failure
+    // and leaves the latch alone.
+    host.fake().set_mode(Mode::Error);
+    host.send_line(SHUTDOWN_SEAM);
+    host.sync_prompt(Duration::from_secs(5));
+    warm_to_a_hit(&mut host, "(cc-4 setup)");
+
+    let live = host.worker_state();
+    let candgen = dump_field(&live, "candgen").to_string();
+    let entry = host.cache_state();
+    let age: i64 = dump_field(&entry, "age")
+        .parse()
+        .unwrap_or_else(|e| panic!("(cc-4a) non-numeric age in {entry:?} ({e})"));
+    // Established here, while the session is still alive: from now on the only
+    // hit condition that changes is the latch. (The fingerprint counts every
+    // function, zrush's own generated `zle -F` handlers included, so it stops
+    // being a fixed quantity once a session tears down.)
+    assert!(
+        candgen != "0" && dump_field(&live, "latch") == candgen,
+        "(cc-4a) the cache store did not latch its own generation: {live}"
+    );
+    assert!(
+        state_has(&entry, &["fpmatch=1"]) && (0..=300).contains(&age),
+        "(cc-4a) the entry is not fingerprint- and TTL-valid before the death: {entry}"
+    );
+
+    // A hit sends nothing but a plan, so this death costs no generation.
+    host.fake().set_mode(Mode::Die);
+    let failures = host.log_count("worker: session failure:");
+    assert!(
+        query(&mut host, "(cc-4b)"),
+        "(cc-4b) the query that was meant to die on a plan-only hit collected instead"
+    );
+    assert!(
+        host.wait_log(
+            "worker: session failure:",
+            failures,
+            Duration::from_secs(15)
+        ),
+        "(cc-4b) the worker did not die on the hit's plan"
+    );
+    host.clear_line();
+    host.drain(Duration::from_millis(300));
+    host.fake().set_mode(Mode::Proxy);
+
+    let dropped = host
+        .wait_worker_state(
+            Duration::from_secs(15),
+            &["latch=0", "stopping=0", "pending=0"],
+        )
+        .unwrap_or_else(|last| panic!("(cc-4c) the dead session kept its latch: {last}"));
+    assert!(
+        state_has(&dropped, &[&format!("candgen={candgen}")]),
+        "(cc-4c) the dead session spent a candidate generation: {dropped}"
+    );
+    let usable = host.cache_state();
+    let age: i64 = dump_field(&usable, "age")
+        .parse()
+        .unwrap_or_else(|e| panic!("(cc-4d) non-numeric age in {usable:?} ({e})"));
+    assert!(
+        (0..=300).contains(&age),
+        "(cc-4d) the entry aged out of its TTL on its own: {usable}"
+    );
+
+    // The reason matters: the check tests the latch before the fingerprint, so
+    // a `(latch)` miss is the entry being valid up to the lost session.
+    let latchless = host.log_count("cache: miss (latch)");
+    let collecting = host.log_count(COLLECTING);
+    assert!(
+        !query(&mut host, "(cc-4e)"),
+        "(cc-4e) a latch that died with its worker still served a hit"
+    );
+    assert!(
+        host.log_count("cache: miss (latch)") == latchless + 1
+            && host.log_count(COLLECTING) > collecting,
+        "(cc-4f) the lost latch did not recollect"
+    );
+    host.clear_line();
+    host.drain(Duration::from_millis(300));
+
+    // ---- and again across an explicit re-source ----
+    let before = host.worker_state();
+    let candgen: i64 = dump_field(&before, "candgen")
+        .parse()
+        .unwrap_or_else(|e| panic!("(cc-4g) non-numeric candgen in {before:?} ({e})"));
+    host.send_line("source <($ZRUSH_REAL_BIN init zsh)");
+    assert!(
+        host.sync_prompt(Duration::from_secs(10)),
+        "(cc-4g) the re-source did not return to a prompt"
+    );
+    let resourced = host.worker_state();
+    let after: i64 = dump_field(&resourced, "candgen")
+        .parse()
+        .unwrap_or_else(|e| panic!("(cc-4g) non-numeric candgen in {resourced:?} ({e})"));
+    assert!(
+        state_has(&resourced, &["latch=0"]) && after >= candgen,
+        "(cc-4g) the re-source kept a latch or rewound the generation counter \
+         (was {candgen}): {resourced}"
+    );
+
+    let hits = host.log_count(HIT);
+    let collecting = host.log_count(COLLECTING);
+    assert!(
+        !query(&mut host, "(cc-4h)"),
+        "(cc-4h) a re-sourced shell served the query from a stale latch"
+    );
+    assert!(
+        host.log_count(HIT) == hits && host.log_count(COLLECTING) > collecting,
+        "(cc-4i) the re-sourced shell did not recollect"
+    );
+}
+
+/// The cached generation lives in its own slot: argument completions and the
+/// history menu keep storing into `live`, and the worker drops only the
+/// previous generation *of the same slot*, so the cached one survives them all
+/// (cli-protocol.md 「要求と応答」 slot semantics).
+#[test]
+fn live_slot_stores_leave_the_cached_generation_intact() {
+    let mut host = Host::boot_history();
+    // Both live-slot producers run once up front: their compsys lazy-loading
+    // is a fingerprint change, and it must not land between latch and hit.
+    argument_completion(&mut host);
+    history_menu(&mut host, "(cc-5 setup)");
+    warm_to_a_hit(&mut host, "(cc-5 setup)");
+    let cached = hit_generation(&host, "(cc-5 setup)");
+
+    argument_completion(&mut host);
+    let (slot, argument) = last_store(&host, "(cc-5a)");
+    assert!(
+        slot == "live" && argument > cached,
+        "(cc-5a) the argument completion did not store a newer generation into live: \
+         slot={slot} generation={argument} cached={cached}"
+    );
+    history_menu(&mut host, "(cc-5b)");
+    let (slot, history) = last_store(&host, "(cc-5b)");
+    assert!(
+        slot == "live" && history > argument,
+        "(cc-5b) the history menu did not store a newer generation into live: \
+         slot={slot} generation={history} previous={argument}"
+    );
+
+    let collecting = host.log_count(COLLECTING);
+    assert!(
+        query(&mut host, "(cc-5c)"),
+        "(cc-5c) the cached generation did not survive the live-slot stores"
+    );
+    assert!(
+        hit_generation(&host, "(cc-5c)") == cached && host.log_count(COLLECTING) == collecting,
+        "(cc-5d) the hit did not come from the generation latched before the live stores \
+         (cached={cached})"
+    );
+}
+
+/// `unknown-generation` is an ordinary terminal error: it costs no session
+/// failure and replays nothing. Only the `plan` that read the latch drops it
+/// and recollects; the one that merely followed its own `store` is dropped and
+/// waits for the next real input
+/// (cli-protocol.md 「応答の検証と zsh 側の適用」).
+#[test]
+fn unknown_generation_recollects_only_for_the_plan_that_read_the_latch() {
+    let mut host = Host::boot_fake();
+    // A worker whose candidate store never holds the referenced generation,
+    // while its `store` keeps answering `ok` -- so the latch is taken normally
+    // and every plan, latched or not, comes back with `unknown-generation`.
+    host.fake().set_mode(Mode::UnknownGeneration);
+
+    // A miss: this collection's own store succeeds and latches, and the plan
+    // pipelined behind it never read the latch.
+    let unknown = host.log_count("code=unknown-generation");
+    assert!(
+        !query(&mut host, "(cc-6a)"),
+        "(cc-6a) the first query of a fresh host was served from a latch"
+    );
+    let collecting = host.log_count(COLLECTING);
+    assert!(
+        host.wait_log("code=unknown-generation", unknown, Duration::from_secs(10)),
+        "(cc-6b) the plan was not answered with unknown-generation"
+    );
+    // The recollection, when there is one, is decided before the error is
+    // logged, so the counts either side of that line settle the question.
+    let kept = host.worker_state();
+    assert!(
+        host.log_count(COLLECTING) == collecting
+            && dump_field(&kept, "latch") != "0"
+            && state_has(
+                &kept,
+                &["failures=0", "disabled=0", "pending=0", "staged=0"]
+            ),
+        "(cc-6c) a plan that never read the latch recollected or dropped the latch: {kept}"
+    );
+    host.clear_line();
+    host.drain(Duration::from_millis(300));
+
+    // A hit: that plan does read the latch, so its error drops the latch and
+    // starts a fresh collection for the still-current input.
+    let mut read_the_latch = false;
+    for _ in 0..5 {
+        let collecting = host.log_count(COLLECTING);
+        let latchless = host.log_count("cache: miss (latch)");
+        if query(&mut host, "(cc-6d)") {
+            assert!(
+                host.wait_log("cache: miss (latch)", latchless, Duration::from_secs(10)),
+                "(cc-6e) the latched plan's unknown-generation did not drop the latch"
+            );
+            assert!(
+                host.log_count(COLLECTING) > collecting,
+                "(cc-6f) the latched plan's unknown-generation did not recollect"
+            );
+            read_the_latch = true;
+            break;
+        }
+        host.clear_line();
+        host.drain(Duration::from_millis(300));
+    }
+    assert!(
+        read_the_latch,
+        "(cc-6d) the cache never hit, so no plan ever read the latch"
+    );
+
+    let after = host.worker_state();
+    assert!(
+        state_has(&after, &["failures=0", "disabled=0"]),
+        "(cc-6g) unknown-generation was counted against the worker session: {after}"
     );
 }

--- a/tests/driver/capture.rs
+++ b/tests/driver/capture.rs
@@ -26,9 +26,15 @@ fn fork_capture_round_trip_reuses_one_worker() {
     let first = host.worker_state();
     let first_rfd: i32 = dump_field(&first, "rfd").parse().expect("numeric rfd");
     let first_runtime = dump_field(&first, "runtime").to_string();
+    // One collection spends two request ids and one candidate generation: the
+    // `store` that hands the records over and the `plan` pipelined behind it
+    // (cli-protocol.md 「要求と応答」).
     assert!(
         first_rfd > 2
-            && state_has(&first, &["ready=1", "seq=1", "stopping=0", "tainted=0"])
+            && state_has(
+                &first,
+                &["ready=1", "seq=2", "candgen=1", "stopping=0", "tainted=0"]
+            )
             && first_runtime != "<none>",
         "(worker-1b) unexpected first-request state: {first}"
     );

--- a/tests/driver/death.rs
+++ b/tests/driver/death.rs
@@ -114,6 +114,9 @@ fn active_session_deaths_open_the_breaker_and_a_re_source_recovers() {
         .is_ok();
 
     // ---- the lazy replacement, held after ready and assignment ----
+    // The fake parks on the first request it reads -- the `store` -- with the
+    // `plan` of the same collection already queued behind it, so a held
+    // collection leaves two outstanding requests (cli-protocol.md 「要求と応答」).
     host.fake().set_mode(Mode::Hold);
     let held0 = host.fake().count(&format!("hold {second} "));
     host.send_keys("ls fx/basic/");
@@ -124,7 +127,7 @@ fn active_session_deaths_open_the_breaker_and_a_re_source_recovers() {
             && held
             && state_has(
                 &replacement,
-                &["ready=1", "failures=1", "disabled=0", "pending=1"]
+                &["ready=1", "failures=1", "disabled=0", "pending=2"]
             )
             && host.fake().starts() == starts0 + 2,
         "(err-1c) held replacement state missing: clean={first_death_clean} held={held} \
@@ -259,4 +262,81 @@ fn active_session_deaths_open_the_breaker_and_a_re_source_recovers() {
 
     // The panic inside send_keys_wait_plan is this case's assertion.
     host.send_keys_wait_plan(PlanShape::Nonempty, "ls fx/basic/al"); // (err-5b)
+}
+
+/// A well-formed terminal `error` ends its request for good: neither that
+/// `plan` nor the `store` it was pipelined behind is sent again, and no
+/// candidate generation is spent recovering. Only the next real input makes the
+/// next generation (cli-protocol.md 「応答の検証と zsh 側の適用」,
+/// behavior.md 「worker ライフサイクル」).
+#[test]
+fn a_failed_request_is_not_replayed_and_only_new_input_makes_a_generation() {
+    let mut host = Host::boot_fake();
+    // Every `store` this mode sees succeeds and every `plan` gets an in-band
+    // `error`, so the failing request is a correlated one -- not a session
+    // failure that would discard the pair for a different reason.
+    host.fake().set_mode(Mode::Error);
+
+    let errors0 = host.log_count("worker: error request_id=");
+    // An argument position: this collection stores into `live`, so the
+    // empty-word cache plays no part in what is or is not resent.
+    host.send_keys("ls fx/basic/al");
+    assert!(
+        host.wait_log(
+            "worker: error request_id=",
+            errors0,
+            Duration::from_secs(10)
+        ),
+        "(err-6a) the fake session never answered the plan with an in-band error"
+    );
+
+    let store_line = host
+        .last_log_line("worker: queued store request_id=")
+        .expect("(err-6a) no store was queued for the collection");
+    let plan_line = host
+        .last_log_line("worker: queued request_id=")
+        .expect("(err-6a) no plan was queued for the collection");
+    let store_id = dump_field(&store_line, "request_id").to_string();
+    let plan_id = dump_field(&plan_line, "request_id").to_string();
+    let settled = host.worker_state();
+    let candgen = dump_field(&settled, "candgen").to_string();
+
+    // Long enough for a replay or an unsolicited recollection to show up.
+    host.drain(Duration::from_secs(1));
+    let idle = host.worker_state();
+    assert!(
+        host.fake().requests_for(&store_id) == 1
+            && host.fake().requests_for(&plan_id) == 1
+            && state_has(
+                &idle,
+                &[
+                    &format!("candgen={candgen}"),
+                    "pending=0",
+                    "staged=0",
+                    "failures=0",
+                    "disabled=0",
+                ]
+            ),
+        "(err-6b) the failed pair was replayed or spent a generation: \
+         store={store_id} plan={plan_id} state={idle}"
+    );
+
+    // One more keystroke: one new collection, one new generation.
+    let stores0 = host.log_count("worker: queued store request_id=");
+    host.send_keys("p");
+    assert!(
+        host.wait_log(
+            "worker: queued store request_id=",
+            stores0,
+            Duration::from_secs(10)
+        ),
+        "(err-6c) the next real input did not reach the worker"
+    );
+    let next: i64 = candgen.parse().expect("numeric candgen");
+    let after = host.worker_state();
+    assert!(
+        state_has(&after, &[&format!("candgen={}", next + 1)]),
+        "(err-6d) the next input did not make exactly one new generation \
+         (was candgen={candgen}): {after}"
+    );
 }

--- a/tests/driver/fake.rs
+++ b/tests/driver/fake.rs
@@ -23,10 +23,14 @@ pub enum Mode {
     Hold,
     /// Exit without a terminal response.
     Die,
-    /// Reply with an in-band `error` and keep serving.
+    /// Reply to every `plan` with an in-band `error` and keep serving; a
+    /// `store` still succeeds, as it does in every replying mode.
     Error,
     /// Like `Error`, plus a raw non-protocol tail on stdin EOF.
     Drain,
+    /// Answer every `plan` with the in-band `unknown-generation` error, as a
+    /// worker whose candidate store never holds the referenced generation.
+    UnknownGeneration,
 }
 
 impl Mode {
@@ -38,6 +42,7 @@ impl Mode {
             Self::Die => "die",
             Self::Error => "error",
             Self::Drain => "drain",
+            Self::UnknownGeneration => "unknown-generation",
         }
     }
 }
@@ -112,18 +117,19 @@ impl Fake {
             .count()
     }
 
-    /// How many `request <session> <request_id>` lines carry exactly this id,
-    /// across every session -- one means it was never replayed.
+    /// How many `request <session> <kind> <request_id>` lines carry exactly
+    /// this id, across every session and either kind -- one means it was
+    /// never replayed.
     pub fn requests_for(&self, request_id: &str) -> usize {
         self.lines()
             .iter()
             .filter(|line| {
                 let fields: Vec<&str> = line.split(' ').collect();
-                fields.len() == 3
+                fields.len() == 4
                     && fields[0] == "request"
                     && !fields[1].is_empty()
                     && fields[1].bytes().all(|b| b.is_ascii_digit())
-                    && fields[2] == request_id
+                    && fields[3] == request_id
             })
             .count()
     }

--- a/tests/driver/fifo.rs
+++ b/tests/driver/fifo.rs
@@ -1,17 +1,22 @@
 //! FIFO-capacity frame delegation: a candidate_payload larger than the
 //! request-FIFO buffer must still cross in one delegated `syswrite`
 //! (docs/internal/specs/behavior.md:81, "writer は 1 回の `syswrite` で
-//! frame 全体を書き").
+//! frame 全体を書き"). The payload rides the `store` request; the `plan`
+//! pipelined behind it only names the generation
+//! (docs/internal/contracts/cli-protocol.md 「要求と応答」).
 
 use std::time::Duration;
 
 use crate::host::Host;
 
+/// The one frame that carries a candidate record stream.
+const QUEUED_STORE: &str = "worker: queued store request_id=";
+
 #[test]
 fn overflow_payload_delegates_in_one_frame_and_renders() {
     let mut host = Host::boot_with_overflow();
 
-    let queued_before = host.log_count("worker: queued request_id=");
+    let queued_before = host.log_count(QUEUED_STORE);
     host.send_keys("ls fx/overflow/");
     assert!(
         host.expect("0000-marker.txt", Duration::from_secs(15)),
@@ -19,16 +24,12 @@ fn overflow_payload_delegates_in_one_frame_and_renders() {
     );
 
     assert!(
-        host.wait_log(
-            "worker: queued request_id=",
-            queued_before,
-            Duration::from_secs(5)
-        ),
-        "(fifo-1b) no 'worker: queued request_id=' log line for the overflow request"
+        host.wait_log(QUEUED_STORE, queued_before, Duration::from_secs(5)),
+        "(fifo-1b) no {QUEUED_STORE:?} log line for the overflow request"
     );
     let line = host
-        .last_log_line("worker: queued request_id=")
-        .expect("(fifo-1b) queued-request log line vanished after wait_log succeeded");
+        .last_log_line(QUEUED_STORE)
+        .expect("(fifo-1b) queued-store log line vanished after wait_log succeeded");
     let bytes: usize = line
         .rsplit_once("bytes=")
         .and_then(|(_, rest)| rest.split_whitespace().next())

--- a/tests/driver/host.rs
+++ b/tests/driver/host.rs
@@ -37,6 +37,10 @@ pub mod keys {
     /// The whole `region_highlight` array, third-party entries included.
     pub const DUMP_ALL_RH: &str = "\x18a";
     pub const DUMP_WORKER: &str = "\x18w";
+    /// Empty-word-cache validity: `fpmatch=<0|1> age=<seconds|-1>`.
+    pub const DUMP_CACHE: &str = "\x18c";
+    /// Age the empty-word cache entry past its fixed TTL.
+    pub const AGE_CACHE: &str = "\x18n";
     /// Listing kind, selection and position count (history rc only).
     pub const DUMP_KIND: &str = "\x18k";
     /// The `$history` event number of the newest fixture line (history rc only).
@@ -669,6 +673,12 @@ impl Host {
     pub fn worker_state(&mut self) -> String {
         self.dump_get(keys::DUMP_WORKER, "TESTWORKER")
             .expect("worker-state dump did not run")
+    }
+
+    /// The `^Xc` empty-word-cache dump.
+    pub fn cache_state(&mut self) -> String {
+        self.dump_get(keys::DUMP_CACHE, "TESTCACHE")
+            .expect("cache-state dump did not run")
     }
 
     /// Poll `^Xw` until the dump carries every one of `fields`, returning it;

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -155,19 +155,26 @@ fn run_vector_raw(path: &Path) -> std::process::Output {
     }
     let payload = read_vector_file(&path.join("payload"));
     let cwd = std::env::current_dir().expect("cwd");
-    let request = msg(&[
-        b"plan",
-        b"1",
-        cwd.as_os_str().as_bytes(),
-        value("--producer").as_bytes(),
-        value("--query").as_bytes(),
-        value("--mode").as_bytes(),
-        value("--smart-case").as_bytes(),
-        value("--rows").as_bytes(),
-        value("--width").as_bytes(),
-        value("--trailing-space").as_bytes(),
-        &payload,
-    ]);
+    // One session carries the vector as the contract's two requests: the
+    // payload goes in with `store` (request_id 1, generation 1), and `plan`
+    // (request_id 2) reads it back out of the slot.
+    let requests = [
+        msg(&[b"store", b"1", b"live", b"1", &payload]),
+        msg(&[
+            b"plan",
+            b"2",
+            b"1",
+            cwd.as_os_str().as_bytes(),
+            value("--producer").as_bytes(),
+            value("--query").as_bytes(),
+            value("--mode").as_bytes(),
+            value("--smart-case").as_bytes(),
+            value("--rows").as_bytes(),
+            value("--width").as_bytes(),
+            value("--trailing-space").as_bytes(),
+        ]),
+    ]
+    .concat();
     let (control_read, _control_write) = UnixStream::pair().expect("create control channel");
     let control_fd = control_read.as_raw_fd();
     let mut command = Command::new(env!("CARGO_BIN_EXE_zrush"));
@@ -194,7 +201,7 @@ fn run_vector_raw(path: &Path) -> std::process::Output {
         .stdin
         .take()
         .expect("vector child stdin")
-        .write_all(&[msg(&[b"hello", BUILD_STAMP]), request].concat());
+        .write_all(&[msg(&[b"hello", BUILD_STAMP]), requests].concat());
     if let Err(error) = write_result {
         assert_eq!(
             error.kind(),
@@ -385,19 +392,29 @@ fn reject_vectors_match_expected_in_band_errors() {
         let name = vector_name(&path);
         let output = run_vector_raw(&path);
         let frames = decode_strict(&output.stdout);
-        let expected = if name.ends_with("nonterminated-stdin") {
-            b"invalid-payload"
+        // A vector is rejected by exactly one of the session's two requests.
+        // A bad payload fails the `store` (request_id 1), leaving nothing for
+        // the `plan` (request_id 2) to reference; bad scalars store fine and
+        // fail the `plan` itself.
+        let (store_reply, plan_reply): (&[u8], &[u8]) = if name.ends_with("nonterminated-stdin") {
+            (b"invalid-payload", b"unknown-generation")
         } else {
-            b"invalid-request"
+            (b"", b"invalid-request")
+        };
+        let store_frame = if store_reply.is_empty() {
+            vec![b"ok".to_vec(), b"1".to_vec(), Vec::new()]
+        } else {
+            vec![b"error".to_vec(), b"1".to_vec(), store_reply.to_vec()]
         };
         let valid = output.status.code() == Some(0)
-            && frames.len() == 2
+            && frames.len() == 3
             && decode_fields_strict(&frames[0]) == vec![b"ready".to_vec(), BUILD_STAMP.to_vec()]
-            && decode_fields_strict(&frames[1])
-                == vec![b"error".to_vec(), b"1".to_vec(), expected.to_vec()];
+            && decode_fields_strict(&frames[1]) == store_frame
+            && decode_fields_strict(&frames[2])
+                == vec![b"error".to_vec(), b"2".to_vec(), plan_reply.to_vec()];
         if !valid {
             failures.push(format!(
-                "{name}: expected ready + one terminal in-band error; got exit {:?}, stdout: {}, stderr: {}",
+                "{name}: expected ready + a terminal store reply + a terminal in-band plan error; got exit {:?}, stdout: {}, stderr: {}",
                 output.status.code(),
                 dump(&output.stdout),
                 dump(&output.stderr)

--- a/tests/vectors/README.md
+++ b/tests/vectors/README.md
@@ -2,12 +2,14 @@
 
 This corpus turns the prose rules in `docs/internal/contracts/cli-protocol.md` into executable byte-level fixtures.
 
-Each `plan/<name>/` directory contains `args`, `payload`, and `expected`.
+Each `plan/<name>/` directory contains `args`, `payload`, and `expected`: the `plan` request's scalar fields, the `store` request's `candidate_payload`, and the `plan` response's `ok` body.
 Each `reject/<name>/` directory contains `args` and `payload`.
 Each `reject-plan/<name>/` directory contains only `plan`.
 Each `encode/<name>/` directory contains `argv`, `hits`, `dscr`, `expected`, and an optional `env`.
-The runner sends each vector as a `plan` request to a persistent `zrush worker`; `args` contains flags and their values only.
-Reject vectors expect a worker session with exactly one terminal `error` response (`invalid-request` for malformed request shape/scalars, `invalid-payload` for candidate framing).
+The runner drives each vector through one persistent `zrush worker` session as the contract's two requests: a `store` (request_id 1, slot `live`, generation 1) carrying `payload`, then a `plan` (request_id 2) referencing that generation.
+`args` contains flags and their values only.
+Reject vectors expect that session to answer with a terminal response per request, exactly one of which is an `error`.
+A candidate-stream framing violation fails the `store` with `invalid-payload`, leaving no generation for the `plan` to reference (`unknown-generation`); a malformed request shape or scalar stores fine and fails the `plan` itself with `invalid-request`.
 Vector names use kebab case and describe the rule being fixed.
 
 ## File format
@@ -70,7 +72,8 @@ A generated `expected` is a proposal, not an answer -- read it against cli-proto
 
 ## Who checks what
 
-`cargo test` checks `plan/`, `reject/`, and `reject-plan/` against the Rust worker and the `wire` reference parser. Reject vectors structurally validate exactly `[ready,7]` plus one terminal in-band `error`; no process exit 2/3 compatibility is tested.
+`cargo test` checks `plan/`, `reject/`, and `reject-plan/` against the Rust worker and the `wire` reference parser.
+Reject vectors structurally validate exactly the handshake `ready` plus the terminal in-band responses of the session's `store` and `plan`; no process exit 2/3 compatibility is tested.
 Both runners independently implement the file format above, check every corpus file for canonical spelling, and hold their own codec to a round trip over arbitrary byte strings.
 `zsh -f tests/zsh/vectors.zsh` checks `encode/` against the zsh encoder `_zrush_encode_batch`,
 the history sender's line/event-number pairing and filtering against `_zrush_history_payload`,

--- a/tests/zsh/rc/minimal.zshrc
+++ b/tests/zsh/rc/minimal.zshrc
@@ -32,10 +32,34 @@ bindkey '^Xa' _zrt-dump-all-rh
 # ^Xw: persistent-worker lifecycle state. This exposes only stable invariants
 # the tests need (lazy start, reuse, monotonic ids, and clean teardown).
 _zrt_dump_worker() {
-  _zlog "TESTWORKER=ready=$_zrush_worker_ready seq=$_zrush_request_seq failures=$_zrush_worker_failures disabled=$_zrush_disabled reason=$_zrush_disable_reason stale=$_zrush_stale_disabled warned=$_zrush_worker_warned buildwarned=$_zrush_build_warned following=$_zrush_build_following verifying=$_zrush_build_verifying stopping=$_zrush_worker_stopping tainted=$_zrush_worker_runtime_tainted rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd control=$_zrush_worker_control_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending runtime=${_zrush_worker_runtime_dir:-<none>}"
+  _zlog "TESTWORKER=ready=$_zrush_worker_ready seq=$_zrush_request_seq candgen=$_zrush_cand_gen_seq latch=$_zrush_cc_cand_gen staged=$#_zrush_cc_staged failures=$_zrush_worker_failures disabled=$_zrush_disabled reason=$_zrush_disable_reason stale=$_zrush_stale_disabled warned=$_zrush_worker_warned buildwarned=$_zrush_build_warned following=$_zrush_build_following verifying=$_zrush_build_verifying stopping=$_zrush_worker_stopping tainted=$_zrush_worker_runtime_tainted rfd=$_zrush_worker_rfd wfd=$_zrush_worker_wfd control=$_zrush_worker_control_wfd ack=$_zrush_worker_ack_fd pending=$#_zrush_worker_pending runtime=${_zrush_worker_runtime_dir:-<none>}"
 }
 zle -N _zrt-dump-worker _zrt_dump_worker
 bindkey '^Xw' _zrt-dump-worker
+
+# ^Xc: the two empty-word-cache hit conditions that are computed rather than
+# stored -- whether the saved fingerprint still describes this environment, and
+# how old the entry is. ^Xw carries the third (the latch) as raw state. A test
+# that expects a recollection needs to show which condition forced it
+# (behavior.md "空語収集キャッシュ").
+_zrt_dump_cache() {
+  emulate -L zsh
+  local -i match=0 age=-1
+  _zrush_cc_fingerprint
+  [[ -n $_zrush_cc_fp && $REPLY == "$_zrush_cc_fp" ]] && match=1
+  (( _zrush_cc_time )) && age=$(( EPOCHSECONDS - _zrush_cc_time ))
+  _zlog "TESTCACHE=fpmatch=$match age=$age"
+}
+zle -N _zrt-dump-cache _zrt_dump_cache
+bindkey '^Xc' _zrt-dump-cache
+
+# ^Xn: age the cache entry past the fixed 300 s TTL. A widget rather than a
+# typed assignment: typing one would itself be a command-position collection
+# whose store could re-latch the entry -- with a fresh save time -- after the
+# assignment ran.
+_zrt_age_cache() { _zrush_cc_time=$(( EPOCHSECONDS - _ZRUSH_CC_TTL - 1 )) }
+zle -N _zrt-age-cache _zrt_age_cache
+bindkey '^Xn' _zrt-age-cache
 
 _zrt_teardown_worker() { _zrush_worker_shutdown }
 zle -N _zrt-teardown-worker _zrt_teardown_worker

--- a/tests/zsh/transport.zsh
+++ b/tests/zsh/transport.zsh
@@ -97,7 +97,8 @@ unset ZDOTDIR
     _zrush_worker_ready=0
     _zrush_worker_stopping=0 _zrush_worker_rx=
     _zrush_worker_runtime_tainted=0
-    _zrush_worker_txq=() _zrush_worker_pending=()
+    _zrush_worker_txq=() _zrush_worker_pending=() _zrush_cc_staged=()
+    _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0
     _zrush_current_request=0 _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
     _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_build_warned=0
     _zrush_build_following=0 _zrush_build_verifying=0 _zrush_stale_disabled=0
@@ -326,8 +327,11 @@ unset ZDOTDIR
   sysopen -rw -o cloexec -u HOLD_ANCHOR $HOLD_FIFO
   sysopen -r -o cloexec -u HOLD_R $HOLD_FIFO
   sysopen -w -o cloexec -u HOLD_W $HOLD_FIFO
-  _zrush_encode_message hello "$_ZRUSH_EXPECTED_BUILD_STAMP"; typeset -g FRAME_A=$REPLY
-  _zrush_encode_message plan 1 / compsys q prefix false 1 1 false ''; typeset -g FRAME_B=$REPLY
+  # The pipelined pair a finished collection sends: the store that fills a slot
+  # under a fresh generation, then the plan reading that generation back
+  # (cli-protocol.md "要求と応答").
+  _zrush_encode_message store 1 live 1 $'b\1\0'; typeset -g FRAME_A=$REPLY
+  _zrush_encode_message plan 2 1 / compsys q prefix false 1 1 false; typeset -g FRAME_B=$REPLY
   print -rn -- "$FRAME_A" >| $WORK/a.expected
   print -rn -- "$FRAME_B" >| $WORK/b.expected
   print() {
@@ -376,7 +380,7 @@ unset ZDOTDIR
   typeset -g writer_failed_ctl=$_zrush_worker_control_path
   typeset -gi writer0 writer1 writer2
   exec {writer0}<&0 {writer1}>&1 {writer2}>&2
-  _zrush_encode_message plan 77 / compsys q prefix false 1 1 false ''
+  _zrush_encode_message plan 77 5 / compsys q prefix false 1 1 false
   _zrush_worker_txq=( "$REPLY" never-replayed )
   functions[_zrt_poll_writer]=$functions[_zrush_worker_poll_writer]
   functions[_zrt_poll_eof]=$functions[_zrush_worker_poll_eof]
@@ -676,18 +680,41 @@ unset ZDOTDIR
   verdict "job table: worker and delegated writers remain invisible"
 
   # ------------------------------------------- synchronous history read seam
+  # The history exchange sends store + plan and ends on the plan's terminal
+  # response; the store's is consumed on the way there (behavior.md "履歴メニュー").
   reset_transport
   _zrush_worker_ready=1
-  _zrush_worker_pending=( 1 history 2 compsys )
-  _zrush_sync_target=1 _zrush_sync_done=0 _zrush_sync_ok=0
-  _zrush_encode_message ok 1 $'\0'"0"$'\0'"0"$'\0'"0"$'\0'; typeset -g TARGET=$REPLY
-  _zrush_encode_message error 2 invalid-request; typeset -g TRAILING=$REPLY
-  _zrush_worker_rx=$TARGET$TRAILING
+  _zrush_worker_pending=( 1 'store live 1' 2 'plan history 0' 3 'plan compsys 0' )
+  _zrush_sync_target=2 _zrush_sync_done=0 _zrush_sync_ok=0
+  _zrush_encode_message ok 1 ''; typeset -g STORE_OK=$REPLY
+  _zrush_encode_message ok 2 $'\0'"0"$'\0'"0"$'\0'"0"$'\0'; typeset -g TARGET=$REPLY
+  _zrush_encode_message error 3 invalid-request; typeset -g TRAILING=$REPLY
+  _zrush_worker_rx=$STORE_OK$TARGET$TRAILING
   _zrush_worker_read sync $(( EPOCHREALTIME + 1.0 )); typeset -gi sync_st=$?
   eq "sync target status" $sync_st 0
+  eq "store response consumed en route" ${+_zrush_worker_pending[1]} 0
   eq "sync target committed" "$_zrush_sync_done:$_zrush_sync_ok" 1:1
   eq "trailing response retained" "$_zrush_worker_rx" "$TRAILING"
-  verdict "sync read: target commits while trailing responses remain asynchronous"
+  verdict "sync read: the store is consumed and the plan commits while trailing responses remain asynchronous"
+
+  # A store whose ok carries a body does not satisfy the contract; the plan it
+  # backs must never be applied on such a session.
+  reset_transport
+  _zrush_worker_ready=1
+  _zrush_worker_pending=( 4 'store live 4' )
+  typeset -g STORE_FAILURE=
+  functions[_zrt_session_fail]=$functions[_zrush_worker_session_fail]
+  _zrush_worker_session_fail() { STORE_FAILURE=$1; return 1 }
+  _zrush_encode_message ok 4 'unexpected'
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"; typeset -gi store_body_st=$?
+  functions[_zrush_worker_session_fail]=$functions[_zrt_session_fail]
+  unfunction _zrt_session_fail
+  eq "store body status" $store_body_st 1
+  [[ $STORE_FAILURE == 'store ok carries a body request_id=4' ]] ||
+    note "unexpected store-body failure reason: ${STORE_FAILURE:-<none>}"
+  eq "store body leaves the request pending" ${+_zrush_worker_pending[4]} 1
+  verdict "sync read: a store ok with a body ends the session"
 
   reset_transport
   out "SUMMARY: PASS=$PASS FAIL=$FAIL"

--- a/tests/zsh/vectors.zsh
+++ b/tests/zsh/vectors.zsh
@@ -201,7 +201,7 @@ encode_vector() {  # $1=vector directory -> REPLY=wire bytes, or return 1 with R
 }
 
 # Re-serialize the parsed _zrush_plan_* state back into plan bytes, following
-# the field order of cli-protocol.md "stdout(描画プラン)".
+# the field order of cli-protocol.md "plan の ok body".
 # Fails (return 1, reason in REPLY) when _zrush_plan_text does not split back
 # into exactly L rows -- that split is only reversible because display rows are
 # guaranteed to contain no newline, so checking it tests that guarantee too.
@@ -395,7 +395,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   _zrush_netstring_take "$ready_frame"
   _zrush_worker_handle_message "$REPLY"
   local -i ready_kept_failures=$(( _zrush_worker_ready == 1 && _zrush_worker_failures == 1 ))
-  typeset -gA _zrush_worker_pending=( 41 compsys )
+  typeset -gA _zrush_worker_pending=( 41 'plan compsys 0' )
   _zrush_current_request=0
   _zrush_netstring_take "$error_frame"
   _zrush_worker_handle_message "$REPLY"
@@ -412,7 +412,7 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
     || { out "FATAL: $REPLY"; exit 1 }
   local stale_plan=$REPLY
   _zrush_worker_ready=1 _zrush_worker_failures=1 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
-  typeset -gA _zrush_worker_pending=( 41 compsys )
+  typeset -gA _zrush_worker_pending=( 41 'plan compsys 0' )
   _zrush_current_request=42
   _zrush_plan_text=sentinel _zrush_plan_cp=sentinel-cp _zrush_plan_kind=history
   _zrush_plan_nlines=7 _zrush_plan_npos=0
@@ -428,6 +428,74 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   else
     ng "worker lifecycle: stale response changed current plan or remained pending"
   fi
+
+  # A store's terminal response is consumed on its own: it carries no body and
+  # never touches the plan the paired request will deliver
+  # (cli-protocol.md "要求と応答").
+  _zrush_worker_ready=1 _zrush_worker_failures=1 _zrush_enabled=1
+  typeset -gA _zrush_worker_pending=( 50 'store live 50' )
+  _zrush_current_request=50
+  _zrush_plan_text=store-sentinel _zrush_plan_nlines=7
+  _zrush_encode_message ok 50 ''
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"; local -i store_ok_st=$?
+  if (( store_ok_st == 0 && ! ${+_zrush_worker_pending[50]} \
+        && _zrush_worker_failures == 0 && _zrush_plan_nlines == 7 )) \
+     && [[ $_zrush_plan_text == store-sentinel ]]; then
+    ok "worker lifecycle: an empty-bodied store ok is terminal and leaves the plan alone"
+  else
+    ng "worker lifecycle: store ok status=$store_ok_st pending=${+_zrush_worker_pending[50]} failures=$_zrush_worker_failures plan=${(qqqq)_zrush_plan_text}"
+  fi
+  _zrush_plan_text= _zrush_plan_nlines=0
+
+  # unknown-generation is a normal terminal error: it never fails the session,
+  # and what follows it on the asynchronous path depends on whether the plan
+  # read the latch (cli-protocol.md "応答の検証と zsh 側の適用"). A latch-backed
+  # plan drops the latch and recollects; nothing is ever replayed.
+  local saved_start_request=$functions[_zrush_start_request]
+  typeset -gi _zrt_restarts=0
+  functions[_zrush_start_request]='(( ++_zrt_restarts )); return 0'
+  _zrush_worker_ready=1 _zrush_worker_failures=0 _zrush_worker_stopping=0
+  _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
+  typeset -gA _zrush_worker_pending=( 51 'plan compsys 1' )
+  _zrush_current_request=51 _zrush_sync_target=0
+  _zrush_cc_fp=fingerprint _zrush_cc_time=$EPOCHSECONDS _zrush_cc_cand_gen=9
+  _zrush_encode_message error 51 unknown-generation
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"; local -i unknown_st=$?
+  local -i latched_dropped=$(( unknown_st == 0 && _zrush_cc_cand_gen == 0 \
+    && _zrt_restarts == 1 && _zrush_worker_failures == 0 && !_zrush_disabled \
+    && !_zrush_worker_stopping && ! ${+_zrush_worker_pending[51]} ))
+  # A plan built on its own fresh store holds no latch: there is none to drop,
+  # and it does not recollect either. Only its own store can have failed, and
+  # repeating a deterministic store failure would loop recollection forever.
+  _zrt_restarts=0 _zrush_cc_cand_gen=9
+  typeset -gA _zrush_worker_pending=( 52 'plan compsys 0' )
+  _zrush_current_request=52
+  _zrush_encode_message error 52 unknown-generation
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"
+  local -i unlatched_dropped=$(( _zrush_cc_cand_gen == 9 && _zrt_restarts == 0 \
+    && _zrush_worker_failures == 0 && ! ${+_zrush_worker_pending[52]} \
+    && _zrush_current_request == 0 && !_zrush_worker_stopping ))
+  # The synchronous history exchange treats it as an exchange failure instead,
+  # and never starts a collection (behavior.md "履歴メニュー").
+  _zrt_restarts=0
+  typeset -gA _zrush_worker_pending=( 53 'plan history 0' )
+  _zrush_current_request=0 _zrush_sync_target=53 _zrush_sync_done=0 _zrush_sync_ok=0
+  _zrush_encode_message error 53 unknown-generation
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"
+  local -i sync_failed=$(( _zrush_sync_done == 1 && _zrush_sync_ok == 0 \
+    && _zrt_restarts == 0 && _zrush_worker_failures == 0 && !_zrush_worker_stopping ))
+  functions[_zrush_start_request]=$saved_start_request
+  _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0 _zrush_cc_cand_gen=0 _zrush_cc_fp=
+  if (( latched_dropped && unlatched_dropped && sync_failed )); then
+    ok "worker lifecycle: unknown-generation recollects only behind a read latch, and fails the sync exchange"
+  else
+    ng "worker lifecycle: unknown-generation latched=$latched_dropped unlatched=$unlatched_dropped sync=$sync_failed"
+  fi
+  unset _zrt_restarts
 
   # A buffer/cursor change invalidates the old async request before debounce
   # assigns its successor. A Tab pressed in that window belongs to the newer
@@ -446,13 +514,13 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   _zrush_line_pre_redraw
   local -i invalidated=$(( _zrush_current_request == 0 ))
   _zrush_tab_pending=1
-  typeset -gA _zrush_worker_pending=( 41 compsys )
+  typeset -gA _zrush_worker_pending=( 41 'plan compsys 0' )
   _zrush_encode_message ok 41 "$stale_plan"
   _zrush_netstring_take "$REPLY"
   _zrush_worker_handle_message "$REPLY"
   local -i old_stayed_stale=$(( _zrt_settle_calls == 0 && _zrush_tab_pending == 1 ))
   _zrush_current_request=42
-  _zrush_worker_pending[42]=compsys
+  _zrush_worker_pending[42]='plan compsys 0'
   _zrush_encode_message ok 42 "$stale_plan"
   _zrush_netstring_take "$REPLY"
   _zrush_worker_handle_message "$REPLY"
@@ -528,6 +596,165 @@ reserialize_plan() {  # -> REPLY=bytes, or return 1 with REPLY=reason
   fi
   ZRUSH_LOG=$saved_log
   _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=0
+
+  # ---------------- Empty-word collection cache latch ----------------
+  # The latch is the worker session's, not the shell's: a lost session drops it
+  # and the entry misses even while fingerprint and TTL are still good
+  # (behavior.md "空語収集キャッシュ" / "worker ライフサイクル").
+  zmodload -F zsh/stat b:zstat 2>/dev/null
+  ZRUSH_LOG=$WORK/cache.log
+  local -i cache_ok=1
+  _zrush_query=
+  _zrush_cc_subject || cache_ok=0
+  # A widened word keeps its prefix, so only a line-start empty word is the
+  # cache's subject; `sudo ` and `git ` collections use the live slot.
+  _zrush_query='sudo '
+  _zrush_cc_subject && cache_ok=0
+  _zrush_query=
+  _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0 _zrush_cc_staged=()
+  _zrush_cc_check && cache_ok=0
+  # Staging alone is not a latch: only the store's ok turns it into one.
+  _zrush_cc_stage 300
+  (( _zrush_cc_cand_gen == 0 )) || cache_ok=0
+  _zrush_cc_check && cache_ok=0
+  _zrush_cc_commit 300 12
+  (( _zrush_cc_cand_gen == 12 && $#_zrush_cc_staged == 0 )) || cache_ok=0
+  _zrush_cc_check || cache_ok=0
+  _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
+  _zrush_worker_rfd=-1 _zrush_worker_wfd=-1 _zrush_worker_control_wfd=-1
+  _zrush_cc_stage 301
+  _zrush_worker_session_fail latch-fixture 2>/dev/null
+  (( _zrush_cc_cand_gen == 0 && $#_zrush_cc_staged == 0 )) || cache_ok=0
+  _zrush_cc_check && cache_ok=0
+  [[ -z $_zrush_cc_fp ]] || cache_ok=0
+  if (( cache_ok )); then
+    ok "cache latch: a session failure drops the latch and turns a live entry into a miss"
+  else
+    ng "cache latch: subject/latch state fp=${(qqqq)_zrush_cc_fp} generation=$_zrush_cc_cand_gen"
+  fi
+  ZRUSH_LOG=$saved_log
+  _zrush_query= _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0
+  _zrush_worker_failures=0 _zrush_worker_warned=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=0
+
+  # ---------------- Request wiring (observed on the outbound queue) ----------------
+  # Pin the callers, not just the message handler. Publishing a response fd
+  # makes the session look up, and holding the writer slot busy makes
+  # _zrush_worker_flush leave completed frames on _zrush_worker_txq, where the
+  # same netstring decoder the worker session uses can read them back. No fork,
+  # no worker, no zle.
+  local -i wire_fd
+  exec {wire_fd}< /dev/null
+  wire_fields() {  # $1=frame -> reply=(fields)
+    emulate -L zsh
+    _zrush_netstring_take "$1" || return 1
+    _zrush_decode_fields "$REPLY"
+  }
+  wire_reset() {
+    emulate -L zsh
+    _zrush_worker_rfd=$wire_fd _zrush_worker_ack_fd=$wire_fd
+    _zrush_worker_wfd=-1 _zrush_worker_control_wfd=-1 _zrush_worker_drain_fd=-1
+    _zrush_worker_ready=1 _zrush_worker_stopping=0 _zrush_worker_runtime_tainted=0
+    _zrush_worker_failures=0 _zrush_disabled=0 _zrush_disable_reason= _zrush_enabled=1
+    _zrush_worker_txq=() _zrush_worker_pending=() _zrush_cc_staged=()
+    _zrush_current_request=0 _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
+    _zrush_buf= _zrush_pty= _zrush_rfd=-1 _zrush_wfd=-1
+  }
+  ZRUSH_CFG_MODE=prefix ZRUSH_CFG_SMART_CASE=false ZRUSH_CFG_MAX_LINES=10
+  ZRUSH_CFG_TRAILING_SPACE=true ZRUSH_CFG_MIN_INPUT=0
+  BUFFER= LBUFFER= RBUFFER=
+  local -a sf=() pf=() hf=()
+  local store_id=
+
+  # A cache hit collects nothing and stores nothing: one plan frame, reading
+  # the latched generation, recorded as latch-backed. A latched=0 regression
+  # here would leave a dead latch in place and false-hit on every prompt.
+  wire_reset
+  _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0 _zrush_cc_staged=()
+  _zrush_cc_stage 400
+  _zrush_cc_commit 400 7
+  local -i hit_wire=1
+  _zrush_start_request 2>/dev/null
+  (( $#_zrush_worker_txq == 1 )) || hit_wire=0
+  if wire_fields "$_zrush_worker_txq[1]"; then
+    hf=( "${(@)reply}" )
+    (( $#hf == 11 )) || hit_wire=0
+    [[ $hf[1] == plan && $hf[3] == 7 && $hf[5] == compsys ]] || hit_wire=0
+    [[ ${_zrush_worker_pending[$hf[2]]} == 'plan compsys 1' ]] || hit_wire=0
+  else
+    hit_wire=0
+  fi
+  (( _zrush_cc_cand_gen == 7 && $#_zrush_cc_staged == 0 )) || hit_wire=0
+  if (( hit_wire )); then
+    ok "request wiring: a cache hit sends one latch-backed plan and no store"
+  else
+    ng "request wiring: cache hit queued ${#_zrush_worker_txq} frame(s) ${(qqqq)_zrush_worker_txq}"
+  fi
+
+  local -i store_wire=1
+  # A finished empty-word capture: store into the cache slot, plan behind it on
+  # the same generation, and the latch only once that store answers ok.
+  wire_reset
+  _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0 _zrush_cc_staged=()
+  _zrush_query= _zrush_fuzzy= _zrush_buf=$'b\1\0w\1ls\0'
+  _zrush_finalize
+  (( $#_zrush_worker_txq == 2 )) || store_wire=0
+  wire_fields "$_zrush_worker_txq[1]" && sf=( "${(@)reply}" ) || store_wire=0
+  wire_fields "$_zrush_worker_txq[2]" && pf=( "${(@)reply}" ) || store_wire=0
+  (( $#sf == 5 )) || store_wire=0
+  [[ $sf[1] == store && $sf[3] == cache && $sf[5] == $'b\1\0w\1ls\0' ]] || store_wire=0
+  [[ $pf[1] == plan && $pf[3] == $sf[4] ]] || store_wire=0
+  store_id=$sf[2]
+  [[ ${_zrush_worker_pending[$store_id]} == "store cache $sf[4]" ]] || store_wire=0
+  [[ ${_zrush_worker_pending[$pf[2]]} == 'plan compsys 0' ]] || store_wire=0
+  (( ${+_zrush_cc_staged[$store_id]} && _zrush_cc_cand_gen == 0 )) || store_wire=0
+  _zrush_encode_message ok $store_id ''
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"
+  (( _zrush_cc_cand_gen == $sf[4] && $#_zrush_cc_staged == 0 )) || store_wire=0
+
+  # A store that ends in error changed no slot, so no latch may appear.
+  wire_reset
+  _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0
+  _zrush_query= _zrush_fuzzy= _zrush_buf=$'b\1\0w\1ls\0'
+  _zrush_finalize
+  wire_fields "$_zrush_worker_txq[1]" && sf=( "${(@)reply}" ) || store_wire=0
+  _zrush_encode_message error $sf[2] invalid-payload
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"
+  (( _zrush_cc_cand_gen == 0 && $#_zrush_cc_staged == 0 )) || store_wire=0
+
+  # A widened word that keeps a prefix is not the cache's subject, and neither
+  # is a capture that came back empty: both take the live slot and leave an
+  # existing latch alone.
+  wire_reset
+  _zrush_cc_cand_gen=5 _zrush_cc_fp=keep _zrush_cc_time=$EPOCHSECONDS
+  _zrush_query='git ' _zrush_fuzzy=lo _zrush_buf=$'b\1\0w\1log\0'
+  _zrush_finalize
+  wire_fields "$_zrush_worker_txq[1]" && sf=( "${(@)reply}" ) || store_wire=0
+  [[ $sf[1] == store && $sf[3] == live ]] || store_wire=0
+  (( $#_zrush_cc_staged == 0 )) || store_wire=0
+  _zrush_encode_message ok $sf[2] ''
+  _zrush_netstring_take "$REPLY"
+  _zrush_worker_handle_message "$REPLY"
+  (( _zrush_cc_cand_gen == 5 )) || store_wire=0
+  wire_reset
+  _zrush_query= _zrush_fuzzy= _zrush_buf=
+  _zrush_finalize
+  wire_fields "$_zrush_worker_txq[1]" && sf=( "${(@)reply}" ) || store_wire=0
+  [[ $sf[1] == store && $sf[3] == live && -z $sf[5] ]] || store_wire=0
+  (( $#_zrush_cc_staged == 0 && _zrush_cc_cand_gen == 5 )) || store_wire=0
+  if (( store_wire )); then
+    ok "request wiring: the slot follows the cache's subject and only a store ok takes the latch"
+  else
+    ng "request wiring: finalize store/plan pair or latch commit mismatch"
+  fi
+
+  unfunction wire_fields wire_reset
+  _zrush_worker_rfd=-1 _zrush_worker_ack_fd=-1
+  _zrush_close_internal_fd $wire_fd
+  _zrush_worker_txq=() _zrush_worker_pending=() _zrush_cc_staged=()
+  _zrush_current_request=0 _zrush_enabled=0 _zrush_worker_ready=0
+  _zrush_cc_fp= _zrush_cc_time=0 _zrush_cc_cand_gen=0 _zrush_query= _zrush_fuzzy=
 
   # ---------------- History payload sender ----------------
   # `print -s` leaves its newest entry as the current event until another

--- a/zsh/zrush.zsh
+++ b/zsh/zrush.zsh
@@ -69,6 +69,10 @@ typeset -g  _zrush_cfg_path= _zrush_cfg_mtime=
 # Shell-session identity/latches survive a manual re-source; the
 # session-failure breaker below is the explicit recovery exception.
 typeset -gi _zrush_request_seq=${_zrush_request_seq:-0}
+# candidate_generation is independent of request_id and shares its survival
+# rule: monotonic per shell session, never reused, never reset by a worker
+# restart or a re-source (cli-protocol.md "要求と応答").
+typeset -gi _zrush_cand_gen_seq=${_zrush_cand_gen_seq:-0}
 typeset -gi _zrush_worker_warned=${_zrush_worker_warned:-0}
 typeset -gi _zrush_build_warned=${_zrush_build_warned:-0}
 typeset -gi _zrush_worker_failures=${_zrush_worker_failures:-0}
@@ -137,7 +141,7 @@ typeset -gi _ZRUSH_WORKER_SHUTDOWN_MS=100
 # Byte ceiling on one synthesized history payload (behavior.md "履歴メニュー").
 typeset -gi _ZRUSH_HISTORY_PAYLOAD_MAX_BYTES=262144
 
-# Render plan received from the Rust worker (cli-protocol.md "render_plan").
+# Render plan received from the Rust worker (cli-protocol.md "plan の ok body").
 # zsh applies these verbatim; it never recomputes layout, offsets, or spans.
 typeset -g  _zrush_plan_text=          # L display-row texts, \n-joined
 typeset -gi _zrush_plan_nlines=0       # L
@@ -164,12 +168,18 @@ typeset -gi _zrush_tab_pending=0   # Tab was pressed before candidates arrived
 
 # See docs/internal/specs/behavior.md "空語収集キャッシュ".
 # Cache storage is separate from working state and survives across prompts.
-# The stored payload is the raw capture stream (pid record already stripped,
-# cli-protocol.md "候補レコード" / "スキップ規律"), sent to the worker unparsed
-# on a hit; an empty fingerprint means no cache entry.
+# The parsed candidates live in the worker's `cache` slot; this side keeps only
+# the fingerprint, the save time and the candidate store latch. An empty
+# fingerprint means no cache entry.
 typeset -g  _zrush_cc_fp=          # fingerprint at save time
 typeset -gi _zrush_cc_time=0       # save time (EPOCHSECONDS)
-typeset -g  _zrush_cc_payload=
+# Candidate store latch: the generation this worker session holds in its
+# `cache` slot, 0 when there is none. Belongs to the worker session, so a
+# source starts without one (behavior.md "worker ライフサイクル").
+typeset -gi _zrush_cc_cand_gen=0
+# Cache entries whose `store` is still outstanding, by request_id ->
+# "<save time> <fingerprint>"; they become the latch on that store's `ok`.
+typeset -gA _zrush_cc_staged=()
 typeset -gi _ZRUSH_CC_TTL=300      # seconds; catches same-count replacement and is not configurable
 
 # Key bindings (dispatch widget -> predecessor/action)
@@ -779,17 +789,37 @@ _zrush_cc_fingerprint() {
   return 0
 }
 
+# The worker no longer holds the cache slot's generation. Called from every
+# invalidation point named in behavior.md "worker ライフサイクル".
+_zrush_cc_latch_drop() {
+  _zrush_cc_cand_gen=0
+  return 0
+}
+
 _zrush_cc_invalidate() {
   _zrush_cc_fp=
-  _zrush_cc_payload=
   _zrush_cc_time=0
+  _zrush_cc_latch_drop
   return 0
+}
+
+# Is this collection the empty-word cache's subject? Asked before collecting,
+# to reuse the entry, and again on the finished capture -- which also has to be
+# non-empty -- to pick the `cache` slot. Nothing outside the subject can
+# overwrite the latched generation.
+_zrush_cc_subject() {
+  [[ -z $_zrush_query ]]
 }
 
 _zrush_cc_check() {  # 0=usable hit; on a miss, log the reason and return nonzero
   emulate -L zsh
   if [[ -z $_zrush_cc_fp ]]; then
     _zlog "cache: miss (empty)"
+    return 1
+  fi
+  if (( _zrush_cc_cand_gen <= 0 )); then
+    _zlog "cache: miss (latch)"
+    _zrush_cc_invalidate
     return 1
   fi
   if (( EPOCHSECONDS - _zrush_cc_time > _ZRUSH_CC_TTL )); then
@@ -803,17 +833,31 @@ _zrush_cc_check() {  # 0=usable hit; on a miss, log the reason and return nonzer
     _zrush_cc_invalidate
     return 1
   fi
-  _zlog "cache: hit (${#_zrush_cc_payload} bytes)"
+  _zlog "cache: hit (generation=$_zrush_cc_cand_gen)"
   return 0
 }
 
-_zrush_cc_save() {  # $1=raw capture payload (pid stripped)
+# The latch may only name a generation the worker actually holds
+# (behavior.md "空語収集キャッシュ"), so an entry is staged when the `cache`
+# store goes out and committed when that store's `ok` comes back. The
+# fingerprint and the save time are snapshotted here, at collection time:
+# computing them on arrival would describe an environment the capture never saw.
+_zrush_cc_stage() {  # $1=store request_id
   emulate -L zsh
   _zrush_cc_fingerprint
-  _zrush_cc_fp=$REPLY
-  _zrush_cc_time=$EPOCHSECONDS
-  _zrush_cc_payload=$1
-  _zlog "cache: saved (${#1} bytes)"
+  _zrush_cc_staged[$1]="$EPOCHSECONDS $REPLY"
+  return 0
+}
+
+_zrush_cc_commit() {  # $1=store request_id $2=generation the worker accepted
+  emulate -L zsh
+  local staged=${_zrush_cc_staged[$1]:-}
+  unset "_zrush_cc_staged[$1]"
+  [[ -n $staged ]] || return 0
+  _zrush_cc_time=${staged%% *}
+  _zrush_cc_fp=${staged#* }
+  _zrush_cc_cand_gen=$2
+  _zlog "cache: latched (generation=$2)"
   return 0
 }
 
@@ -831,9 +875,12 @@ _zrush_start_request() {
   _zrush_fuzzy=${REPLY_QUERY//$'\0'/}   # the sender must strip NUL from --query
   _zlog "request: widened=${(qqqq)_zrush_query} fuzzy=${(qqqq)_zrush_fuzzy}"
 
-  # See behavior.md "空語収集キャッシュ". zle -F -w callers require explicit redraw.
-  if [[ -z $_zrush_query ]] && _zrush_cc_check; then
-    _zrush_request_plan "$_zrush_cc_payload" compsys "$_zrush_fuzzy" "$ZRUSH_CFG_TRAILING_SPACE" || _zrush_teardown
+  # See behavior.md "空語収集キャッシュ": a hit collects nothing and stores
+  # nothing; it plans against the generation the worker already holds.
+  # zle -F -w callers require explicit redraw.
+  if _zrush_cc_subject && _zrush_cc_check; then
+    _zrush_request_plan $_zrush_cc_cand_gen compsys "$_zrush_fuzzy" \
+      "$ZRUSH_CFG_TRAILING_SPACE" 1 || _zrush_teardown
     zle -R
     return 0
   fi
@@ -901,11 +948,15 @@ _zrush_on_data() {  # zle -F -w handler ($1=fd)
   return 0
 }
 
-# Collection payload (pid already stripped) -> worker request.
+# Collection payload (pid already stripped) -> worker requests.
 # The payload is handed to Rust unparsed: record parsing, matching,
 # ranking, layout, and highlight/nav/insert construction are all Rust's job
-# (cli-protocol.md). Cache successful empty-word command-position results
-# across prompts (behavior.md "空語収集キャッシュ").
+# (cli-protocol.md). It goes out once, in a `store` under a fresh generation,
+# with the `plan` that references that generation pipelined behind it; zsh
+# keeps no copy. A successful empty-word command-position collection is the
+# cache's subject, so it stores into the `cache` slot; the latch itself is
+# staged here and taken only once that store answers `ok`
+# (behavior.md "空語収集キャッシュ").
 _zrush_finalize() {
   emulate -L zsh
   setopt localoptions no_monitor no_notify
@@ -914,10 +965,12 @@ _zrush_finalize() {
   # Marks "transport" (fork -> parent pipe) complete, mirroring every other
   # pipeline stage's own checkpoint; driver-latency.zsh's breakdown reads it.
   _zlog "finalize: ${#payload} bytes"
-  if [[ -z $_zrush_query && -n $payload ]]; then
-    _zrush_cc_save "$payload"
-  fi
-  _zrush_request_plan "$payload" compsys "$_zrush_fuzzy" "$ZRUSH_CFG_TRAILING_SPACE" || _zrush_teardown
+  local slot=live
+  _zrush_cc_subject && [[ -n $payload ]] && slot=cache
+  _zrush_request_store $slot "$payload" || { _zrush_teardown; return 0 }
+  local -i gen=$REPLY
+  _zrush_request_plan $gen compsys "$_zrush_fuzzy" "$ZRUSH_CFG_TRAILING_SPACE" 0 ||
+    _zrush_teardown
   return 0
 }
 
@@ -1198,9 +1251,13 @@ _zrush_worker_close_response() {
 _zrush_worker_begin_stop() {
   emulate -L zsh
   _zrush_worker_stopping=1
+  # The candidate store dies with the session, whether this is a normal
+  # shutdown, an abort, or a session failure (behavior.md "worker ライフサイクル").
+  _zrush_cc_latch_drop
   _zrush_worker_disarm_drain
   _zrush_worker_txq=()
   _zrush_worker_pending=()
+  _zrush_cc_staged=()
   _zrush_current_request=0
   _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
 }
@@ -1216,6 +1273,7 @@ _zrush_worker_finalize() {
   _zrush_worker_rx=
   _zrush_worker_txq=()
   _zrush_worker_pending=()
+  _zrush_cc_staged=()
   _zrush_current_request=0
   _zrush_sync_target=0 _zrush_sync_done=0 _zrush_sync_ok=0
   _zrush_worker_stopping=0
@@ -1366,6 +1424,8 @@ _zrush_worker_start() {
   setopt localoptions no_monitor no_notify no_bg_nice localtraps
   (( !_zrush_disabled && !_zrush_worker_stopping && !_zrush_worker_runtime_tainted )) || return 1
   (( _zrush_worker_rfd >= 0 )) && return 0
+  # A new session starts with empty slots.
+  _zrush_cc_latch_drop
   _zrush_worker_runtime_valid || {
     _zrush_worker_session_fail "worker runtime unavailable"
     return 1
@@ -1561,10 +1621,20 @@ _zrush_worker_handle_message() {  # message [absolute-deadline]
     _zrush_worker_session_fail "response for unknown request_id=$id"
     return 1
   }
-  local producer=$_zrush_worker_pending[$id]
+  # "store <slot> <generation>" for a store, "plan <producer> <latched>" for a plan.
+  local -a req=( ${=_zrush_worker_pending[$id]} )
+  local reqkind=$req[1] producer= slot=
+  local -i latched=0 stored_gen=0
+  if [[ $reqkind == store ]]; then
+    slot=${req[2]:-} stored_gen=${req[3]:-0}
+  else
+    producer=${req[2]:-} latched=${req[3]:-0}
+  fi
 
   if [[ $kind == error ]]; then
-    [[ $f[3] == invalid-request || $f[3] == invalid-payload ]] || {
+    local code=$f[3]
+    [[ $code == invalid-request || $code == invalid-payload ||
+       $code == unknown-generation ]] || {
       _zrush_worker_session_fail "invalid error code"
       return 1
     }
@@ -1573,18 +1643,47 @@ _zrush_worker_handle_message() {  # message [absolute-deadline]
       return 1
     fi
     unset "_zrush_worker_pending[$id]"
+    # A store that ends in error changed no slot, so its staged entry never
+    # becomes a latch.
+    unset "_zrush_cc_staged[$id]"
     _zrush_worker_failures=0
     _zrush_status_set ""
+    # cli-protocol.md "応答の検証と zsh 側の適用": unknown-generation is an
+    # ordinary terminal error, and nothing is replayed. Only a plan that read
+    # the latch invalidates it and recollects; a plan whose own store failed is
+    # dropped and waits for the next real input.
+    local -i recollect=0
+    if [[ $code == unknown-generation ]] && (( latched )); then
+      _zrush_cc_latch_drop
+      recollect=1
+    fi
     if (( id == _zrush_sync_target )); then
       _zrush_sync_done=1 _zrush_sync_ok=0
     elif (( id == _zrush_current_request )); then
       _zrush_teardown
+      (( recollect )) && _zrush_start_request
       zle -R 2>/dev/null
     fi
-    _zlog "worker: error request_id=$id code=$f[3]"
+    _zlog "worker: error request_id=$id code=$code"
     return 0
   fi
   [[ $kind == ok ]] || { _zrush_worker_session_fail "invalid response kind"; return 1 }
+
+  if [[ $reqkind == store ]]; then
+    # cli-protocol.md "要求と応答": a successful store answers with an empty body.
+    [[ -z $f[3] ]] || {
+      _zrush_worker_session_fail "store ok carries a body request_id=$id"
+      return 1
+    }
+    unset "_zrush_worker_pending[$id]"
+    _zrush_worker_failures=0
+    _zrush_status_set ""
+    # The worker now holds this generation, so the entry staged for it becomes
+    # the latch (behavior.md "空語収集キャッシュ").
+    [[ $slot == cache ]] && _zrush_cc_commit $id $stored_gen
+    _zlog "worker: ok store request_id=$id slot=$slot generation=$stored_gen"
+    return 0
+  fi
 
   local old_text=$_zrush_plan_text old_cp=$_zrush_plan_cp old_kind=$_zrush_plan_kind
   local -i old_l=$_zrush_plan_nlines old_p=$_zrush_plan_npos
@@ -1726,10 +1825,73 @@ _zrush_worker_on_drain() {
   return 0
 }
 
-_zrush_request_plan() {  # payload producer query trailing-space
+_zrush_next_request_id() {  # -> REPLY
+  emulate -L zsh
+  (( _zrush_request_seq < 9223372036854775807 )) || {
+    _zrush_worker_disable_policy "request_id exhausted"
+    _zrush_worker_shutdown
+    _zrush_teardown
+    return 1
+  }
+  typeset -g REPLY=$(( ++_zrush_request_seq ))
+  return 0
+}
+
+_zrush_next_cand_gen() {  # -> REPLY
+  emulate -L zsh
+  (( _zrush_cand_gen_seq < 9223372036854775807 )) || {
+    _zrush_worker_disable_policy "candidate_generation exhausted"
+    _zrush_worker_shutdown
+    _zrush_teardown
+    return 1
+  }
+  typeset -g REPLY=$(( ++_zrush_cand_gen_seq ))
+  return 0
+}
+
+_zrush_worker_ensure_session() {
+  emulate -L zsh
+  (( _zrush_worker_rfd >= 0 )) && return 0
+  local -i failures_before=$_zrush_worker_failures
+  if ! _zrush_worker_start; then
+    (( _zrush_worker_failures != failures_before )) || _zrush_worker_session_fail "startup failed"
+    return 1
+  fi
+  return 0
+}
+
+# Hand a candidate record stream to one slot of the worker's candidate store
+# (cli-protocol.md "要求と応答"). The plan that reads the generation back is
+# pipelined behind this without waiting for its terminal response.
+_zrush_request_store() {  # slot payload -> REPLY = candidate generation
   emulate -L zsh
   setopt localoptions typesetsilent no_monitor no_notify
-  local payload=$1 producer=$2 query=$3 tspace=$4
+  local slot=$1 payload=$2
+  (( !_zrush_worker_stopping && !_zrush_worker_runtime_tainted )) || return 1
+  _zrush_next_request_id || return 1
+  local -i id=$REPLY
+  _zrush_next_cand_gen || return 1
+  local -i gen=$REPLY
+  _zrush_worker_pending[$id]="store $slot $gen"
+  [[ $slot == cache ]] && _zrush_cc_stage $id
+  _zrush_worker_ensure_session || return 1
+  _zrush_encode_message store "$id" "$slot" "$gen" "$payload"
+  _zrush_worker_txq+=( "$REPLY" )
+  _zlog "worker: queued store request_id=$id slot=$slot generation=$gen bytes=${#REPLY} queued=$#_zrush_worker_txq"
+  _zrush_worker_flush || return 1
+  typeset -g REPLY=$gen
+  return 0
+}
+
+# $5 records whether this plan reached the store through the cache latch: an
+# `unknown-generation` answer invalidates the latch and recollects only for
+# such a plan (cli-protocol.md "応答の検証と zsh 側の適用").
+_zrush_request_plan() {  # candidate-generation producer query trailing-space latched
+  emulate -L zsh
+  setopt localoptions typesetsilent no_monitor no_notify
+  local -i gen=$1
+  local producer=$2 query=$3 tspace=$4
+  local -i latched=${5:-0}
   (( !_zrush_worker_stopping && !_zrush_worker_runtime_tainted )) || return 1
 
   # cli-protocol.md "起動": rows = min(max-lines, LINES - 1), clamped to >= 1
@@ -1741,26 +1903,15 @@ _zrush_request_plan() {  # payload producer query trailing-space
   local -i width=$(( COLUMNS - 1 ))
   (( width < 1 )) && width=1
 
-  (( _zrush_request_seq < 9223372036854775807 )) || {
-    _zrush_worker_disable_policy "request_id exhausted"
-    _zrush_worker_shutdown
-    _zrush_teardown
-    return 1
-  }
-  local -i id=$(( ++_zrush_request_seq ))
+  _zrush_next_request_id || return 1
+  local -i id=$REPLY
   _zrush_current_request=$id
-  _zrush_worker_pending[$id]=$producer
-  if (( _zrush_worker_rfd < 0 )); then
-    local -i failures_before=$_zrush_worker_failures
-    if ! _zrush_worker_start; then
-      (( _zrush_worker_failures != failures_before )) || _zrush_worker_session_fail "startup failed"
-      return 1
-    fi
-  fi
-  _zrush_encode_message plan "$id" "$PWD" "$producer" "$query" \
-    "$ZRUSH_CFG_MODE" "$ZRUSH_CFG_SMART_CASE" "$rows" "$width" "$tspace" "$payload"
+  _zrush_worker_pending[$id]="plan $producer $latched"
+  _zrush_worker_ensure_session || return 1
+  _zrush_encode_message plan "$id" "$gen" "$PWD" "$producer" "$query" \
+    "$ZRUSH_CFG_MODE" "$ZRUSH_CFG_SMART_CASE" "$rows" "$width" "$tspace"
   _zrush_worker_txq+=( "$REPLY" )
-  _zlog "worker: queued request_id=$id producer=$producer bytes=${#REPLY} queued=$#_zrush_worker_txq"
+  _zlog "worker: queued request_id=$id producer=$producer generation=$gen bytes=${#REPLY} queued=$#_zrush_worker_txq"
   _zrush_worker_flush || return 1
   typeset -g REPLY=$id
   return 0
@@ -1787,7 +1938,7 @@ _zrush_dec_le_all() {  # $1=bound, $2.. = values, all matched by <->
 }
 
 # Validate and split one render-plan buffer into _zrush_plan_*.
-# Field layout is fixed (cli-protocol.md "stdout(描画プラン)"):
+# Field layout is fixed (cli-protocol.md "plan の ok body"):
 #   common-prefix, L, P, L rows, H, H "role pos start len", P "start len",
 #   P "next prev left right", P insert texts -- total 4 + L + H + 3P fields.
 _zrush_parse_plan() {  # $1=raw render-plan bytes
@@ -1976,11 +2127,16 @@ _zrush_history_payload() {  # -> REPLY = candidate payload bytes
   return 0
 }
 
+# behavior.md "履歴メニュー": the store and the plan share the single absolute
+# deadline that starts once the payload is synthesized, and the exchange ends
+# on the plan's terminal response -- the store's is consumed on the way there.
 _zrush_request_plan_sync() {
   emulate -L zsh
   local payload=$1 producer=$2 query=$3 tspace=$4
   local -F deadline=$(( EPOCHREALTIME + ${ZRUSH_HISTORY_DEADLINE_MS:-100} / 1000.0 )) remaining
-  _zrush_request_plan "$payload" "$producer" "$query" "$tspace" || return 1
+  _zrush_request_store live "$payload" || return 1
+  local -i gen=$REPLY
+  _zrush_request_plan $gen "$producer" "$query" "$tspace" 0 || return 1
   local -i target=$REPLY cs
   _zrush_sync_target=$target _zrush_sync_done=0 _zrush_sync_ok=0
   while (( !_zrush_sync_done )); do


### PR DESCRIPTION
candidate payload を worker 側の per-slot candidate store へ移し、`plan` 要求から payload 同送を廃止する。
zsh は収集完了時に `store`(slot + candidate_generation + payload)→ 同 generation 参照の `plan` を連送し、
空語収集キャッシュは fingerprint・保存時刻・`cache` スロット latch だけを保持する(raw payload の保持と再送を削除)。

Closes #24

## 変更点

- protocol: `store: [store, request_id, slot, candidate_generation, candidate_payload]` を新設し、
  `plan` は `candidate_generation` 参照に変更(payload field 削除)。
  slot は `live` / `cache` の zsh 所有列挙で、store は同一スロットの前 generation だけを置き換える。
  存在しない generation への plan は terminal error `unknown-generation`(session failure に数えない)。
  非互換性は build stamp が担保する(version 番号は存在しない)。
- Rust worker: `record::parse` を owned buffer + ByteSpan の `Stored` へ変更し、parse は generation ごとに 1 回。
  `CandidateStore` は slot ごとに最大 1 generation、失敗した store は全スロット無変更。
- zsh: candidate generation の採番(`_zrush_cand_gen_seq`、re-source・worker 再起動を跨いで単調増加)、
  latch は store の `ok` で確定する stage → commit の 2 段階
  (送信時確定だと store 失敗時に worker が保持しない generation を指すため)。
  latch は worker の起動・shutdown・abort・session failure・交換・re-source・`unknown-generation` 受信で無効化。
  `unknown-generation` での再収集は latch 参照 plan に限定し、決定的な store 失敗が再収集ループを起こさない。
  履歴メニューの同期経路は store(`live`)+ plan を既存の単一絶対 100ms deadline 内で連送。
- 空語収集キャッシュ: hit = fingerprint 一致 ∧ TTL 内 ∧ latch 有効。hit 時は plan のみ送る(fork も transport もなし)。
  捕獲 payload が空の収集は対象外(`live`)。worker session 喪失後は fingerprint/TTL が有効でも miss。
- docs: `cli-protocol.md`(要求と応答・検証順・error code 表・応答の検証)と
  `behavior.md`(worker ライフサイクル・候補収集・空語収集キャッシュ・履歴メニュー)を新契約に全面改訂。

## テスト

- worker 単体: store 1 回 → 複数 plan、同一スロット置換(他スロット保持)、unknown/失効 generation、
  新 session の空 store、store framing error 後の session 継続と全スロット無変更。
  span ↔ payload の property test を追加(オフセット改変ミューテーション 2 種で FAILED を確認)。
- driver(`cargo test --test driver`、69 passed): cache hit/miss に加え TTL 失効・fingerprint 失効の
  driver テストを新設。worker death / re-source 後の latch 無効化と再収集、no replay
  (次の実入力だけが新 generation を作る)、`unknown-generation` の経路別分岐、
  `live` store が `cache` generation を壊さないこと。
- zsh スイート: vectors 79 / transport 19 / keybinds 4。配線 assertion
  (cache hit は latch 参照 plan 1 本のみ・store なし、latch は store `ok` でのみ確定)を追加し、
  主要な退行ミューテーションで FAIL することを確認済み。

## 計測

`tests/zsh/driver-latency.zsh` による first-paint 内訳の before(2d3b7ef)/ after(本変更)比較。
環境: Apple M3 / macOS 26.0(Darwin 27.0.0 arm64)/ zsh 5.9 / rustc 1.94.0、release build。
before→after を 1 組として 6 組を交互に連続実行(内訳は 1 run 1 サンプル、n=6 の中央値)。

cache-hit(`whic` @ min-zrush):

| bucket | before | after |
| --- | --- | --- |
| debounce | 35.0 ms | 34.0 ms |
| cache-check | 3.0 ms | 3.0 ms |
| worker-roundtrip+apply | **12.5 ms** | **6.5 ms**(−48%) |
| first-paint | 60.0 ms | 54.5 ms |

cache-hit の短縮は worker-roundtrip+apply バケットに集中しており(before 11–14 / after 4–9 でほぼ分離)、
payload transport と再 parse の除去という期待効果と整合する。
cache-miss 側は store + plan の 2 要求化で `zle -F` 起床が 1 回増え、
worker-roundtrip+apply が一貫して +4 ms 程度(file 5.5→9.5、git 7.0→11.5)。
ミス経路は compsys fork(数十〜数百 ms)が支配的なため first-paint への影響は小さく、
高頻度 request の coalesce は #26 で扱う。
n=6・±1–2 ms 精度のため微小差は論じない。詳細な生データと再現手順は計測記録
(オーケストレーション作業ディレクトリの latency.md)にある。

## 検証

`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --release` / `cargo test`、
`tests/zsh/keybinds.zsh` / `tests/zsh/vectors.zsh` / `tests/zsh/transport.zsh` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
